### PR TITLE
RSDK-2435 Remove Dev Flag Cartographer

### DIFF
--- a/viam-cartographer.go
+++ b/viam-cartographer.go
@@ -151,7 +151,6 @@ func New(
 		cancelFunc:            cancelFunc,
 		logger:                logger,
 		bufferSLAMProcessLogs: bufferSLAMProcessLogs,
-		dev:                   svcConfig.Dev,
 	}
 
 	success := false
@@ -207,8 +206,6 @@ type cartographerService struct {
 	port       string
 	dataRateMs int
 	mapRateSec int
-
-	dev bool
 
 	cancelFunc              func()
 	logger                  golog.Logger


### PR DESCRIPTION
Remove the unused dev flag in SLAM Map Representation project. Similar edits were also made in rdk, viam-orb-slam3 and slam repo, see associated PRs.

JIRA Ticket: https://viam.atlassian.net/browse/RSDK-2435

Associated PRs: 
- https://github.com/viamrobotics/slam/pull/184
- https://github.com/viamrobotics/rdk/pull/2150
- https://github.com/viamrobotics/viam-orb-slam3/pull/34