### PR TITLE
RSDK-2546 Fix Timestamp Flaky Test

### DIFF
--- a/viam-cartographer/src/io/file_handler.cc
+++ b/viam-cartographer/src/io/file_handler.cc
@@ -19,8 +19,9 @@ namespace io {
 
 namespace fs = boost::filesystem;
 
-const std::string MakeFilenameWithTimestamp(std::string path_to_dir, std::time_t t) {
-    //std::time_t t = std::time(nullptr);
+const std::string MakeFilenameWithTimestamp(std::string path_to_dir,
+                                            std::time_t t) {
+    // std::time_t t = std::time(nullptr);
     char timestamp[100];
     std::strftime(timestamp, sizeof(timestamp), time_format.c_str(),
                   std::gmtime(&t));

--- a/viam-cartographer/src/io/file_handler.cc
+++ b/viam-cartographer/src/io/file_handler.cc
@@ -19,8 +19,8 @@ namespace io {
 
 namespace fs = boost::filesystem;
 
-const std::string MakeFilenameWithTimestamp(std::string path_to_dir) {
-    std::time_t t = std::time(nullptr);
+const std::string MakeFilenameWithTimestamp(std::string path_to_dir, std::time_t t) {
+    //std::time_t t = std::time(nullptr);
     char timestamp[100];
     std::strftime(timestamp, sizeof(timestamp), time_format.c_str(),
                   std::gmtime(&t));

--- a/viam-cartographer/src/io/file_handler.h
+++ b/viam-cartographer/src/io/file_handler.h
@@ -8,6 +8,7 @@
 #include <ostream>
 #include <ratio>
 #include <string>
+#include <ctime>
 
 #include "cartographer/sensor/timed_point_cloud_data.h"
 
@@ -19,7 +20,7 @@ static const std::string time_format = "%Y-%m-%dT%H:%M:%S.0000Z";
 // MakeFilenameWithTimestamp creates a filename for a provided sensor with a
 // timestamp. The filename includes the path to the file. Does not support
 // millisecond resolution.
-const std::string MakeFilenameWithTimestamp(std::string path_to_dir);
+const std::string MakeFilenameWithTimestamp(std::string path_to_dir, std::time_t t);
 
 // ListSortedFilesInDirectory returns a list of the files in the directory
 // sorted by name.

--- a/viam-cartographer/src/io/file_handler.h
+++ b/viam-cartographer/src/io/file_handler.h
@@ -5,10 +5,10 @@
 #include <inttypes.h>
 
 #include <chrono>
+#include <ctime>
 #include <ostream>
 #include <ratio>
 #include <string>
-#include <ctime>
 
 #include "cartographer/sensor/timed_point_cloud_data.h"
 
@@ -20,7 +20,8 @@ static const std::string time_format = "%Y-%m-%dT%H:%M:%S.0000Z";
 // MakeFilenameWithTimestamp creates a filename for a provided sensor with a
 // timestamp. The filename includes the path to the file. Does not support
 // millisecond resolution.
-const std::string MakeFilenameWithTimestamp(std::string path_to_dir, std::time_t t);
+const std::string MakeFilenameWithTimestamp(std::string path_to_dir,
+                                            std::time_t t);
 
 // ListSortedFilesInDirectory returns a list of the files in the directory
 // sorted by name.

--- a/viam-cartographer/src/io/file_handler_test.cc
+++ b/viam-cartographer/src/io/file_handler_test.cc
@@ -10,6 +10,7 @@
 #include <chrono>
 
 #include "../utils/test_helpers.h"
+#include <unistd.h>
 
 namespace viam {
 namespace io {
@@ -19,17 +20,21 @@ BOOST_AUTO_TEST_SUITE(file_handler)
 
 BOOST_AUTO_TEST_CASE(MakeFilenameWithTimestamp_success) {
     std::string path_to_dir = "path_to_dir";
-    std::time_t start_time =
-        std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+    // std::time_t start_time =
+    //     std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
 
-   // std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    // //std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    // usleep(500000);
+    std::time_t t = std::time(nullptr);
+    std::string filename = MakeFilenameWithTimestamp(path_to_dir, t);
 
-    std::string filename = MakeFilenameWithTimestamp(path_to_dir);
+    // //std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    // usleep(500000);
 
-    //std::this_thread::sleep_for(std::chrono::milliseconds(5));
-
-    std::time_t end_time =
-        std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+    // std::time_t end_time =
+    //     std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+    // std::cout << (double)start_time << " | | "  << (double)end_time << "\n";
+    // std::cout << (float)start_time << " | | "  << (float)end_time << "\n";
     // Check if the filename beginning is as expected
     std::string path_prefix = "/map_data_";
     std::string filename_start =
@@ -39,10 +44,12 @@ BOOST_AUTO_TEST_CASE(MakeFilenameWithTimestamp_success) {
     double filename_time = ReadTimeFromTimestamp(filename.substr(
         filename.find(filename_prefix) + filename_prefix.length(),
         filename.find(".pcd")));
-    // Check if timestamp is between start_time and end_time
-    std::cout << (double)start_time << "| " << filename_time << " | " << (double)end_time << "\n";
-    BOOST_TEST((double)start_time <= filename_time);
-    BOOST_TEST(filename_time <= (double)end_time);
+    //std::cout.precision(17);
+    // std::cout << (double)start_time << " | " << filename_time << " | " << (double)end_time << "\n";
+    // // Check if timestamp is between start_time and end_time
+    // BOOST_TEST((double)start_time <= filename_time);
+    // BOOST_TEST(filename_time <= (double)end_time);
+    BOOST_TEST((double)t <= filename_time);
 }
 
 BOOST_AUTO_TEST_CASE(ListSortedFilesInDirectory_success) {

--- a/viam-cartographer/src/io/file_handler_test.cc
+++ b/viam-cartographer/src/io/file_handler_test.cc
@@ -6,6 +6,8 @@
 #include <ctime>
 #include <exception>
 #include <iostream>
+#include <thread>
+#include <chrono>
 
 #include "../utils/test_helpers.h"
 
@@ -19,7 +21,13 @@ BOOST_AUTO_TEST_CASE(MakeFilenameWithTimestamp_success) {
     std::string path_to_dir = "path_to_dir";
     std::time_t start_time =
         std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+
+   // std::this_thread::sleep_for(std::chrono::milliseconds(5));
+
     std::string filename = MakeFilenameWithTimestamp(path_to_dir);
+
+    //std::this_thread::sleep_for(std::chrono::milliseconds(5));
+
     std::time_t end_time =
         std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
     // Check if the filename beginning is as expected
@@ -32,8 +40,9 @@ BOOST_AUTO_TEST_CASE(MakeFilenameWithTimestamp_success) {
         filename.find(filename_prefix) + filename_prefix.length(),
         filename.find(".pcd")));
     // Check if timestamp is between start_time and end_time
+    std::cout << (double)start_time << "| " << filename_time << " | " << (double)end_time << "\n";
     BOOST_TEST((double)start_time <= filename_time);
-    BOOST_TEST(filename_time >= (double)end_time);
+    BOOST_TEST(filename_time <= (double)end_time);
 }
 
 BOOST_AUTO_TEST_CASE(ListSortedFilesInDirectory_success) {

--- a/viam-cartographer/src/io/file_handler_test.cc
+++ b/viam-cartographer/src/io/file_handler_test.cc
@@ -6,11 +6,8 @@
 #include <ctime>
 #include <exception>
 #include <iostream>
-#include <thread>
-#include <chrono>
 
 #include "../utils/test_helpers.h"
-#include <unistd.h>
 
 namespace viam {
 namespace io {
@@ -20,21 +17,10 @@ BOOST_AUTO_TEST_SUITE(file_handler)
 
 BOOST_AUTO_TEST_CASE(MakeFilenameWithTimestamp_success) {
     std::string path_to_dir = "path_to_dir";
-    // std::time_t start_time =
-    //     std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
 
-    // //std::this_thread::sleep_for(std::chrono::milliseconds(5));
-    // usleep(500000);
     std::time_t t = std::time(nullptr);
     std::string filename = MakeFilenameWithTimestamp(path_to_dir, t);
 
-    // //std::this_thread::sleep_for(std::chrono::milliseconds(5));
-    // usleep(500000);
-
-    // std::time_t end_time =
-    //     std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
-    // std::cout << (double)start_time << " | | "  << (double)end_time << "\n";
-    // std::cout << (float)start_time << " | | "  << (float)end_time << "\n";
     // Check if the filename beginning is as expected
     std::string path_prefix = "/map_data_";
     std::string filename_start =
@@ -44,12 +30,8 @@ BOOST_AUTO_TEST_CASE(MakeFilenameWithTimestamp_success) {
     double filename_time = ReadTimeFromTimestamp(filename.substr(
         filename.find(filename_prefix) + filename_prefix.length(),
         filename.find(".pcd")));
-    //std::cout.precision(17);
-    // std::cout << (double)start_time << " | " << filename_time << " | " << (double)end_time << "\n";
-    // // Check if timestamp is between start_time and end_time
-    // BOOST_TEST((double)start_time <= filename_time);
-    // BOOST_TEST(filename_time <= (double)end_time);
-    BOOST_TEST((double)t <= filename_time);
+
+    BOOST_TEST((double)t == filename_time);
 }
 
 BOOST_AUTO_TEST_CASE(ListSortedFilesInDirectory_success) {

--- a/viam-cartographer/src/slam_service/slam_service.cc
+++ b/viam-cartographer/src/slam_service/slam_service.cc
@@ -689,8 +689,9 @@ void SLAMServiceImpl::SaveMapWithTimestamp() {
             break;
         }
 
+        std::time_t t = std::time(nullptr);
         const std::string filename_with_timestamp =
-            viam::io::MakeFilenameWithTimestamp(path_to_map);
+            viam::io::MakeFilenameWithTimestamp(path_to_map, t);
 
         if (!use_live_data && finished_processing_offline) {
             {

--- a/viam-cartographer/src/slam_service/slam_service.h
+++ b/viam-cartographer/src/slam_service/slam_service.h
@@ -9,6 +9,7 @@
 #include <atomic>
 #include <shared_mutex>
 #include <string>
+#include <ctime>
 
 #include "../io/draw_trajectories.h"
 #include "../io/file_handler.h"

--- a/viam-cartographer/src/slam_service/slam_service.h
+++ b/viam-cartographer/src/slam_service/slam_service.h
@@ -7,9 +7,9 @@
 #include <grpcpp/server_context.h>
 
 #include <atomic>
+#include <ctime>
 #include <shared_mutex>
 #include <string>
-#include <ctime>
 
 #include "../io/draw_trajectories.h"
 #include "../io/file_handler.h"


### PR DESCRIPTION
Current testing of the filename timestamp generation is flaky due to the precision level of chrono's time request function. This has been fixed by requiring a timestamp to be sent to the filename generation function thus making it time independent. 

For the test, this means that instead of having to record the time before and after the filename generation step and confirm the timestamp is in between these two values, we are able to directly check if the timestamp parsed from the filename matches the one inputted into the function.

Testing was done by running the unit test 10,000 times. Zero failures were seen as compared to ~5 failures seen using the older method.

Note: an alternative path could be to add millisecond resolution to the filename generation, however, making this function time-independent is more correct without changing the underlying behavior of the current setup. We can still choose to pursue millisecond accuracy in the future should it be desired.

JIRA Ticket: https://viam.atlassian.net/browse/RSDK-2546
