### PR TITLE
RSDK-2561 Remove unused JPEG Code

### DIFF
--- a/viam-cartographer/src/slam_service/slam_service.cc
+++ b/viam-cartographer/src/slam_service/slam_service.cc
@@ -239,14 +239,10 @@ std::string SLAMServiceImpl::TryFileClose(std::ifstream &tempFile,
 }
 
 void SLAMServiceImpl::BackupLatestMap() {
-    std::string jpeg_map_with_marker_tmp = GetLatestJpegMapString(true);
-    std::string jpeg_map_without_marker_tmp = GetLatestJpegMapString(false);
     std::string pointcloud_map_tmp;
     GetLatestSampledPointCloudMapString(pointcloud_map_tmp);
 
     std::lock_guard<std::mutex> lk(viam_response_mutex);
-    latest_jpeg_map_with_marker = std::move(jpeg_map_with_marker_tmp);
-    latest_jpeg_map_without_marker = std::move(jpeg_map_without_marker_tmp);
     latest_pointcloud_map = std::move(pointcloud_map_tmp);
 }
 
@@ -326,32 +322,6 @@ void SLAMServiceImpl::SetUpMapBuilder() {
     OverwriteMapBuilderParameters();
     std::lock_guard<std::mutex> lk(map_builder_mutex);
     map_builder.BuildMapBuilder();
-}
-
-std::string SLAMServiceImpl::GetLatestJpegMapString(bool add_pose_marker) {
-    std::unique_ptr<cartographer::io::PaintSubmapSlicesResult> painted_slices =
-        nullptr;
-    try {
-        painted_slices =
-            std::make_unique<cartographer::io::PaintSubmapSlicesResult>(
-                GetLatestPaintedMapSlices());
-    } catch (std::exception &e) {
-        if (e.what() == errorNoSubmaps) {
-            LOG(INFO) << "Error creating jpeg map: " << e.what();
-            return "";
-        } else {
-            std::string errorLog = "Error writing submap to proto: ";
-            errorLog += e.what();
-            LOG(ERROR) << errorLog;
-            throw std::runtime_error(errorLog);
-        }
-    }
-    if (add_pose_marker) {
-        PaintMarker(painted_slices.get());
-    }
-
-    auto image = io::Image(std::move(painted_slices->surface));
-    return image.WriteJpegToString(jpegQuality);
 }
 
 void SLAMServiceImpl::GetLatestSampledPointCloudMapString(

--- a/viam-cartographer/src/slam_service/slam_service.h
+++ b/viam-cartographer/src/slam_service/slam_service.h
@@ -50,7 +50,7 @@ static const Eigen::Quaterniond pcdRotation(0.7071068, -0.7071068, 0, 0);
 // in the XZ plane
 static const Eigen::Quaterniond pcdOffsetRotation(0.7071068, 0.7071068, 0, 0);
 // The resolutionMeters variable defines the area in meters that each pixel
-// represents. This is used to draw the jpeg map and in so doing defines the
+// represents. This is used to draw the cairo map and in so doing defines the
 // resolution of the outputted PCD
 static const double resolutionMeters = 0.05;
 
@@ -211,10 +211,6 @@ class SLAMServiceImpl final : public SLAMService::Service {
     // Cartographer
     cartographer::io::PaintSubmapSlicesResult GetLatestPaintedMapSlices();
 
-    // GetLatestJpegMapString paints and returns the latest map as a jpeg string
-    // with or without the pose marker depending on the argument value.
-    std::string GetLatestJpegMapString(bool add_pose_marker);
-
     // PaintMarker paints the latest global pose on the painted slices.
     void PaintMarker(cartographer::io::PaintSubmapSlicesResult *painted_slices);
 
@@ -259,13 +255,11 @@ class SLAMServiceImpl final : public SLAMService::Service {
     std::mutex viam_response_mutex;
     cartographer::transform::Rigid3d latest_global_pose =
         cartographer::transform::Rigid3d();
-    // --- The following variables are used exclusively to
-    // enable GetMap to send the most recent map out while
-    // cartographer works on creating an optimized map.
-    // The variables are only updated right before the
-    // optimization is started.
-    std::string latest_jpeg_map_with_marker;
-    std::string latest_jpeg_map_without_marker;
+
+    // The latest_pointcloud_map variable is used enable GetPointCloudMap to
+    // send the most recent map out while cartographer works on creating an
+    // optimized map. It is only updated right before the optimization is
+    // started.
     std::string latest_pointcloud_map;
     // ---
 };


### PR DESCRIPTION
This PR removes some final code that dealt with creating the JPEG string that was originally returned by the GetMap call when a JPEG mime_type was given. 

JIRA Ticket: https://viam.atlassian.net/browse/RSDK-2561
