### PR TITLE
Update make install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,7 @@ test: test-cpp test-go
 
 install:
 	sudo cp viam-cartographer/build/carto_grpc_server /usr/local/bin/carto_grpc_server
+	sudo cp bin/cartographer-module /usr/local/bin/cartographer-module
 
 appimage: build
 	cd etc/packaging/appimages && BUILD_CHANNEL=${BUILD_CHANNEL} appimage-builder --recipe cartographer-module-`uname -m`.yml


### PR DESCRIPTION
This PR adds copying the cartographer-module to `/usr/local/bin `when running `make install`.

This was tested by removing the associated binaries, running make install, and seeing them getting copied into  /usr/local/bin with no error.