### PR TITLE
[RSDK-2760] Setup script should force install openssl

### DIFF
--- a/viam-cartographer/scripts/setup_cartographer_macos.sh
+++ b/viam-cartographer/scripts/setup_cartographer_macos.sh
@@ -6,4 +6,4 @@ brew install abseil boost ceres-solver protobuf ninja cairo googletest lua@5.3
 brew link lua@5.3
 brew install openssl eigen gflags glog suite-sparse sphinx-doc pcl
 brew link protobuf
-brew link openssl
+brew link openssl --force


### PR DESCRIPTION
When I tried to build cartographer on my Mac for the first time, I ran into issues with OpenSSL (sadly I don't remember what the error was and didn't save it). @nicksanford and I cross-referenced the `setup_cartographer_macos` script with the `setup_orbslam_macos` script and observed that in orb slam, we run `brew link openssl` with the `--force` flag. When I ran this locally, I stopped getting errors. This PR changes the `setup_cartographer_macos` script to run the correct command.