### PR TITLE
revert-setupTestGRPCServer-to-private

### DIFF
--- a/internal/testhelper/testhelper.go
+++ b/internal/testhelper/testhelper.go
@@ -6,7 +6,6 @@ package testhelper
 import (
 	"bufio"
 	"context"
-	"net"
 	"os"
 	"strconv"
 	"sync/atomic"
@@ -28,7 +27,6 @@ import (
 	"go.viam.com/test"
 	"go.viam.com/utils/artifact"
 	"go.viam.com/utils/pexec"
-	"google.golang.org/grpc"
 
 	viamcartographer "github.com/viamrobotics/viam-cartographer"
 )
@@ -158,21 +156,6 @@ func ClearDirectory(t *testing.T, path string) {
 
 	err := slamTesthelper.ResetFolder(path)
 	test.That(t, err, test.ShouldBeNil)
-}
-
-// SetupTestGRPCServer sets up and starts a grpc server.
-// It returns the grpc server and the port at which it is served.
-func SetupTestGRPCServer(tb testing.TB, logger golog.Logger) (*grpc.Server, int) {
-	//nolint:gosec
-	listener, err := net.Listen("tcp", ":0")
-	test.That(tb, err, test.ShouldBeNil)
-	grpcServer := grpc.NewServer()
-	go func() {
-		err := grpcServer.Serve(listener)
-		test.That(tb, err, test.ShouldBeNil)
-	}()
-
-	return grpcServer, listener.Addr().(*net.TCPAddr).Port
 }
 
 // CreateSLAMService creates a slam service for testing.

--- a/viam-cartographer_test.go
+++ b/viam-cartographer_test.go
@@ -8,6 +8,7 @@ package viamcartographer_test
 import (
 	"context"
 	"fmt"
+	"net"
 	"os"
 	"strconv"
 	"testing"
@@ -19,6 +20,7 @@ import (
 	slamTesthelper "go.viam.com/slam/testhelper"
 	"go.viam.com/test"
 	"go.viam.com/utils"
+	"google.golang.org/grpc"
 
 	"github.com/viamrobotics/viam-cartographer/internal/testhelper"
 )
@@ -40,7 +42,7 @@ func TestNew(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 
 	t.Run("Successful creation of cartographer slam service with no sensor", func(t *testing.T) {
-		grpcServer, port := testhelper.SetupTestGRPCServer(t, logger)
+		grpcServer, port := setupTestGRPCServer(t, logger)
 		test.That(t, err, test.ShouldBeNil)
 		attrCfg := &slamConfig.AttrConfig{
 			Sensors:       []string{},
@@ -58,7 +60,7 @@ func TestNew(t *testing.T) {
 	})
 
 	t.Run("Failed creation of cartographer slam service with more than one sensor", func(t *testing.T) {
-		grpcServer, port := testhelper.SetupTestGRPCServer(t, logger)
+		grpcServer, port := setupTestGRPCServer(t, logger)
 		test.That(t, err, test.ShouldBeNil)
 		attrCfg := &slamConfig.AttrConfig{
 			Sensors:       []string{"lidar", "one-too-many"},
@@ -93,7 +95,7 @@ func TestNew(t *testing.T) {
 	})
 
 	t.Run("Successful creation of cartographer slam service with good lidar", func(t *testing.T) {
-		grpcServer, port := testhelper.SetupTestGRPCServer(t, logger)
+		grpcServer, port := setupTestGRPCServer(t, logger)
 		attrCfg := &slamConfig.AttrConfig{
 			Sensors:       []string{"good_lidar"},
 			ConfigParams:  map[string]string{"mode": "2d"},
@@ -133,7 +135,7 @@ func TestDataProcess(t *testing.T) {
 	dataDir, err := slamTesthelper.CreateTempFolderArchitecture(logger)
 	test.That(t, err, test.ShouldBeNil)
 
-	grpcServer, port := testhelper.SetupTestGRPCServer(t, logger)
+	grpcServer, port := setupTestGRPCServer(t, logger)
 	attrCfg := &slamConfig.AttrConfig{
 		Sensors:       []string{"good_lidar"},
 		ConfigParams:  map[string]string{"mode": "2d"},
@@ -194,7 +196,7 @@ func TestEndpointFailures(t *testing.T) {
 	dataDir, err := slamTesthelper.CreateTempFolderArchitecture(logger)
 	test.That(t, err, test.ShouldBeNil)
 
-	grpcServer, port := testhelper.SetupTestGRPCServer(t, logger)
+	grpcServer, port := setupTestGRPCServer(t, logger)
 	attrCfg := &slamConfig.AttrConfig{
 		Sensors:       []string{"good_lidar"},
 		ConfigParams:  map[string]string{"mode": "2d", "test_param": "viam"},
@@ -239,7 +241,7 @@ func TestSLAMProcess(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 
 	t.Run("Successful start of live SLAM process with default parameters", func(t *testing.T) {
-		grpcServer, port := testhelper.SetupTestGRPCServer(t, logger)
+		grpcServer, port := setupTestGRPCServer(t, logger)
 		attrCfg := &slamConfig.AttrConfig{
 			Sensors:       []string{"good_lidar"},
 			ConfigParams:  map[string]string{"mode": "2d", "test_param": "viam"},
@@ -279,7 +281,7 @@ func TestSLAMProcess(t *testing.T) {
 	})
 
 	t.Run("Successful start of offline SLAM process with default parameters", func(t *testing.T) {
-		grpcServer, port := testhelper.SetupTestGRPCServer(t, logger)
+		grpcServer, port := setupTestGRPCServer(t, logger)
 		attrCfg := &slamConfig.AttrConfig{
 			Sensors:       []string{},
 			ConfigParams:  map[string]string{"mode": "2d", "test_param": "viam"},
@@ -319,7 +321,7 @@ func TestSLAMProcess(t *testing.T) {
 	})
 
 	t.Run("Failed start of SLAM process that errors out due to invalid binary location", func(t *testing.T) {
-		grpcServer, port := testhelper.SetupTestGRPCServer(t, logger)
+		grpcServer, port := setupTestGRPCServer(t, logger)
 		attrCfg := &slamConfig.AttrConfig{
 			Sensors:       []string{"good_lidar"},
 			ConfigParams:  map[string]string{"mode": "2d", "test_param": "viam"},
@@ -335,4 +337,16 @@ func TestSLAMProcess(t *testing.T) {
 	})
 
 	testhelper.ClearDirectory(t, dataDir)
+}
+
+// SetupTestGRPCServer sets up and starts a grpc server.
+// It returns the grpc server and the port at which it is served.
+func setupTestGRPCServer(tb testing.TB, logger golog.Logger) (*grpc.Server, int) {
+	//nolint:gosec
+	listener, err := net.Listen("tcp", ":0")
+	test.That(tb, err, test.ShouldBeNil)
+	grpcServer := grpc.NewServer()
+	go grpcServer.Serve(listener)
+
+	return grpcServer, listener.Addr().(*net.TCPAddr).Port
 }

--- a/viam-cartographer_test.go
+++ b/viam-cartographer_test.go
@@ -42,7 +42,7 @@ func TestNew(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 
 	t.Run("Successful creation of cartographer slam service with no sensor", func(t *testing.T) {
-		grpcServer, port := setupTestGRPCServer(t, logger)
+		grpcServer, port := setupTestGRPCServer(t)
 		test.That(t, err, test.ShouldBeNil)
 		attrCfg := &slamConfig.AttrConfig{
 			Sensors:       []string{},
@@ -60,7 +60,7 @@ func TestNew(t *testing.T) {
 	})
 
 	t.Run("Failed creation of cartographer slam service with more than one sensor", func(t *testing.T) {
-		grpcServer, port := setupTestGRPCServer(t, logger)
+		grpcServer, port := setupTestGRPCServer(t)
 		test.That(t, err, test.ShouldBeNil)
 		attrCfg := &slamConfig.AttrConfig{
 			Sensors:       []string{"lidar", "one-too-many"},
@@ -95,7 +95,7 @@ func TestNew(t *testing.T) {
 	})
 
 	t.Run("Successful creation of cartographer slam service with good lidar", func(t *testing.T) {
-		grpcServer, port := setupTestGRPCServer(t, logger)
+		grpcServer, port := setupTestGRPCServer(t)
 		attrCfg := &slamConfig.AttrConfig{
 			Sensors:       []string{"good_lidar"},
 			ConfigParams:  map[string]string{"mode": "2d"},
@@ -135,7 +135,7 @@ func TestDataProcess(t *testing.T) {
 	dataDir, err := slamTesthelper.CreateTempFolderArchitecture(logger)
 	test.That(t, err, test.ShouldBeNil)
 
-	grpcServer, port := setupTestGRPCServer(t, logger)
+	grpcServer, port := setupTestGRPCServer(t)
 	attrCfg := &slamConfig.AttrConfig{
 		Sensors:       []string{"good_lidar"},
 		ConfigParams:  map[string]string{"mode": "2d"},
@@ -196,7 +196,7 @@ func TestEndpointFailures(t *testing.T) {
 	dataDir, err := slamTesthelper.CreateTempFolderArchitecture(logger)
 	test.That(t, err, test.ShouldBeNil)
 
-	grpcServer, port := setupTestGRPCServer(t, logger)
+	grpcServer, port := setupTestGRPCServer(t)
 	attrCfg := &slamConfig.AttrConfig{
 		Sensors:       []string{"good_lidar"},
 		ConfigParams:  map[string]string{"mode": "2d", "test_param": "viam"},
@@ -241,7 +241,7 @@ func TestSLAMProcess(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 
 	t.Run("Successful start of live SLAM process with default parameters", func(t *testing.T) {
-		grpcServer, port := setupTestGRPCServer(t, logger)
+		grpcServer, port := setupTestGRPCServer(t)
 		attrCfg := &slamConfig.AttrConfig{
 			Sensors:       []string{"good_lidar"},
 			ConfigParams:  map[string]string{"mode": "2d", "test_param": "viam"},
@@ -281,7 +281,7 @@ func TestSLAMProcess(t *testing.T) {
 	})
 
 	t.Run("Successful start of offline SLAM process with default parameters", func(t *testing.T) {
-		grpcServer, port := setupTestGRPCServer(t, logger)
+		grpcServer, port := setupTestGRPCServer(t)
 		attrCfg := &slamConfig.AttrConfig{
 			Sensors:       []string{},
 			ConfigParams:  map[string]string{"mode": "2d", "test_param": "viam"},
@@ -321,7 +321,7 @@ func TestSLAMProcess(t *testing.T) {
 	})
 
 	t.Run("Failed start of SLAM process that errors out due to invalid binary location", func(t *testing.T) {
-		grpcServer, port := setupTestGRPCServer(t, logger)
+		grpcServer, port := setupTestGRPCServer(t)
 		attrCfg := &slamConfig.AttrConfig{
 			Sensors:       []string{"good_lidar"},
 			ConfigParams:  map[string]string{"mode": "2d", "test_param": "viam"},
@@ -341,8 +341,7 @@ func TestSLAMProcess(t *testing.T) {
 
 // SetupTestGRPCServer sets up and starts a grpc server.
 // It returns the grpc server and the port at which it is served.
-func setupTestGRPCServer(tb testing.TB, logger golog.Logger) (*grpc.Server, int) {
-	//nolint:gosec
+func setupTestGRPCServer(tb testing.TB) (*grpc.Server, int) {
 	listener, err := net.Listen("tcp", ":0")
 	test.That(tb, err, test.ShouldBeNil)
 	grpcServer := grpc.NewServer()


### PR DESCRIPTION
Attempts to fix: https://github.com/viamrobotics/viam-cartographer/actions/runs/4536705514/jobs/7993714034 

Currently, tests are flakey as sometimes the server returns an error. Given that modularization v2 will remove the grpc server, this change doesn't investigate the cause of the error & instead reverts the code back to the pre modularization v1 code state which can still be seen in orbslam here: https://github.com/viamrobotics/viam-orb-slam3/blob/main/viam-orb-slam3_test.go#L77