### PR TITLE
RSDK-2027 - Set up cartographer integration tests automation in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,8 +16,8 @@ on:
 # and tag your working branch instead of @main in any viamrobotics/viam-cartographer "uses" below.
 # Don't forget to tag back to @main before merge.
 
-jobs:
-  appimage:
-    uses: viamrobotics/viam-cartographer/.github/workflows/appimage.yml@kk/rsdk-2027-ci-integration-test
-    secrets:
-      GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
+# jobs:
+#   appimage:
+#     uses: viamrobotics/viam-cartographer/.github/workflows/appimage.yml@kk/rsdk-2027-ci-integration-test
+#     secrets:
+#       GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ concurrency:
 on:
   workflow_dispatch:
   push:
-    branches: [ 'main' ]
+    branches: [ 'kk/rsdk-2027-ci-integration-test' ]
     paths-ignore:
       - 'README.md'
     tags:
@@ -18,6 +18,6 @@ on:
 
 jobs:
   appimage:
-    uses: viamrobotics/viam-cartographer/.github/workflows/appimage.yml@main
+    uses: viamrobotics/viam-cartographer/.github/workflows/appimage.yml@kk/rsdk-2027-ci-integration-test
     secrets:
       GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ concurrency:
 on:
   workflow_dispatch:
   push:
-    branches: [ 'kk/rsdk-2027-ci-integration-test' ]
+    branches: [ 'main' ]
     paths-ignore:
       - 'README.md'
     tags:
@@ -16,8 +16,8 @@ on:
 # and tag your working branch instead of @main in any viamrobotics/viam-cartographer "uses" below.
 # Don't forget to tag back to @main before merge.
 
-# jobs:
-#   appimage:
-#     uses: viamrobotics/viam-cartographer/.github/workflows/appimage.yml@kk/rsdk-2027-ci-integration-test
-#     secrets:
-#       GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
+jobs:
+  appimage:
+    uses: viamrobotics/viam-cartographer/.github/workflows/appimage.yml@main
+    secrets:
+      GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -7,7 +7,7 @@ concurrency:
 on:
   workflow_dispatch:
   pull_request:
-    branches: [ 'main' ]
+    branches: [ 'kk/rsdk-2027-ci-integration-test' ]
     types: [ 'opened', 'reopened', 'synchronize' ]
 
 # To test workflow updates you need to work in a branch directly on viamrobotics/viam-cartographer
@@ -16,4 +16,4 @@ on:
 
 jobs:
   test:
-    uses: viamrobotics/viam-cartographer/.github/workflows/test.yml@main
+    uses: viamrobotics/viam-cartographer/.github/workflows/test.yml@kk/rsdk-2027-ci-integration-test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,3 +96,8 @@ jobs:
       if: matrix.platform == 'linux/amd64'
       run: |
         sudo -u testbot bash -lc 'cd rdk/services/slam/builtin && sudo go test -v -run TestCartographerIntegration'
+
+    - name: Run viam-cartographer cartographer integration tests
+      if: matrix.platform == 'linux/amd64'
+      run: |
+        sudo -u testbot bash -lc 'cd viam-cartographer && sudo go test -v -run TestCartographerIntegration'


### PR DESCRIPTION
Ticket: https://viam.atlassian.net/browse/RSDK-2027

Done:

* Set up cartographer integration tests automation in CI
* I am keeping running the same integration tests against the code in RDK until we are ready to delete builtin from RDK.
    * PR for testing the CI: https://github.com/viamrobotics/viam-cartographer/pull/17