### PR TITLE
RSDK-2021 - Add the cartographer AppImage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ buf: bufsetup
 
 clean:
 	rm -rf grpc
+	rm -rf bin
 	rm -rf viam-cartographer/build
 	rm -rf viam-cartographer/cartographer/build
 
@@ -98,6 +99,8 @@ install:
 appimage: build
 	cd etc/packaging/appimages && BUILD_CHANNEL=${BUILD_CHANNEL} appimage-builder --recipe carto_grpc_server-`uname -m`.yml
 	cd etc/packaging/appimages && ./package_release_carto.sh
+	cd etc/packaging/appimages && BUILD_CHANNEL=${BUILD_CHANNEL} appimage-builder --recipe cartographer-module-`uname -m`.yml
+	cd etc/packaging/appimages && ./package_release_module.sh
 	mkdir -p etc/packaging/appimages/deploy/
 	mv etc/packaging/appimages/*.AppImage* etc/packaging/appimages/deploy/
 	chmod 755 etc/packaging/appimages/deploy/*.AppImage

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,9 @@ clean:
 	rm -rf viam-cartographer/build
 	rm -rf viam-cartographer/cartographer/build
 
+clean-all:
+	git clean -fxd
+
 ensure-submodule-initialized:
 	@if [ ! -d "viam-cartographer/cartographer/cartographer" ]; then \
 		echo "Submodule was not found. Initializing..."; \

--- a/etc/packaging/appimages/cartographer-module-aarch64.yml
+++ b/etc/packaging/appimages/cartographer-module-aarch64.yml
@@ -1,0 +1,73 @@
+# appimage-builder recipe see https://appimage-builder.readthedocs.io for details
+version: 1
+script:
+ - rm -rf $TARGET_APPDIR | true
+ - mkdir -p $TARGET_APPDIR/usr/bin
+ - mkdir -p $TARGET_APPDIR/usr/lib
+ - mkdir -p $TARGET_APPDIR/usr/share/cartographer/lua_files
+ - cp ../../../bin/cartographer-module $TARGET_APPDIR/usr/bin/
+ - cp ../../../viam-cartographer/build/carto_grpc_server $TARGET_APPDIR/usr/bin/
+ - cp ../../../viam-cartographer/cartographer/build/libcartographer.a $TARGET_APPDIR/usr/lib/
+ - cp ../../../viam-cartographer/build/libviam-cartographer.a $TARGET_APPDIR/usr/lib/
+ - cp ../../../viam-cartographer/lua_files/* $TARGET_APPDIR/usr/share/cartographer/lua_files
+ - cp ../../../viam-cartographer/cartographer/configuration_files/* $TARGET_APPDIR/usr/share/cartographer/lua_files
+ - mkdir -p $TARGET_APPDIR/usr/share/icons/viam/256x256/apps/
+ - cp ./viam-server.png $TARGET_APPDIR/usr/share/icons/viam/256x256/apps/viam-server.png
+ - go install github.com/Otterverse/aix@latest
+ - cp `go env GOPATH`/bin/aix $TARGET_APPDIR/usr/bin/
+ - chmod 755 $TARGET_APPDIR/usr/bin/*
+
+AppDir:
+  path: ./AppDir
+  app_info:
+    id: com.viam.cartographer-module
+    name: cartographer-module
+    icon: viam-server
+    version: ${BUILD_CHANNEL}
+    exec: usr/bin/aix
+    exec_args: $@
+  apt:
+    arch:
+    - arm64
+    allow_unauthenticated: true
+    sources:
+    - sourceline: deb [trusted=yes] http://deb.debian.org/debian bullseye main
+    - sourceline: deb [trusted=yes] http://deb.debian.org/debian-security bullseye-security main
+    - sourceline: deb [trusted=yes] http://deb.debian.org/debian bullseye-updates main
+    - sourceline: deb [trusted=yes] https://us-apt.pkg.dev/projects/static-file-server-310021 bullseye main
+    include:
+    - libboost-iostreams1.74.0:arm64
+    - libboost-filesystem1.74.0:arm64
+    - libssl1.1:arm64
+    - libgrpc++1:arm64
+    - libgrpc10:arm64
+    - libprotobuf31:arm64
+    - libxcb-render0:arm64
+    - libxcb-shm0:arm64
+    - libabsl20200923:arm64
+    - libc6:arm64
+    - libceres1
+    - libgoogle-glog0v5
+    - libgflags2.2
+    - liblua5.3-0:arm64
+    - libcairo2:arm64
+    - libpcl-io1.11:arm64
+    - libpcl-common1.11:arm64
+    - libjpeg62-turbo:arm64
+    - libstdc++6:arm64
+
+  files:
+    include: []
+    exclude:
+    - usr/include/
+    - usr/share/man
+    - usr/share/doc
+    - usr/share/info
+    - usr/share/lintian
+
+  runtime:
+    env:
+        AIX_TARGET: usr/bin/cartographer-module
+AppImage:
+  arch: aarch64
+  update-information: zsync|http://packages.viam.com/apps/slam-servers/cartographer-module-${BUILD_CHANNEL}-aarch64.AppImage.zsync

--- a/etc/packaging/appimages/cartographer-module-x86_64.yml
+++ b/etc/packaging/appimages/cartographer-module-x86_64.yml
@@ -1,0 +1,72 @@
+# appimage-builder recipe see https://appimage-builder.readthedocs.io for details
+version: 1
+script:
+ - rm -rf $TARGET_APPDIR | true
+ - mkdir -p $TARGET_APPDIR/usr/bin
+ - mkdir -p $TARGET_APPDIR/usr/lib
+ - mkdir -p $TARGET_APPDIR/usr/share/cartographer/lua_files
+ - cp ../../../bin/cartographer-module $TARGET_APPDIR/usr/bin/
+ - cp ../../../viam-cartographer/build/carto_grpc_server $TARGET_APPDIR/usr/bin/
+ - cp ../../../viam-cartographer/cartographer/build/libcartographer.a $TARGET_APPDIR/usr/lib/
+ - cp ../../../viam-cartographer/build/libviam-cartographer.a $TARGET_APPDIR/usr/lib/
+ - cp ../../../viam-cartographer/lua_files/* $TARGET_APPDIR/usr/share/cartographer/lua_files
+ - cp ../../../viam-cartographer/cartographer/configuration_files/* $TARGET_APPDIR/usr/share/cartographer/lua_files
+ - mkdir -p $TARGET_APPDIR/usr/share/icons/viam/256x256/apps/
+ - cp ./viam-server.png $TARGET_APPDIR/usr/share/icons/viam/256x256/apps/viam-server.png
+ - go install github.com/Otterverse/aix@latest
+ - cp `go env GOPATH`/bin/aix $TARGET_APPDIR/usr/bin/
+ - chmod 755 $TARGET_APPDIR/usr/bin/*
+
+AppDir:
+  path: ./AppDir
+  app_info:
+    id: com.viam.cartographer-module
+    name: cartographer-module
+    icon: viam-server
+    version: ${BUILD_CHANNEL}
+    exec: usr/bin/aix
+    exec_args: $@
+  apt:
+    arch:
+    - amd64
+    allow_unauthenticated: true
+    sources:
+    - sourceline: deb [trusted=yes] http://deb.debian.org/debian bullseye main
+    - sourceline: deb [trusted=yes] http://deb.debian.org/debian-security bullseye-security main
+    - sourceline: deb [trusted=yes] http://deb.debian.org/debian bullseye-updates main
+    - sourceline: deb [trusted=yes] https://us-apt.pkg.dev/projects/static-file-server-310021 bullseye main
+    include:
+    - libboost-iostreams1.74.0:amd64
+    - libboost-filesystem1.74.0:amd64
+    - libssl1.1:amd64
+    - libgrpc++1:amd64
+    - libgrpc10:amd64
+    - libprotobuf31:amd64
+    - libxcb-render0:amd64
+    - libxcb-shm0:amd64
+    - libabsl20200923:amd64
+    - libc6:amd64
+    - libceres1
+    - libgoogle-glog0v5
+    - libgflags2.2
+    - liblua5.3-0:amd64
+    - libcairo2:amd64
+    - libpcl-io1.11:amd64
+    - libpcl-common1.11:amd64
+    - libjpeg62-turbo:amd64
+    - libstdc++6:amd64
+  files:
+    include: []
+    exclude:
+    - usr/include/
+    - usr/share/man
+    - usr/share/doc
+    - usr/share/info
+    - usr/share/lintian
+
+  runtime:
+    env:
+        AIX_TARGET: usr/bin/cartographer-module
+AppImage:
+  arch: x86_64
+  update-information: zsync|http://packages.viam.com/apps/slam-servers/cartographer-module-${BUILD_CHANNEL}-x86_64.AppImage.zsync

--- a/etc/packaging/appimages/package_release_module.sh
+++ b/etc/packaging/appimages/package_release_module.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+SELF=$(realpath $0)
+source "$(dirname $SELF)/utils.sh"
+
+if get_version_tag > /dev/null
+then
+	CUR_TAG=$(get_version_tag)
+	BUILD_CHANNEL=stable appimage-builder --recipe cartographer-module-`uname -m`.yml
+	BUILD_CHANNEL=$CUR_TAG appimage-builder --recipe cartographer-module-`uname -m`.yml
+fi

--- a/viam-cartographer.go
+++ b/viam-cartographer.go
@@ -353,7 +353,7 @@ func (cartoSvc *cartographerService) GetSLAMProcessConfig() pexec.ProcessConfig 
 
 	if appDir != "" {
 		// The carto grpc server is expected to be in
-		// /usr/bin/ if we are running in an appimage
+		// /usr/bin/ if we are running in an AppImage
 		target = appDir + "/usr/bin/" + strings.TrimPrefix(target, "/")
 	}
 

--- a/viam-cartographer.go
+++ b/viam-cartographer.go
@@ -358,10 +358,14 @@ func (cartoSvc *cartographerService) GetSLAMProcessConfig() pexec.ProcessConfig 
 	}
 
 	return pexec.ProcessConfig{
-		ID:      "slam_cartographer",
-		Name:    target,
-		Args:    args,
-		Log:     true,
+		ID:   "slam_cartographer",
+		Name: target,
+		Args: args,
+		Log:  true,
+		// In appimage this is set to the appimage
+		// squashfs mount location (/tmp/.mountXXXXX)
+		// Otherwise, it is an empty string
+		CWD:     os.Getenv("APPRUN_RUNTIME"),
 		OneShot: false,
 	}
 }

--- a/viam-cartographer.go
+++ b/viam-cartographer.go
@@ -6,6 +6,7 @@ import (
 	"bufio"
 	"context"
 	"io"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -346,9 +347,19 @@ func (cartoSvc *cartographerService) GetSLAMProcessConfig() pexec.ProcessConfig 
 	args = append(args, "-port="+cartoSvc.port)
 	args = append(args, "--aix-auto-update")
 
+	target := cartoSvc.executableName
+
+	appDir := os.Getenv("APPDIR")
+
+	if appDir != "" {
+		// The carto grpc server is expected to be in
+		// /usr/bin/ if we are running in an appimage
+		target = appDir + "/usr/bin/" + strings.TrimPrefix(target, "/")
+	}
+
 	return pexec.ProcessConfig{
 		ID:      "slam_cartographer",
-		Name:    cartoSvc.executableName,
+		Name:    target,
 		Args:    args,
 		Log:     true,
 		OneShot: false,


### PR DESCRIPTION
Ticket: https://viam.atlassian.net/browse/RSDK-2021

Done:
* Adds orbslam3-module app image creation to Makefile & github workflow

Tested on:
- [x] arm64 linux (AppImage)
- [ ] x86_64 linux (AppImage)
- [x] MacOS (built locally)
