### PR TITLE
Fix Readme for seamless setup & build process

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,10 +88,11 @@ These containers are set to persist between sessions via the `persistent` parame
 make bufinstall && make buf 
 # Install dependencies
 make setup
+# Build the binary
+make build
 # Install lua files
 make install-lua-files
-# Build & install the binary
-make build
+# Install the cartographer-module binary
 make install
 # Run the binary
 cartographer-module

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ These containers are set to persist between sessions via the `persistent` parame
 make bufinstall && make buf 
 # Install dependencies
 make setup
+# Install lua files
+make install-lua-files
 # Build & install the binary
 make build
 make install


### PR DESCRIPTION
I ran into issues with running cartographer today after uninstalling and attempting to reinstall everything. What was missing was running the `make install-lua-files` command, which is why I think we should add it to the set of instructions in the README.