### PR TITLE
[RSDK-2519] add version information

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 BUILD_CHANNEL?=local
 TOOL_BIN = bin/gotools/$(shell uname -s)-$(shell uname -m)
 PATH_WITH_TOOLS="`pwd`/$(TOOL_BIN):${PATH}"
+GIT_REVISION = $(shell git rev-parse HEAD | tr -d '\n')
+TAG_VERSION?=$(shell etc/tag_version.sh)
+LDFLAGS = -ldflags "-X 'main.Version=${TAG_VERSION}' -X 'main.GitRevision=${GIT_REVISION}'"
 
 set-pkg-config-openssl:
 	pkg-config openssl || export PKG_CONFIG_PATH=$$PKG_CONFIG_PATH:`find \`which brew > /dev/null && brew --prefix\` -name openssl.pc | head -n1 | xargs dirname`
@@ -81,7 +84,7 @@ else
 endif
 
 build-module:
-	mkdir -p bin && go build -o bin/cartographer-module module/main.go
+	mkdir -p bin && go build $(LDFLAGS) -o bin/cartographer-module module/main.go
 
 install-lua-files:
 	sudo mkdir -p /usr/local/share/cartographer/lua_files/

--- a/etc/tag_version.sh
+++ b/etc/tag_version.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+SELF=$(realpath $0)
+source "$(dirname $SELF)/utils.sh"
+fn_name="get_version_tag"
+
+if declare -F "$fn_name" > /dev/null
+then
+	echo $($fn_name)
+fi
+exit 0
+

--- a/etc/utils.sh
+++ b/etc/utils.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# This is a helper function to determine if the current git commit constitutes a new release.
+# Specifically, is it tagged in the format "v1.2.3" and a higher version than any other tags.
+# This is used for internal tagging and release building.
+get_version_tag() {
+	set -e
+	CUR_TAG=`git tag --points-at | sort -Vr | head -n1`
+	if [[ $CUR_TAG =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]
+	then
+		NEWEST_TAG=`git tag -l "v*.*.*" | sort -Vr | head -n1`
+		if [[ $CUR_TAG == $NEWEST_TAG ]]
+		then
+			echo $CUR_TAG
+			return 0
+		else
+			echo "latest"
+			return 128
+		fi
+	fi
+	return 1
+}
+

--- a/module/main.go
+++ b/module/main.go
@@ -12,11 +12,30 @@ import (
 	viamcartographer "github.com/viamrobotics/viam-cartographer"
 )
 
+// Versioning variables which are replaced by LD flags.
+var (
+	Version     = "development"
+	GitRevision = ""
+)
+
+// Arguments for the command.
+type Arguments struct {
+	Version bool `flag:"version,usage=print version"`
+}
+
 func main() {
 	utils.ContextualMain(mainWithArgs, golog.NewLogger("cartographerModule"))
 }
 
 func mainWithArgs(ctx context.Context, args []string, logger golog.Logger) error {
+	argsParsed, err := printVersion(args, logger)
+	if err != nil {
+		return err
+	}
+	if argsParsed.Version {
+		return nil
+	}
+
 	// Instantiate the module
 	cartoModule, err := module.NewModuleFromArgs(ctx, logger)
 	if err != nil {
@@ -36,4 +55,28 @@ func mainWithArgs(ctx context.Context, args []string, logger golog.Logger) error
 	}
 	<-ctx.Done()
 	return nil
+}
+
+func printVersion(args []string, logger golog.Logger) (Arguments, error) {
+	var argsParsed Arguments
+	if err := utils.ParseFlags(args, &argsParsed); err != nil {
+		return argsParsed, err
+	}
+
+	// Always log the version, return early if the '-version' flag was provided
+	// fmt.Println would be better but fails linting. Good enough.
+	var versionFields []interface{}
+	if Version != "" {
+		versionFields = append(versionFields, "version", Version)
+	}
+	if GitRevision != "" {
+		versionFields = append(versionFields, "git_rev", GitRevision)
+	}
+	if len(versionFields) != 0 {
+		logger.Infow(viamcartographer.Model.String(), versionFields...)
+	} else {
+		logger.Info(viamcartographer.Model.String() + " built from source; version unknown")
+	}
+
+	return argsParsed, nil
 }


### PR DESCRIPTION
[Ticket](https://viam.atlassian.net/browse/RSDK-2519)

Sources: 
1. https://www.digitalocean.com/community/tutorials/using-ldflags-to-set-version-information-for-go-applications
2. https://github.com/viamrobotics/rdk/blob/main/Makefile#L9



1. log model, git sha & tag information as first log line (same as [viam-server](https://github.com/viamrobotics/rdk/blob/main/web/server/entrypoint.go#L77))
3. terminate the program early if `--version` or `-version` is provided via argv

Example logs:
```
./bin/cartographer-module --version
1.683062604287018e+09   info    cartographerModule      module/main.go:76       viam:slam:cartographer  {"git_rev": "dbace9cfbbf3a9c184e682823cfe39d8e3e062c1"}
```

