### PR TITLE
RSDK-2029 - Remove/replace rdk integration tests with local tests

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -74,18 +74,10 @@ jobs:
       run: |
         sudo cp viam-cartographer/viam-cartographer/build/carto_grpc_server /usr/local/bin/carto_grpc_server
 
-    - name: Check out code in rdk directory
-      if: matrix.platform == 'linux/amd64'
-      uses: actions/checkout@v3
-      with:
-        repository: viamrobotics/rdk
-        path: rdk
-
-    - name: Run rdk slam integration tests
+    - name: Run viam-cartographer cartographer integration tests
       if: matrix.platform == 'linux/amd64'
       run: |
-        chown -R testbot:testbot .
-        sudo -u testbot bash -lc 'cd rdk/services/slam/builtin && go test -v -run TestCartographerIntegration'
+        sudo -u testbot bash -lc 'cd viam-cartographer && sudo go test -v -race -run TestCartographerIntegration'
 
     - name: Build AppImage (PR)
       if: contains(github.event.pull_request.labels.*.name, 'appimage') || contains(github.event.pull_request.labels.*.name, 'appimage-ignore-tests')

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,19 +108,6 @@ jobs:
       run: |
         sudo cp viam-cartographer/viam-cartographer/build/carto_grpc_server /usr/local/bin/carto_grpc_server
 
-    - name: Check out code in rdk directory
-      if: matrix.platform == 'linux/amd64'
-      uses: actions/checkout@v3
-      # Pulls main/HEAD from rdk to ensure no accidental regressions
-      with:
-        repository: viamrobotics/rdk 
-        path: rdk
-
-    - name: Run rdk cartographer integration tests
-      if: matrix.platform == 'linux/amd64'
-      run: |
-        sudo -u testbot bash -lc 'cd rdk/services/slam/builtin && sudo go test -v -race -run TestCartographerIntegration'
-
     - name: Run viam-cartographer cartographer integration tests
       if: matrix.platform == 'linux/amd64'
       run: |


### PR DESCRIPTION
Ticket: https://viam.atlassian.net/browse/RSDK-2029

Done:
* Removed/replaced any RDK builtin based integration tests with viam-cartographer equivalent integration tests

NOTE: 
* Must be merged before merging https://github.com/viamrobotics/rdk/pull/2262