### PR TITLE
[RSDK-2969] update appimage links to use the module

### DIFF
--- a/.github/workflows/appimage-comment.yml
+++ b/.github/workflows/appimage-comment.yml
@@ -30,6 +30,6 @@ jobs:
           recreate: true
           message: |
             AppImages ready!
-            <https://storage.googleapis.com/packages.viam.com/apps/slam-servers/carto_grpc_server-pr-${{ env.PR_NUMBER }}-aarch64.AppImage>
-            <https://storage.googleapis.com/packages.viam.com/apps/slam-servers/carto_grpc_server-pr-${{ env.PR_NUMBER }}-x86_64.AppImage>
+            <http://packages.viam.com/apps/slam-servers/cartographer-module-pr-${{ env.PR_NUMBER }}-aarch64.AppImage>
+            <http://packages.viam.com/apps/slam-servers/cartographer-module-pr-${{ env.PR_NUMBER }}-x86_64.AppImage>
 

--- a/.github/workflows/appimage-comment.yml
+++ b/.github/workflows/appimage-comment.yml
@@ -30,6 +30,6 @@ jobs:
           recreate: true
           message: |
             AppImages ready!
-            <http://packages.viam.com/apps/slam-servers/cartographer-module-pr-${{ env.PR_NUMBER }}-aarch64.AppImage>
-            <http://packages.viam.com/apps/slam-servers/cartographer-module-pr-${{ env.PR_NUMBER }}-x86_64.AppImage>
+            <https://storage.googleapis.com//packages.viam.com/apps/slam-servers/cartographer-module-pr-${{ env.PR_NUMBER }}-aarch64.AppImage>
+            <https://storage.googleapis.com//packages.viam.com/apps/slam-servers/cartographer-module-pr-${{ env.PR_NUMBER }}-x86_64.AppImage>
 

--- a/viam-cartographer/src/slam_service/slam_service.cc
+++ b/viam-cartographer/src/slam_service/slam_service.cc
@@ -29,8 +29,9 @@ struct ColorARGB {
 
 // Check if the green color channel is 0 to filter unobserved pixels which is
 // set in DrawTexture at
-// https://github.com/cartographer-project/cartographer/blob/ef00de231
-// 7dcf7895b09f18cc4d87f8b533a019b/cartographer/io/submap_painter.cc#L206-L207
+// https://github.com/cartographer-project/cartographer/blob/
+// ef00de2317dcf7895b09f18cc4d87f8b533a019b/cartographer/
+// io/submap_painter.cc#L206-L207
 bool CheckIfEmptyPixel(ColorARGB pixel_color) { return (pixel_color.G == 0); }
 
 // Convert the scale of a specified color channel from the given UCHAR

--- a/viam-cartographer/src/slam_service/slam_service.cc
+++ b/viam-cartographer/src/slam_service/slam_service.cc
@@ -27,12 +27,13 @@ struct ColorARGB {
     unsigned char B;
 };
 
-// Check if the green color channel is 0 to filter unobserved pixels which is set in 
-// DrawTexture at https://github.com/cartographer-project/cartographer/blob/ef00de231
+// Check if the green color channel is 0 to filter unobserved pixels which is
+// set in DrawTexture at
+// https://github.com/cartographer-project/cartographer/blob/ef00de231
 // 7dcf7895b09f18cc4d87f8b533a019b/cartographer/io/submap_painter.cc#L206-L207
 bool CheckIfEmptyPixel(ColorARGB pixel_color) { return (pixel_color.G == 0); }
 
-// Convert the scale of a specified color channel from the given UCHAR 
+// Convert the scale of a specified color channel from the given UCHAR
 // range of 0 - 255 to an inverse probability range of 100 - 0
 int CalculateProbabilityFromColorChannels(ColorARGB pixel_color) {
     unsigned char max_val = UCHAR_MAX;

--- a/viam-cartographer/src/slam_service/slam_service.cc
+++ b/viam-cartographer/src/slam_service/slam_service.cc
@@ -27,13 +27,12 @@ struct ColorARGB {
     unsigned char B;
 };
 
-// Check if the green color channel is 0 to filter unobserved pixels which is
-// set in DrawTexture at
-// https://github.com/cartographer-project/cartographer/blob/ef00de231
+// Check if the green color channel is 0 to filter unobserved pixels which is set in 
+// DrawTexture at https://github.com/cartographer-project/cartographer/blob/ef00de231
 // 7dcf7895b09f18cc4d87f8b533a019b/cartographer/io/submap_painter.cc#L206-L207
 bool CheckIfEmptyPixel(ColorARGB pixel_color) { return (pixel_color.G == 0); }
 
-// Convert the scale of a specified color channel from the given UCHAR
+// Convert the scale of a specified color channel from the given UCHAR 
 // range of 0 - 255 to an inverse probability range of 100 - 0
 int CalculateProbabilityFromColorChannels(ColorARGB pixel_color) {
     unsigned char max_val = UCHAR_MAX;

--- a/viam-cartographer/src/slam_service/slam_service.cc
+++ b/viam-cartographer/src/slam_service/slam_service.cc
@@ -27,14 +27,12 @@ struct ColorARGB {
     unsigned char B;
 };
 
-// Check if the green color channel is 0 to filter unobserved pixels which is
-// set in DrawTexture at
-// https://github.com/cartographer-project/cartographer/blob/
-// ef00de2317dcf7895b09f18cc4d87f8b533a019b/cartographer/
-// io/submap_painter.cc#L206-L207
+// Check if the green color channel is 0 to filter unobserved pixels which is set in 
+// DrawTexture at https://github.com/cartographer-project/cartographer/blob/ef00de231
+// 7dcf7895b09f18cc4d87f8b533a019b/cartographer/io/submap_painter.cc#L206-L207
 bool CheckIfEmptyPixel(ColorARGB pixel_color) { return (pixel_color.G == 0); }
 
-// Convert the scale of a specified color channel from the given UCHAR
+// Convert the scale of a specified color channel from the given UCHAR 
 // range of 0 - 255 to an inverse probability range of 100 - 0
 int CalculateProbabilityFromColorChannels(ColorARGB pixel_color) {
     unsigned char max_val = UCHAR_MAX;


### PR DESCRIPTION
noticed the links were still referencing `carto_grpc_server` when adding the appimage label. This is a quick PR to switch it to `cartographer-module`