### PR TITLE
RSDK-2896 Add timezone fix for file handler

### DIFF
--- a/viam-cartographer/src/io/file_handler.cc
+++ b/viam-cartographer/src/io/file_handler.cc
@@ -102,7 +102,7 @@ double ReadTimeFromTimestamp(std::string timestamp) {
         throw std::runtime_error(
             "timestamp cannot be parsed into a std::tm object: " + timestamp);
     }
-    double timestamp_time = (double)std::mktime(&dt);
+    double timestamp_time = (double)std::mktime(&dt) - timezone;
     if (timestamp_time == -1) {
         throw std::runtime_error(
             "timestamp cannot be represented as a std::time_t object: " +


### PR DESCRIPTION
This PR adds timezone offsets for `ReadTimeFromTimestamp` so that it is platform and timezone-agnostic. The issue is that `mktime` will convert a `struct tm` to LOCAL TIME not UTC.

Note: `timezone` is a global variable in C++ when importing `time.h`: https://www.mkssoftware.com/docs/man5/tzname.5.asp

Tested this on mac with immediate success.

JIRA Ticket: https://viam.atlassian.net/browse/RSDK-2896