### PR TITLE
[RSDK-2511] remove duplicate appimage workflow call

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -7,11 +7,6 @@ on:
       GCP_CREDENTIALS:
         required: true
 
-  push:
-    branches: main
-    paths-ignore:
-      - 'README.md'
-
 jobs:
   appimage:
     name: AppImage Build Cartographer


### PR DESCRIPTION
currently when a PR gets pushed to main, both the main branch update workflow and the appimage workflow will both run, causing the appimage to be built twice. This PR changes the appimage workflow to [match rdk](https://github.com/viamrobotics/rdk/blob/main/.github/workflows/appimage.yml#L3-L9)

ticket: https://viam.atlassian.net/browse/RSDK-2511