### PR TITLE
[RSDK-3430] viam_carto_lib_init_term

### DIFF
--- a/viam-cartographer/src/carto_facade/carto_facade.cc
+++ b/viam-cartographer/src/carto_facade/carto_facade.cc
@@ -79,6 +79,9 @@ extern int viam_carto_lib_init(viam_carto_lib **ppVCL) {
     FLAGS_logtostderr = 1;
     google::InitGoogleLogging("cartographer");
     viam_carto_lib *vcl = (viam_carto_lib *)malloc(sizeof(viam_carto_lib));
+    if (vcl == nullptr) {
+        return VIAM_CARTO_OUT_OF_MEMORY;
+    }
     vcl->initialized = 1;
 
     *ppVCL = vcl;
@@ -111,6 +114,9 @@ extern int viam_carto_init(viam_carto **ppVC, viam_carto_lib *pVCL,
 
     // allocate viam_carto struct
     viam_carto *vc = (viam_carto *)malloc(sizeof(viam_carto));
+    if (vc == nullptr) {
+        return VIAM_CARTO_OUT_OF_MEMORY;
+    }
 
     vc->carto_obj = new viam::carto_facade::CartoFacade(pVCL, c, ac);
 

--- a/viam-cartographer/src/carto_facade/carto_facade.cc
+++ b/viam-cartographer/src/carto_facade/carto_facade.cc
@@ -76,11 +76,6 @@ extern int viam_carto_lib_init(viam_carto_lib **ppVCL) {
     if (!((sizeof(float) == 4) && (CHAR_BIT == 8) && (sizeof(int) == 4))) {
         return VIAM_CARTO_LIB_PLATFORM_INVALID;
     }
-    /* if (google::IsGoogleLoggingInitialized()) { */
-    /*     return VIAM_CARTO_LIB_ALREADY_INITIALIZED; */
-    /* } */
-
-    /* assert(FLAGS_logtostderr == 0); */
     FLAGS_logtostderr = 1;
     google::InitGoogleLogging("cartographer");
     viam_carto_lib *vcl = (viam_carto_lib *)malloc(sizeof(viam_carto_lib));
@@ -92,9 +87,6 @@ extern int viam_carto_lib_init(viam_carto_lib **ppVCL) {
 };
 
 extern int viam_carto_lib_terminate(viam_carto_lib **ppVCL) {
-    /* if (!(google::IsGoogleLoggingInitialized())) { */
-    /*     return VIAM_CARTO_LIB_ALREADY_TERMINATED; */
-    /* } */
     FLAGS_logtostderr = 0;
     google::ShutdownGoogleLogging();
     free(*ppVCL);

--- a/viam-cartographer/src/carto_facade/carto_facade.cc
+++ b/viam-cartographer/src/carto_facade/carto_facade.cc
@@ -161,7 +161,6 @@ extern int viam_carto_get_position_response_destroy(
     int rc = BSTR_OK;
     rc = bdestroy(r->component_reference);
     if (rc != BSTR_OK) {
-        // TODO: Write error messages
         return_code = VIAM_CARTO_DESTRUCTOR_ERROR;
     }
     r->component_reference = nullptr;

--- a/viam-cartographer/src/carto_facade/carto_facade.cc
+++ b/viam-cartographer/src/carto_facade/carto_facade.cc
@@ -1,5 +1,6 @@
 // This is an experimental integration of cartographer into RDK.
 #include "carto_facade.h"
+
 #include "glog/logging.h"
 
 namespace viam {
@@ -126,13 +127,9 @@ extern int viam_carto_init(viam_carto **ppVC, viam_carto_lib *pVCL,
     return VIAM_CARTO_SUCCESS;
 };
 
-extern int viam_carto_start(viam_carto *vc) {
-    return VIAM_CARTO_SUCCESS;
-};
+extern int viam_carto_start(viam_carto *vc) { return VIAM_CARTO_SUCCESS; };
 
-extern int viam_carto_stop(viam_carto *vc) {
-    return VIAM_CARTO_SUCCESS;
-};
+extern int viam_carto_stop(viam_carto *vc) { return VIAM_CARTO_SUCCESS; };
 
 extern int viam_carto_terminate(viam_carto **ppVC) {
     viam::carto_facade::CartoFacade *cf =
@@ -147,7 +144,8 @@ extern int viam_carto_add_sensor_reading(viam_carto *vc,
     return VIAM_CARTO_SUCCESS;
 };
 
-extern int viam_carto_add_sensor_reading_destroy(viam_carto_sensor_reading *sr) {
+extern int viam_carto_add_sensor_reading_destroy(
+    viam_carto_sensor_reading *sr) {
     return VIAM_CARTO_SUCCESS;
 };
 

--- a/viam-cartographer/src/carto_facade/carto_facade.cc
+++ b/viam-cartographer/src/carto_facade/carto_facade.cc
@@ -114,10 +114,6 @@ extern int viam_carto_init(viam_carto **ppVC, viam_carto_lib *pVCL,
         return VIAM_CARTO_LIB_INVALID;
     }
 
-    if (!pVCL->initialized) {
-        return VIAM_CARTO_LIB_NOT_INITIALIZED;
-    }
-
     // allocate viam_carto struct
     viam_carto *vc = (viam_carto *)malloc(sizeof(viam_carto));
     if (vc == nullptr) {

--- a/viam-cartographer/src/carto_facade/carto_facade.cc
+++ b/viam-cartographer/src/carto_facade/carto_facade.cc
@@ -69,20 +69,24 @@ int CartoFacade::AddSensorReading(viam_carto_sensor_reading *sr) {
 }  // namespace carto_facade
 }  // namespace viam
 
-extern int viam_carto_lib_init(viam_carto_lib **ppVCL) {
+extern int viam_carto_lib_init(viam_carto_lib **ppVCL, int minloglevel,
+                               int verbose) {
     if (ppVCL == nullptr) {
         return VIAM_CARTO_LIB_INVALID;
     }
     if (!((sizeof(float) == 4) && (CHAR_BIT == 8) && (sizeof(int) == 4))) {
         return VIAM_CARTO_LIB_PLATFORM_INVALID;
     }
-    FLAGS_logtostderr = 1;
-    google::InitGoogleLogging("cartographer");
     viam_carto_lib *vcl = (viam_carto_lib *)malloc(sizeof(viam_carto_lib));
     if (vcl == nullptr) {
         return VIAM_CARTO_OUT_OF_MEMORY;
     }
-    vcl->initialized = 1;
+    google::InitGoogleLogging("cartographer");
+    FLAGS_logtostderr = 1;
+    FLAGS_minloglevel = minloglevel;
+    FLAGS_v = verbose;
+    vcl->minloglevel = minloglevel;
+    vcl->verbose = verbose;
 
     *ppVCL = vcl;
 
@@ -91,6 +95,8 @@ extern int viam_carto_lib_init(viam_carto_lib **ppVCL) {
 
 extern int viam_carto_lib_terminate(viam_carto_lib **ppVCL) {
     FLAGS_logtostderr = 0;
+    FLAGS_minloglevel = 0;
+    FLAGS_v = 0;
     google::ShutdownGoogleLogging();
     free(*ppVCL);
     *ppVCL = nullptr;

--- a/viam-cartographer/src/carto_facade/carto_facade.cc
+++ b/viam-cartographer/src/carto_facade/carto_facade.cc
@@ -1,5 +1,6 @@
 // This is an experimental integration of cartographer into RDK.
 #include "carto_facade.h"
+#include "glog/logging.h"
 
 namespace viam {
 namespace carto_facade {
@@ -26,8 +27,9 @@ config from_viam_carto_config(viam_carto_config vcc) {
     return c;
 };
 
-CartoFacade::CartoFacade(const viam_carto_config c,
+CartoFacade::CartoFacade(viam_carto_lib *pVCL, const viam_carto_config c,
                          const viam_carto_algo_config ac) {
+    lib = pVCL;
     config = from_viam_carto_config(c);
     algo_config = ac;
 };
@@ -66,32 +68,73 @@ int CartoFacade::AddSensorReading(viam_carto_sensor_reading *sr) {
 }  // namespace carto_facade
 }  // namespace viam
 
-extern int viam_carto_init(const viam_carto **ppVC, const viam_carto_config c,
-                           const viam_carto_algo_config ac, char **errmsg) {
+extern int viam_carto_lib_init(viam_carto_lib **ppVCL) {
+    if (ppVCL == nullptr) {
+        return VIAM_CARTO_LIB_INVALID;
+    }
+    if (!((sizeof(float) == 4) && (CHAR_BIT == 8) && (sizeof(int) == 4))) {
+        return VIAM_CARTO_LIB_PLATFORM_INVALID;
+    }
+    /* if (google::IsGoogleLoggingInitialized()) { */
+    /*     return VIAM_CARTO_LIB_ALREADY_INITIALIZED; */
+    /* } */
+
+    /* assert(FLAGS_logtostderr == 0); */
+    FLAGS_logtostderr = 1;
+    google::InitGoogleLogging("cartographer");
+    viam_carto_lib *vcl = (viam_carto_lib *)malloc(sizeof(viam_carto_lib));
+    vcl->initialized = 1;
+
+    *ppVCL = vcl;
+
+    return VIAM_CARTO_SUCCESS;
+};
+
+extern int viam_carto_lib_terminate(viam_carto_lib **ppVCL) {
+    /* if (!(google::IsGoogleLoggingInitialized())) { */
+    /*     return VIAM_CARTO_LIB_ALREADY_TERMINATED; */
+    /* } */
+    FLAGS_logtostderr = 0;
+    google::ShutdownGoogleLogging();
+    free(*ppVCL);
+    *ppVCL = nullptr;
+    return VIAM_CARTO_SUCCESS;
+};
+
+extern int viam_carto_init(viam_carto **ppVC, viam_carto_lib *pVCL,
+                           const viam_carto_config c,
+                           const viam_carto_algo_config ac) {
     if (ppVC == nullptr) {
-        *errmsg = "viam_carto pointer should not be NULL";
         return VIAM_CARTO_VC_INVALID;
+    }
+
+    if (pVCL == nullptr) {
+        return VIAM_CARTO_LIB_INVALID;
+    }
+
+    if (!pVCL->initialized) {
+        return VIAM_CARTO_LIB_NOT_INITIALIZED;
     }
 
     // allocate viam_carto struct
     viam_carto *vc = (viam_carto *)malloc(sizeof(viam_carto));
 
-    vc->carto_obj = new viam::carto_facade::CartoFacade(c, ac);
+    vc->carto_obj = new viam::carto_facade::CartoFacade(pVCL, c, ac);
 
     // point to newly created viam_carto struct
     *ppVC = vc;
     return VIAM_CARTO_SUCCESS;
 };
 
-extern int viam_carto_start(const viam_carto **vc, char **errmsg) {
+extern int viam_carto_start(viam_carto *vc) {
     return VIAM_CARTO_SUCCESS;
 };
 
-extern int viam_carto_stop(const viam_carto **vc, char **errmsg) {
+extern int viam_carto_stop(viam_carto *vc) {
     return VIAM_CARTO_SUCCESS;
 };
 
-extern int viam_carto_terminate(const viam_carto **ppVC, char **errmsg) {
+extern int viam_carto_terminate(viam_carto **ppVC) {
     viam::carto_facade::CartoFacade *cf =
         static_cast<viam::carto_facade::CartoFacade *>((*ppVC)->carto_obj);
     delete cf;
@@ -99,28 +142,25 @@ extern int viam_carto_terminate(const viam_carto **ppVC, char **errmsg) {
     return VIAM_CARTO_SUCCESS;
 };
 
-extern int viam_carto_add_sensor_reading(const viam_carto **vc,
-                                         const viam_carto_sensor_reading *sr,
-                                         char **errmsg) {
+extern int viam_carto_add_sensor_reading(viam_carto *vc,
+                                         const viam_carto_sensor_reading *sr) {
     return VIAM_CARTO_SUCCESS;
 };
 
-extern int viam_carto_add_sensor_reading_destroy(viam_carto_sensor_reading *sr,
-                                                 char **errmsg) {
+extern int viam_carto_add_sensor_reading_destroy(viam_carto_sensor_reading *sr) {
     return VIAM_CARTO_SUCCESS;
 };
 
-extern int viam_carto_get_position(const viam_carto **vc,
-                                   viam_carto_get_position_response *r,
-                                   char **errmsg) {
+extern int viam_carto_get_position(viam_carto *vc,
+                                   viam_carto_get_position_response *r) {
     viam::carto_facade::CartoFacade *cf =
-        static_cast<viam::carto_facade::CartoFacade *>((*vc)->carto_obj);
+        static_cast<viam::carto_facade::CartoFacade *>((vc)->carto_obj);
     cf->GetPosition(r);
     return VIAM_CARTO_SUCCESS;
 };
 
 extern int viam_carto_get_position_response_destroy(
-    viam_carto_get_position_response *r, char **errmsg) {
+    viam_carto_get_position_response *r) {
     int return_code = VIAM_CARTO_SUCCESS;
     int rc = BSTR_OK;
     rc = bdestroy(r->component_reference);
@@ -133,23 +173,21 @@ extern int viam_carto_get_position_response_destroy(
 };
 
 extern int viam_carto_get_point_cloud_map(
-    const viam_carto **vc, viam_carto_get_point_cloud_map_response *r,
-    char **errmsg) {
+    viam_carto *vc, viam_carto_get_point_cloud_map_response *r) {
     return VIAM_CARTO_SUCCESS;
 };
 
 extern int viam_carto_get_point_cloud_map_response_destroy(
-    viam_carto_get_point_cloud_map_response *r, char **errmsg) {
+    viam_carto_get_point_cloud_map_response *r) {
     return VIAM_CARTO_SUCCESS;
 };
 
 extern int viam_carto_get_internal_state(
-    const viam_carto **vc, viam_carto_get_internal_state_response *r,
-    char **errmsg) {
+    viam_carto *vc, viam_carto_get_internal_state_response *r) {
     return VIAM_CARTO_SUCCESS;
 };
 
 extern int viam_carto_get_internal_state_response_destroy(
-    viam_carto_get_internal_state_response *r, char **errmsg) {
+    viam_carto_get_internal_state_response *r) {
     return VIAM_CARTO_SUCCESS;
 };

--- a/viam-cartographer/src/carto_facade/carto_facade.h
+++ b/viam-cartographer/src/carto_facade/carto_facade.h
@@ -22,65 +22,71 @@
 extern "C" {
 #endif
 
+// Represents library level state
+typedef struct viam_carto_lib {
+  int initialized;
+} viam_carto_lib;
+
+// Represents carto instance level state
 typedef struct viam_carto {
-    void *carto_obj;
+  void *carto_obj;
 } viam_carto;
 
 // GetPositionResponse
 // https://github.com/viamrobotics/api/blob/main/proto/viam/service/slam/v1/slam.proto#L51
 typedef struct viam_carto_get_position_response {
-    // millimeters from the origin
-    double x;
-    // millimeters from the origin
-    double y;
-    // millimeters from the origin
-    double z;
-    // z component of a vector defining axis of rotation
-    double o_x;
-    // x component of a vector defining axis of rotation
-    double o_y;
-    // y component of a vector defining axis of rotation
-    double o_z;
-    // degrees
-    double theta;
+  // millimeters from the origin
+  double x;
+  // millimeters from the origin
+  double y;
+  // millimeters from the origin
+  double z;
+  // z component of a vector defining axis of rotation
+  double o_x;
+  // x component of a vector defining axis of rotation
+  double o_y;
+  // y component of a vector defining axis of rotation
+  double o_z;
+  // degrees
+  double theta;
 
-    // Quaternian information
-    double real;
-    double imag;
-    double jmag;
-    double kmag;
+  // Quaternian information
+  double real;
+  double imag;
+  double jmag;
+  double kmag;
 
-    bstring component_reference;
-    // TODO: Need to also return quat information as the spaital math exists
-    // only on the go side
+  bstring component_reference;
+  // TODO: Need to also return quat information as the spaital math exists
+  // only on the go side
 } viam_carto_get_position_response;
 
 typedef struct viam_carto_get_point_cloud_map_response {
-    // TODO: change to void* and a size
-    bstring point_cloud_pcd;
+  // TODO: change to void* and a size
+  bstring point_cloud_pcd;
 } viam_carto_get_point_cloud_map_response;
 
 typedef struct viam_carto_get_internal_state_response {
-    // TODO: change to void* and a size
-    bstring internal_state;
+  // TODO: change to void* and a size
+  bstring internal_state;
 } viam_carto_get_internal_state_response;
 
 typedef struct viam_carto_sensor_reading {
-    bstring sensor;
-    // TODO: change to void* and a size
-    bstring sensor_reading;
-    uint64_t sensor_reading_time_unix_micro;
+  bstring sensor;
+  // TODO: change to void* and a size
+  bstring sensor_reading;
+  uint64_t sensor_reading_time_unix_micro;
 } viam_carto_sensor_reading;
 
 typedef enum viam_carto_MODE {
-    VIAM_CARTO_LOCALIZING = 0,
-    VIAM_CARTO_MAPPING = 1,
-    VIAM_CARTO_UPDATING = 2
+  VIAM_CARTO_LOCALIZING = 0,
+  VIAM_CARTO_MAPPING = 1,
+  VIAM_CARTO_UPDATING = 2
 } viam_carto_MODE;
 
 typedef enum viam_carto_LIDAR_CONFIG {
-    VIAM_CARTO_TWO_D = 0,
-    VIAM_CARTO_THREE_D = 1
+  VIAM_CARTO_TWO_D = 0,
+  VIAM_CARTO_THREE_D = 1
 } viam_carto_LIDAR_CONFIG;
 
 // return codes
@@ -89,181 +95,164 @@ typedef enum viam_carto_LIDAR_CONFIG {
 #define VIAM_CARTO_VC_INVALID 2
 #define VIAM_CARTO_OUT_OF_MEMORY 3
 #define VIAM_CARTO_DESTRUCTOR_ERROR 4
+#define VIAM_CARTO_LIB_PLATFORM_INVALID 5;
+/* #define VIAM_CARTO_LIB_ALREADY_INITIALIZED 6; */
+/* #define VIAM_CARTO_LIB_ALREADY_TERMINATED 7; */
+#define VIAM_CARTO_LIB_INVALID 8;
+#define VIAM_CARTO_LIB_NOT_INITIALIZED 9;
 
 typedef struct viam_carto_algo_config {
-    int optimize_every_n_nodes;
-    int num_range_data;
-    float missing_data_ray_length;
-    float max_range;
-    float min_range;
-    int max_submaps_to_keep;
-    int fresh_submaps_count;
-    double min_covered_area;
-    int min_added_submaps_count;
-    double occupied_space_weight;
-    double translation_weight;
-    double rotation_weight;
+  int optimize_every_n_nodes;
+  int num_range_data;
+  float missing_data_ray_length;
+  float max_range;
+  float min_range;
+  int max_submaps_to_keep;
+  int fresh_submaps_count;
+  double min_covered_area;
+  int min_added_submaps_count;
+  double occupied_space_weight;
+  double translation_weight;
+  double rotation_weight;
 } viam_carto_algo_config;
 
 typedef struct viam_carto_config {
-    bstring *sensors;
-    int sensors_len;
-    int map_rate_sec;
-    bstring data_dir;
-    bstring component_reference;
-    viam_carto_MODE mode;
-    viam_carto_LIDAR_CONFIG lidar_config;
+  bstring *sensors;
+  int sensors_len;
+  int map_rate_sec;
+  bstring data_dir;
+  bstring component_reference;
+  viam_carto_MODE mode;
+  viam_carto_LIDAR_CONFIG lidar_config;
 } viam_carto_config;
 
+extern int viam_carto_lib_init(viam_carto_lib **vcl // OUT
+);
+
+extern int viam_carto_lib_terminate(viam_carto_lib **vcl // OUT
+);
+
 // viam_carto_init/4 takes a null viam_carto pointer and a viam_carto_config, a
-// viam_carto_algo_config, and empty errmsg
+// viam_carto_algo_config
 // On error: Returns a non 0 error code and mutates
-// errmsg with a string that contains an informative error message
 //
 // On success: Returns 0 & mutates viam_carto to contain handle to
 // initialized carto object
 // TODO: Change all const viam_carto **vc to viam_carto **vc
-extern int viam_carto_init(const viam_carto **vc,            // OUT
-                           const viam_carto_config c,        //
-                           const viam_carto_algo_config ac,  //
-                           char **errmsg                     // OUT
+extern int viam_carto_init(viam_carto **vc,           // OUT
+                           viam_carto_lib *pVCL,            //
+                           const viam_carto_config c,       //
+                           const viam_carto_algo_config ac
 );
 
-// viam_carto_start/2 takes a viam_carto pointer and an empty errmsg
+// viam_carto_start/2 takes a viam_carto pointer
 //
 // On error: Returns a non 0 error code and mutates
-// errmsg with a string that contains an informative error message
 //
 // On success: Returns 0, starts cartographer
 // TODO: Change all const viam_carto **vc which don't hcange the vc pointer to
 // to viam_carto *vc
-extern int viam_carto_start(const viam_carto **vc,  // OUT
-                            char **errmsg           // OUT
-);
+extern int viam_carto_start(viam_carto *vc // OUT
+                                            );
 
-// viam_carto_stop/2 takes a viam_carto pointer and an empty errmsg
+// viam_carto_stop/2 takes a viam_carto pointer
 //
 // On error: Returns a non 0 error code and mutates
-// errmsg with a string that contains an informative error message
 //
 // On success: Returns 0, stops work begun by viam_carto_start()
-extern int viam_carto_stop(const viam_carto **vc,  // OUT
-                           char **errmsg           // OUT
+extern int viam_carto_stop(viam_carto *vc // OUT
 );
 
-// viam_carto_stop/2 takes a viam_carto pointer and an empty errmsg
+// viam_carto_stop/2 takes a viam_carto pointer
 //
 // On error: Returns a non 0 error code and mutates
-// errmsg with a string that contains an informative error message
 //
 // On success: Returns 0, frees all resources aquired by
 // viam_carto_init/4
-extern int viam_carto_terminate(const viam_carto **vc,  //
-                                char **errmsg           // OUT
+extern int viam_carto_terminate(viam_carto **vc //
 );
 
 // viam_carto_add_sensor_reading/3 takes a viam_carto pointer, a
-// viam_carto_sensor_reading and an empty errmsg
+// viam_carto_sensor_reading
 //
 // On error: Returns a non 0 error code and mutates
-// errmsg with a string that contains an informative error message.
 //
 // An expected error is VIAM_CARTO_UNABLE_TO_AQUIRE_LOCK(1)
 //
 // On success: Returns 0, adds lidar reading to cartographer's data model
-extern int viam_carto_add_sensor_reading(
-    const viam_carto **vc,                //
-    const viam_carto_sensor_reading *sr,  //
-    char **errmsg                         // OUT
+extern int viam_carto_add_sensor_reading(viam_carto *vc,               //
+                                         const viam_carto_sensor_reading *sr //
 );
 
-// viam_carto_add_sensor_reading_destroy/2 takes a viam_carto pointer and an
-// empty errmsg
+// viam_carto_add_sensor_reading_destroy/2 takes a viam_carto pointer
 //
 // On error: Returns a non 0 error code and mutates
-// errmsg with a string that contains an informative error message.
 //
 // On success: Returns 0, frees the viam_carto_sensor_reading.
-extern int viam_carto_add_sensor_reading_destroy(
-    viam_carto_sensor_reading *sr,  //
-    char **errmsg                   // OUT
+extern int
+viam_carto_add_sensor_reading_destroy(viam_carto_sensor_reading *sr //
 );
 
 // viam_carto_get_position/3 takes a viam_carto pointer, a
-// viam_carto_get_position_response pointer and an empty errmsg
+// viam_carto_get_position_response pointer
 //
 // On error: Returns a non 0 error code and mutates
-// errmsg with a string that contains an informative error message.
 //
 // On success: Returns 0, mutates viam_carto_get_position_response
 // to contain the response
-extern int viam_carto_get_position(const viam_carto **vc,                //
-                                   viam_carto_get_position_response *r,  // OUT
-                                   char **errmsg                         // OUT
+extern int viam_carto_get_position(viam_carto *vc,               //
+                                   viam_carto_get_position_response *r // OUT
 );
 
-// viam_carto_get_position_response_destroy/2 takes a viam_carto pointer and an
-// empty errmsg
+// viam_carto_get_position_response_destroy/2 takes a viam_carto pointer
 //
 // On error: Returns a non 0 error code and mutates
-// errmsg with a string that contains an informative error message.
 //
 // On success: Returns 0, frees the viam_carto_get_position_response.
-extern int viam_carto_get_position_response_destroy(
-    viam_carto_get_position_response *r,  //
-    char **errmsg                         // OUT
+extern int
+viam_carto_get_position_response_destroy(viam_carto_get_position_response *r //
 );
 
 // viam_carto_get_point_cloud_map/3 takes a viam_carto pointer, a
-// viam_carto_get_point_cloud_map_response pointer and an empty errmsg
+// viam_carto_get_point_cloud_map_response pointer
 //
 // On error: Returns a non 0 error code and mutates
-// errmsg with a string that contains an informative error message.
 //
 // On success: Returns 0, mutates viam_carto_get_point_cloud_map_response
 // to contain the response
 extern int viam_carto_get_point_cloud_map(
-    const viam_carto **vc,                       //
-    viam_carto_get_point_cloud_map_response *r,  // OUT
-    char **errmsg                                // OUT
+    viam_carto *vc,                      //
+    viam_carto_get_point_cloud_map_response *r // OUT
 );
 
 // viam_carto_get_point_cloud_map_response_destroy/2 takes a viam_carto pointer
-// and an empty errmsg
 //
 // On error: Returns a non 0 error code and mutates
-// errmsg with a string that contains an informative error message.
 //
 // On success: Returns 0, frees the viam_carto_get_point_cloud_map_response.
 extern int viam_carto_get_point_cloud_map_response_destroy(
-    viam_carto_get_point_cloud_map_response *r,  //
-    char **errmsg                                // OUT
+    viam_carto_get_point_cloud_map_response *r //
 );
 
 // viam_carto_get_internal_state/3 takes a viam_carto pointer, a
-// viam_carto_get_internal_state_response pointer and an empty errmsg
+// viam_carto_get_internal_state_response pointer
 //
 // On error: Returns a non 0 error code and mutates
-// errmsg with a string that contains an informative error message.
 //
 // On success: Returns 0, mutates viam_carto_get_internal_state_response
 // to contain the response
-extern int viam_carto_get_internal_state(
-    const viam_carto **vc,                      //
-    viam_carto_get_internal_state_response *r,  // OUT
-    char **errmsg                               // OUT
+extern int
+viam_carto_get_internal_state(viam_carto *vc,                     //
+                              viam_carto_get_internal_state_response *r // OUT
 );
 
 // viam_carto_get_internal_state_response_destroy/2 takes a viam_carto pointer
-// and an empty errmsg
 //
 // On error: Returns a non 0 error code and mutates
-// errmsg with a string that contains an informative error message.
 //
 // On success: Returns 0, frees the viam_carto_get_internal_state_response.
 extern int viam_carto_get_internal_state_response_destroy(
-    viam_carto_get_internal_state_response *r,  //
-    char **errmsg                               // OUT
+    viam_carto_get_internal_state_response *r
 );
 
 #ifdef __cplusplus
@@ -283,12 +272,12 @@ static const int checkForShutdownIntervalMicroseconds = 1e5;
 static const double resolutionMeters = 0.05;
 
 typedef struct config {
-    std::vector<std::string> sensors;
-    int map_rate_sec;
-    std::string data_dir;
-    std::string component_reference;
-    viam_carto_MODE mode;
-    viam_carto_LIDAR_CONFIG lidar_config;
+  std::vector<std::string> sensors;
+  int map_rate_sec;
+  std::string data_dir;
+  std::string component_reference;
+  viam_carto_MODE mode;
+  viam_carto_LIDAR_CONFIG lidar_config;
 } config;
 
 // function to convert viam_carto_config into  viam::carto_facade::config
@@ -298,214 +287,216 @@ config from_viam_carto_config(viam_carto_config vcc);
 // std::string errorNoSubmaps = "No submaps to paint";
 
 class CartoFacade {
-   public:
-    CartoFacade(const viam_carto_config c, const viam_carto_algo_config ac);
-    // GetPosition returns the relative pose of the robot w.r.t the "origin"
-    // of the map, which is the starting point from where the map was initially
-    // created along with a component reference.
-    int GetPosition(viam_carto_get_position_response *r);
+public:
+  CartoFacade(viam_carto_lib *pVCL, const viam_carto_config c,
+              const viam_carto_algo_config ac);
+  // GetPosition returns the relative pose of the robot w.r.t the "origin"
+  // of the map, which is the starting point from where the map was initially
+  // created along with a component reference.
+  int GetPosition(viam_carto_get_position_response *r);
 
-    // GetPointCloudMap returns a stream of the current sampled pointcloud
-    // derived from the painted map, using probability estimates in chunks with
-    // a max size of maximumGRPCByteChunkSize
-    int GetPointCloudMap(viam_carto_get_point_cloud_map_response *r);
+  // GetPointCloudMap returns a stream of the current sampled pointcloud
+  // derived from the painted map, using probability estimates in chunks with
+  // a max size of maximumGRPCByteChunkSize
+  int GetPointCloudMap(viam_carto_get_point_cloud_map_response *r);
 
-    // GetInternalState returns a stream of the current internal state of the
-    // map which is a pbstream for cartographer in chunks of size
-    // maximumGRPCByteChunkSize
-    int GetInternalState(viam_carto_get_internal_state_response *r);
+  // GetInternalState returns a stream of the current internal state of the
+  // map which is a pbstream for cartographer in chunks of size
+  // maximumGRPCByteChunkSize
+  int GetInternalState(viam_carto_get_internal_state_response *r);
 
-    int AddSensorReading(viam_carto_sensor_reading *sr);
+  int AddSensorReading(viam_carto_sensor_reading *sr);
 
-    int Start();
+  int Start();
 
-    int Stop();
+  int Stop();
 
-    // RunSLAM sets up and runs cartographer. It runs cartographer in
-    // the ActionMode mode: Either creating
-    // a new map, updating an apriori map, or localizing on an apriori map.
-    // void RunSLAM();
+  // RunSLAM sets up and runs cartographer. It runs cartographer in
+  // the ActionMode mode: Either creating
+  // a new map, updating an apriori map, or localizing on an apriori map.
+  // void RunSLAM();
 
-    // GetNextDataFile returns the next data file to be processed, determined
-    // by whether cartographer is running in offline or online mode.
-    // std::string GetNextDataFile();
+  // GetNextDataFile returns the next data file to be processed, determined
+  // by whether cartographer is running in offline or online mode.
+  // std::string GetNextDataFile();
 
-    // GetNextDataFileOffline returns the next data file in the directory.
-    // Returns an empty string if done processing files or if stop has been
-    // signaled.
-    // std::string GetNextDataFileOffline();
+  // GetNextDataFileOffline returns the next data file in the directory.
+  // Returns an empty string if done processing files or if stop has been
+  // signaled.
+  // std::string GetNextDataFileOffline();
 
-    // GetNextDataFileOnline returns the most recently generated data that has
-    // not been been processed, blocking if no new file is found. Returns an
-    // empty string if stop has been signaled.
-    // std::string GetNextDataFileOnline();
+  // GetNextDataFileOnline returns the most recently generated data that has
+  // not been been processed, blocking if no new file is found. Returns an
+  // empty string if stop has been signaled.
+  // std::string GetNextDataFileOnline();
 
-    // GetActionMode returns the slam action mode from the provided
-    // parameters.
-    // ActionMode GetActionMode();
+  // GetActionMode returns the slam action mode from the provided
+  // parameters.
+  // ActionMode GetActionMode();
 
-    // SetActionMode sets the slam action mode based on provided
-    // data and parameters.
-    // void SetActionMode();
+  // SetActionMode sets the slam action mode based on provided
+  // data and parameters.
+  // void SetActionMode();
 
-    // OverwriteMapBuilderParameters overwrites cartographer specific
-    // MapBuilder parameters.
-    // void OverwriteMapBuilderParameters();
+  // OverwriteMapBuilderParameters overwrites cartographer specific
+  // MapBuilder parameters.
+  // void OverwriteMapBuilderParameters();
 
-    // Getter functions for map_builder parameters (called: options)
-    // int GetOptimizeEveryNNodesFromMapBuilder();
-    // int GetNumRangeDataFromMapBuilder();
-    // float GetMissingDataRayLengthFromMapBuilder();
-    // float GetMaxRangeFromMapBuilder();
-    // float GetMinRangeFromMapBuilder();
-    // int GetMaxSubmapsToKeepFromMapBuilder();
-    // int GetFreshSubmapsCountFromMapBuilder();
-    // double GetMinCoveredAreaFromMapBuilder();
-    // int GetMinAddedSubmapsCountFromMapBuilder();
-    // double GetOccupiedSpaceWeightFromMapBuilder();
-    // double GetTranslationWeightFromMapBuilder();
-    // double GetRotationWeightFromMapBuilder();
+  // Getter functions for map_builder parameters (called: options)
+  // int GetOptimizeEveryNNodesFromMapBuilder();
+  // int GetNumRangeDataFromMapBuilder();
+  // float GetMissingDataRayLengthFromMapBuilder();
+  // float GetMaxRangeFromMapBuilder();
+  // float GetMinRangeFromMapBuilder();
+  // int GetMaxSubmapsToKeepFromMapBuilder();
+  // int GetFreshSubmapsCountFromMapBuilder();
+  // double GetMinCoveredAreaFromMapBuilder();
+  // int GetMinAddedSubmapsCountFromMapBuilder();
+  // double GetOccupiedSpaceWeightFromMapBuilder();
+  // double GetTranslationWeightFromMapBuilder();
+  // double GetRotationWeightFromMapBuilder();
 
-    // std::string path_to_data;
-    // std::string path_to_map;
-    // std::string configuration_directory;
-    // std::string config_params;
-    // std::string port;
-    // std::string camera_name;
-    // std::chrono::milliseconds data_rate_ms;
-    // std::chrono::seconds map_rate_sec;
-    // std::string slam_mode;
-    // std::atomic<bool> optimize_on_start{false};
-    // std::atomic<bool> use_live_data{false};
-    // bool delete_processed_data = false;
+  // std::string path_to_data;
+  // std::string path_to_map;
+  // std::string configuration_directory;
+  // std::string config_params;
+  // std::string port;
+  // std::string camera_name;
+  // std::chrono::milliseconds data_rate_ms;
+  // std::chrono::seconds map_rate_sec;
+  // std::string slam_mode;
+  // std::atomic<bool> optimize_on_start{false};
+  // std::atomic<bool> use_live_data{false};
+  // bool delete_processed_data = false;
 
-    // The size of the buffer has to be the same as
-    // dataBufferSize in RDK's builtin_test.go
-    // const int data_buffer_size = 4;
-    // int first_processed_file_index = -1;
+  // The size of the buffer has to be the same as
+  // dataBufferSize in RDK's builtin_test.go
+  // const int data_buffer_size = 4;
+  // int first_processed_file_index = -1;
 
-    // -- Cartographer specific config params:
-    // MAP_BUILDER.pose_graph
-    // int optimize_every_n_nodes = 3;
-    // TRAJECTORY_BUILDER.trajectory_builder_2d.submaps
-    // int num_range_data = 100;
-    // TRAJECTORY_BUILDER.trajectory_builder_2d
-    // float missing_data_ray_length = 25.0;
-    // float max_range = 25.0;
-    // float min_range = 0.2;
-    // TRAJECTORY_BUILDER.pure_localization_trimmer
-    // int max_submaps_to_keep = 3;  // LOCALIZATION only
-    // MAP_BUILDER.pose_graph.overlapping_submaps_trimmer_2d
-    // int fresh_submaps_count = 3;      // UPDATING only
-    // double min_covered_area = 1.0;    // UPDATING only
-    // int min_added_submaps_count = 1;  // UPDATING only
-    // MAP_BUILDER.pose_graph.constraint_builder.ceres_scan_matcher
-    // double occupied_space_weight = 20.0;
-    // double translation_weight = 10.0;
-    // double rotation_weight = 1.0;
+  // -- Cartographer specific config params:
+  // MAP_BUILDER.pose_graph
+  // int optimize_every_n_nodes = 3;
+  // TRAJECTORY_BUILDER.trajectory_builder_2d.submaps
+  // int num_range_data = 100;
+  // TRAJECTORY_BUILDER.trajectory_builder_2d
+  // float missing_data_ray_length = 25.0;
+  // float max_range = 25.0;
+  // float min_range = 0.2;
+  // TRAJECTORY_BUILDER.pure_localization_trimmer
+  // int max_submaps_to_keep = 3;  // LOCALIZATION only
+  // MAP_BUILDER.pose_graph.overlapping_submaps_trimmer_2d
+  // int fresh_submaps_count = 3;      // UPDATING only
+  // double min_covered_area = 1.0;    // UPDATING only
+  // int min_added_submaps_count = 1;  // UPDATING only
+  // MAP_BUILDER.pose_graph.constraint_builder.ceres_scan_matcher
+  // double occupied_space_weight = 20.0;
+  // double translation_weight = 10.0;
+  // double rotation_weight = 1.0;
 
-   private:
-    viam::carto_facade::config config;
-    viam_carto_algo_config algo_config;
-    // moved from namespace
-    // std::atomic<bool> b_continue_session;
-    // StartSaveMap starts the map saving process in a separate thread.
-    // void StartSaveMap();
+private:
+  viam_carto_lib *lib;
+  viam::carto_facade::config config;
+  viam_carto_algo_config algo_config;
+  // moved from namespace
+  // std::atomic<bool> b_continue_session;
+  // StartSaveMap starts the map saving process in a separate thread.
+  // void StartSaveMap();
 
-    // StopSaveMap stops the map saving process that is running in a separate
-    // thread.
-    // void StopSaveMap();
+  // StopSaveMap stops the map saving process that is running in a separate
+  // thread.
+  // void StopSaveMap();
 
-    // SaveMapWithTimestamp saves maps with a filename that includes the
-    // timestamp of the time when the map is saved.
-    // void SaveMapWithTimestamp();
+  // SaveMapWithTimestamp saves maps with a filename that includes the
+  // timestamp of the time when the map is saved.
+  // void SaveMapWithTimestamp();
 
-    // ConvertSavedMapToStream converted the saved pbstream to the passed in
-    // string and deletes the file.
-    // void ConvertSavedMapToStream(const std::string filename_with_timestamp,
-    //                              std::string *buffer);
+  // ConvertSavedMapToStream converted the saved pbstream to the passed in
+  // string and deletes the file.
+  // void ConvertSavedMapToStream(const std::string filename_with_timestamp,
+  //                              std::string *buffer);
 
-    // TryFileClose attempts to close an opened ifstream, returning an error
-    // string if it fails.
-    // std::string TryFileClose(std::ifstream &file, std::string filename);
+  // TryFileClose attempts to close an opened ifstream, returning an error
+  // string if it fails.
+  // std::string TryFileClose(std::ifstream &file, std::string filename);
 
-    // ProcessDataAndStartSavingMaps processes the data in the data directory
-    // that is newer than the provided data_cutoff_time
-    // and starts the process to save maps in parallel. In offline mode,
-    // all data in the directory is processed. In online mode, the most
-    // recently generated data is processed until a shutdown signal is
-    // received.
-    // void ProcessDataAndStartSavingMaps(double data_cutoff_time);
+  // ProcessDataAndStartSavingMaps processes the data in the data directory
+  // that is newer than the provided data_cutoff_time
+  // and starts the process to save maps in parallel. In offline mode,
+  // all data in the directory is processed. In online mode, the most
+  // recently generated data is processed until a shutdown signal is
+  // received.
+  // void ProcessDataAndStartSavingMaps(double data_cutoff_time);
 
-    // SetUpMapBuilder loads the lua file with default cartographer config
-    // parameters depending on the action mode. Setting the correct action
-    // mode has to happen before calling this function.
-    // void SetUpMapBuilder();
+  // SetUpMapBuilder loads the lua file with default cartographer config
+  // parameters depending on the action mode. Setting the correct action
+  // mode has to happen before calling this function.
+  // void SetUpMapBuilder();
 
-    // SetUpSLAM sets the correct action mode, prepares the map builder and
-    // loads the right hyperparameters based on the action mode. Needs to be
-    // called before running slam.
-    // double SetUpSLAM();
+  // SetUpSLAM sets the correct action mode, prepares the map builder and
+  // loads the right hyperparameters based on the action mode. Needs to be
+  // called before running slam.
+  // double SetUpSLAM();
 
-    // GetLatestPaintedMapSlices paints and returns the current map of
-    // Cartographer
-    // cartographer::io::PaintSubmapSlicesResult GetLatestPaintedMapSlices();
+  // GetLatestPaintedMapSlices paints and returns the current map of
+  // Cartographer
+  // cartographer::io::PaintSubmapSlicesResult GetLatestPaintedMapSlices();
 
-    // GetLatestSampledPointCloudMapString paints and returns the latest map as
-    // a pcd string with probability estimates written to the color field. The
-    // pcd is generated from PaintedMapSlices() and sampled to fit the 32 MB
-    // limit on gRPC messages. The sampled behavior may change when moving to
-    // streamed point clouds.
-    // void GetLatestSampledPointCloudMapString(std::string &pointcloud);
+  // GetLatestSampledPointCloudMapString paints and returns the latest map as
+  // a pcd string with probability estimates written to the color field. The
+  // pcd is generated from PaintedMapSlices() and sampled to fit the 32 MB
+  // limit on gRPC messages. The sampled behavior may change when moving to
+  // streamed point clouds.
+  // void GetLatestSampledPointCloudMapString(std::string &pointcloud);
 
-    // BackupLatestMap extracts and saves the latest map as a backup in
-    // the respective member variables.
-    // void BackupLatestMap();
+  // BackupLatestMap extracts and saves the latest map as a backup in
+  // the respective member variables.
+  // void BackupLatestMap();
 
-    // If using the LOCALIZING action mode, cache a copy of the map before
-    // beginning to process data. If cartographer fails to do this,
-    // terminate the program.
-    // void CacheMapInLocalizationMode();
+  // If using the LOCALIZING action mode, cache a copy of the map before
+  // beginning to process data. If cartographer fails to do this,
+  // terminate the program.
+  // void CacheMapInLocalizationMode();
 
-    // ActionMode action_mode = ActionMode::MAPPING;
+  // ActionMode action_mode = ActionMode::MAPPING;
 
-    // const std::string configuration_mapping_basename = "mapping_new_map.lua";
-    // const std::string configuration_localization_basename =
-    //     "locating_in_map.lua";
-    // const std::string configuration_update_basename = "updating_a_map.lua";
+  // const std::string configuration_mapping_basename = "mapping_new_map.lua";
+  // const std::string configuration_localization_basename =
+  //     "locating_in_map.lua";
+  // const std::string configuration_update_basename = "updating_a_map.lua";
 
-    // std::vector<std::string> file_list_offline;
-    // size_t current_file_offline = 0;
-    // std::string current_file_online;
+  // std::vector<std::string> file_list_offline;
+  // size_t current_file_offline = 0;
+  // std::string current_file_online;
 
-    // If mutexes map_builder_mutex and optimization_shared_mutex are held
-    // concurrently, then optimization_shared_mutex must be taken
-    // before map_builder_mutex. No other mutexes are expected to
-    // be held concurrently.
-    // std::shared_mutex optimization_shared_mutex;
-    // std::mutex map_builder_mutex;
-    // mapping::MapBuilder map_builder;
+  // If mutexes map_builder_mutex and optimization_shared_mutex are held
+  // concurrently, then optimization_shared_mutex must be taken
+  // before map_builder_mutex. No other mutexes are expected to
+  // be held concurrently.
+  // std::shared_mutex optimization_shared_mutex;
+  // std::mutex map_builder_mutex;
+  // mapping::MapBuilder map_builder;
 
-    // std::atomic<bool> finished_processing_offline{false};
-    // std::thread *thread_save_map_with_timestamp;
+  // std::atomic<bool> finished_processing_offline{false};
+  // std::thread *thread_save_map_with_timestamp;
 
-    // std::mutex viam_response_mutex;
-    // cartographer::transform::Rigid3d latest_global_pose =
-    //     cartographer::transform::Rigid3d();
+  // std::mutex viam_response_mutex;
+  // cartographer::transform::Rigid3d latest_global_pose =
+  //     cartographer::transform::Rigid3d();
 
-    // The latest_pointcloud_map variable is used enable GetPointCloudMap to
-    // send the most recent map out while cartographer works on creating an
-    // optimized map. It is only updated right before the optimization is
-    // started.
-    // std::string latest_pointcloud_map;
-    // ---
+  // The latest_pointcloud_map variable is used enable GetPointCloudMap to
+  // send the most recent map out while cartographer works on creating an
+  // optimized map. It is only updated right before the optimization is
+  // started.
+  // std::string latest_pointcloud_map;
+  // ---
 };
-}  // namespace carto_facade
-}  // namespace viam
+} // namespace carto_facade
+} // namespace viam
 
 #else
 typedef struct CartoFacade CartoFacade;
 #endif
 // END C++ API
 
-#endif  // CARTO_FACADE_H
+#endif // CARTO_FACADE_H

--- a/viam-cartographer/src/carto_facade/carto_facade.h
+++ b/viam-cartographer/src/carto_facade/carto_facade.h
@@ -57,8 +57,6 @@ typedef struct viam_carto_get_position_response {
     double kmag;
 
     bstring component_reference;
-    // TODO: Need to also return quat information as the spaital math exists
-    // only on the go side
 } viam_carto_get_position_response;
 
 typedef struct viam_carto_get_point_cloud_map_response {
@@ -124,19 +122,29 @@ typedef struct viam_carto_config {
     viam_carto_LIDAR_CONFIG lidar_config;
 } viam_carto_config;
 
+// viam_carto_lib_init/4 takes an empty viam_carto_lib pointer to pointer
+// On error: Returns a non 0 error code
+//
+// On success: Returns 0 & mutates viam_carto_lib to contain a handle to
+// the initialized library state.
 extern int viam_carto_lib_init(viam_carto_lib **vcl  // OUT
 );
 
+// viam_carto_lib_terminate/4 takes a valid viam_carto_lib pointer to pointer
+// On error: Returns a non 0 error code
+//
+// On success: Returns 0, frees all resources aquired by
+// viam_carto_lib_init/4
 extern int viam_carto_lib_terminate(viam_carto_lib **vcl  // OUT
 );
 
-// viam_carto_init/4 takes a null viam_carto pointer and a viam_carto_config, a
+// viam_carto_init/4 takes an empty viam_carto pointer to pointer,
+// a viam_carto_lib pointer and a viam_carto_config, and a
 // viam_carto_algo_config
-// On error: Returns a non 0 error code and mutates
+// On error: Returns a non 0 error code
 //
 // On success: Returns 0 & mutates viam_carto to contain handle to
 // initialized carto object
-// TODO: Change all const viam_carto **vc to viam_carto **vc
 extern int viam_carto_init(viam_carto **vc,            // OUT
                            viam_carto_lib *pVCL,       //
                            const viam_carto_config c,  //
@@ -144,25 +152,23 @@ extern int viam_carto_init(viam_carto **vc,            // OUT
 
 // viam_carto_start/2 takes a viam_carto pointer
 //
-// On error: Returns a non 0 error code and mutates
+// On error: Returns a non 0 error code
 //
 // On success: Returns 0, starts cartographer
-// TODO: Change all const viam_carto **vc which don't hcange the vc pointer to
-// to viam_carto *vc
 extern int viam_carto_start(viam_carto *vc  // OUT
 );
 
 // viam_carto_stop/2 takes a viam_carto pointer
 //
-// On error: Returns a non 0 error code and mutates
+// On error: Returns a non 0 error code
 //
 // On success: Returns 0, stops work begun by viam_carto_start()
 extern int viam_carto_stop(viam_carto *vc  // OUT
 );
 
-// viam_carto_stop/2 takes a viam_carto pointer
+// viam_carto_terminate/2 takes a viam_carto pointer
 //
-// On error: Returns a non 0 error code and mutates
+// On error: Returns a non 0 error code
 //
 // On success: Returns 0, frees all resources aquired by
 // viam_carto_init/4
@@ -172,7 +178,7 @@ extern int viam_carto_terminate(viam_carto **vc  //
 // viam_carto_add_sensor_reading/3 takes a viam_carto pointer, a
 // viam_carto_sensor_reading
 //
-// On error: Returns a non 0 error code and mutates
+// On error: Returns a non 0 error code
 //
 // An expected error is VIAM_CARTO_UNABLE_TO_AQUIRE_LOCK(1)
 //
@@ -183,7 +189,7 @@ extern int viam_carto_add_sensor_reading(viam_carto *vc,                      //
 
 // viam_carto_add_sensor_reading_destroy/2 takes a viam_carto pointer
 //
-// On error: Returns a non 0 error code and mutates
+// On error: Returns a non 0 error code
 //
 // On success: Returns 0, frees the viam_carto_sensor_reading.
 extern int viam_carto_add_sensor_reading_destroy(
@@ -193,7 +199,7 @@ extern int viam_carto_add_sensor_reading_destroy(
 // viam_carto_get_position/3 takes a viam_carto pointer, a
 // viam_carto_get_position_response pointer
 //
-// On error: Returns a non 0 error code and mutates
+// On error: Returns a non 0 error code
 //
 // On success: Returns 0, mutates viam_carto_get_position_response
 // to contain the response
@@ -203,7 +209,7 @@ extern int viam_carto_get_position(viam_carto *vc,                      //
 
 // viam_carto_get_position_response_destroy/2 takes a viam_carto pointer
 //
-// On error: Returns a non 0 error code and mutates
+// On error: Returns a non 0 error code
 //
 // On success: Returns 0, frees the viam_carto_get_position_response.
 extern int viam_carto_get_position_response_destroy(
@@ -213,7 +219,7 @@ extern int viam_carto_get_position_response_destroy(
 // viam_carto_get_point_cloud_map/3 takes a viam_carto pointer, a
 // viam_carto_get_point_cloud_map_response pointer
 //
-// On error: Returns a non 0 error code and mutates
+// On error: Returns a non 0 error code
 //
 // On success: Returns 0, mutates viam_carto_get_point_cloud_map_response
 // to contain the response
@@ -224,7 +230,7 @@ extern int viam_carto_get_point_cloud_map(
 
 // viam_carto_get_point_cloud_map_response_destroy/2 takes a viam_carto pointer
 //
-// On error: Returns a non 0 error code and mutates
+// On error: Returns a non 0 error code
 //
 // On success: Returns 0, frees the viam_carto_get_point_cloud_map_response.
 extern int viam_carto_get_point_cloud_map_response_destroy(
@@ -234,7 +240,7 @@ extern int viam_carto_get_point_cloud_map_response_destroy(
 // viam_carto_get_internal_state/3 takes a viam_carto pointer, a
 // viam_carto_get_internal_state_response pointer
 //
-// On error: Returns a non 0 error code and mutates
+// On error: Returns a non 0 error code
 //
 // On success: Returns 0, mutates viam_carto_get_internal_state_response
 // to contain the response
@@ -245,7 +251,7 @@ extern int viam_carto_get_internal_state(
 
 // viam_carto_get_internal_state_response_destroy/2 takes a viam_carto pointer
 //
-// On error: Returns a non 0 error code and mutates
+// On error: Returns a non 0 error code
 //
 // On success: Returns 0, frees the viam_carto_get_internal_state_response.
 extern int viam_carto_get_internal_state_response_destroy(

--- a/viam-cartographer/src/carto_facade/carto_facade.h
+++ b/viam-cartographer/src/carto_facade/carto_facade.h
@@ -95,11 +95,9 @@ typedef enum viam_carto_LIDAR_CONFIG {
 #define VIAM_CARTO_VC_INVALID 2
 #define VIAM_CARTO_OUT_OF_MEMORY 3
 #define VIAM_CARTO_DESTRUCTOR_ERROR 4
-#define VIAM_CARTO_LIB_PLATFORM_INVALID 5;
-/* #define VIAM_CARTO_LIB_ALREADY_INITIALIZED 6; */
-/* #define VIAM_CARTO_LIB_ALREADY_TERMINATED 7; */
-#define VIAM_CARTO_LIB_INVALID 8;
-#define VIAM_CARTO_LIB_NOT_INITIALIZED 9;
+#define VIAM_CARTO_LIB_PLATFORM_INVALID 5
+#define VIAM_CARTO_LIB_INVALID 6
+#define VIAM_CARTO_LIB_NOT_INITIALIZED 7
 
 typedef struct viam_carto_algo_config {
     int optimize_every_n_nodes;

--- a/viam-cartographer/src/carto_facade/carto_facade.h
+++ b/viam-cartographer/src/carto_facade/carto_facade.h
@@ -24,69 +24,69 @@ extern "C" {
 
 // Represents library level state
 typedef struct viam_carto_lib {
-  int initialized;
+    int initialized;
 } viam_carto_lib;
 
 // Represents carto instance level state
 typedef struct viam_carto {
-  void *carto_obj;
+    void *carto_obj;
 } viam_carto;
 
 // GetPositionResponse
 // https://github.com/viamrobotics/api/blob/main/proto/viam/service/slam/v1/slam.proto#L51
 typedef struct viam_carto_get_position_response {
-  // millimeters from the origin
-  double x;
-  // millimeters from the origin
-  double y;
-  // millimeters from the origin
-  double z;
-  // z component of a vector defining axis of rotation
-  double o_x;
-  // x component of a vector defining axis of rotation
-  double o_y;
-  // y component of a vector defining axis of rotation
-  double o_z;
-  // degrees
-  double theta;
+    // millimeters from the origin
+    double x;
+    // millimeters from the origin
+    double y;
+    // millimeters from the origin
+    double z;
+    // z component of a vector defining axis of rotation
+    double o_x;
+    // x component of a vector defining axis of rotation
+    double o_y;
+    // y component of a vector defining axis of rotation
+    double o_z;
+    // degrees
+    double theta;
 
-  // Quaternian information
-  double real;
-  double imag;
-  double jmag;
-  double kmag;
+    // Quaternian information
+    double real;
+    double imag;
+    double jmag;
+    double kmag;
 
-  bstring component_reference;
-  // TODO: Need to also return quat information as the spaital math exists
-  // only on the go side
+    bstring component_reference;
+    // TODO: Need to also return quat information as the spaital math exists
+    // only on the go side
 } viam_carto_get_position_response;
 
 typedef struct viam_carto_get_point_cloud_map_response {
-  // TODO: change to void* and a size
-  bstring point_cloud_pcd;
+    // TODO: change to void* and a size
+    bstring point_cloud_pcd;
 } viam_carto_get_point_cloud_map_response;
 
 typedef struct viam_carto_get_internal_state_response {
-  // TODO: change to void* and a size
-  bstring internal_state;
+    // TODO: change to void* and a size
+    bstring internal_state;
 } viam_carto_get_internal_state_response;
 
 typedef struct viam_carto_sensor_reading {
-  bstring sensor;
-  // TODO: change to void* and a size
-  bstring sensor_reading;
-  uint64_t sensor_reading_time_unix_micro;
+    bstring sensor;
+    // TODO: change to void* and a size
+    bstring sensor_reading;
+    uint64_t sensor_reading_time_unix_micro;
 } viam_carto_sensor_reading;
 
 typedef enum viam_carto_MODE {
-  VIAM_CARTO_LOCALIZING = 0,
-  VIAM_CARTO_MAPPING = 1,
-  VIAM_CARTO_UPDATING = 2
+    VIAM_CARTO_LOCALIZING = 0,
+    VIAM_CARTO_MAPPING = 1,
+    VIAM_CARTO_UPDATING = 2
 } viam_carto_MODE;
 
 typedef enum viam_carto_LIDAR_CONFIG {
-  VIAM_CARTO_TWO_D = 0,
-  VIAM_CARTO_THREE_D = 1
+    VIAM_CARTO_TWO_D = 0,
+    VIAM_CARTO_THREE_D = 1
 } viam_carto_LIDAR_CONFIG;
 
 // return codes
@@ -102,34 +102,34 @@ typedef enum viam_carto_LIDAR_CONFIG {
 #define VIAM_CARTO_LIB_NOT_INITIALIZED 9;
 
 typedef struct viam_carto_algo_config {
-  int optimize_every_n_nodes;
-  int num_range_data;
-  float missing_data_ray_length;
-  float max_range;
-  float min_range;
-  int max_submaps_to_keep;
-  int fresh_submaps_count;
-  double min_covered_area;
-  int min_added_submaps_count;
-  double occupied_space_weight;
-  double translation_weight;
-  double rotation_weight;
+    int optimize_every_n_nodes;
+    int num_range_data;
+    float missing_data_ray_length;
+    float max_range;
+    float min_range;
+    int max_submaps_to_keep;
+    int fresh_submaps_count;
+    double min_covered_area;
+    int min_added_submaps_count;
+    double occupied_space_weight;
+    double translation_weight;
+    double rotation_weight;
 } viam_carto_algo_config;
 
 typedef struct viam_carto_config {
-  bstring *sensors;
-  int sensors_len;
-  int map_rate_sec;
-  bstring data_dir;
-  bstring component_reference;
-  viam_carto_MODE mode;
-  viam_carto_LIDAR_CONFIG lidar_config;
+    bstring *sensors;
+    int sensors_len;
+    int map_rate_sec;
+    bstring data_dir;
+    bstring component_reference;
+    viam_carto_MODE mode;
+    viam_carto_LIDAR_CONFIG lidar_config;
 } viam_carto_config;
 
-extern int viam_carto_lib_init(viam_carto_lib **vcl // OUT
+extern int viam_carto_lib_init(viam_carto_lib **vcl  // OUT
 );
 
-extern int viam_carto_lib_terminate(viam_carto_lib **vcl // OUT
+extern int viam_carto_lib_terminate(viam_carto_lib **vcl  // OUT
 );
 
 // viam_carto_init/4 takes a null viam_carto pointer and a viam_carto_config, a
@@ -139,11 +139,10 @@ extern int viam_carto_lib_terminate(viam_carto_lib **vcl // OUT
 // On success: Returns 0 & mutates viam_carto to contain handle to
 // initialized carto object
 // TODO: Change all const viam_carto **vc to viam_carto **vc
-extern int viam_carto_init(viam_carto **vc,           // OUT
-                           viam_carto_lib *pVCL,            //
-                           const viam_carto_config c,       //
-                           const viam_carto_algo_config ac
-);
+extern int viam_carto_init(viam_carto **vc,            // OUT
+                           viam_carto_lib *pVCL,       //
+                           const viam_carto_config c,  //
+                           const viam_carto_algo_config ac);
 
 // viam_carto_start/2 takes a viam_carto pointer
 //
@@ -152,15 +151,15 @@ extern int viam_carto_init(viam_carto **vc,           // OUT
 // On success: Returns 0, starts cartographer
 // TODO: Change all const viam_carto **vc which don't hcange the vc pointer to
 // to viam_carto *vc
-extern int viam_carto_start(viam_carto *vc // OUT
-                                            );
+extern int viam_carto_start(viam_carto *vc  // OUT
+);
 
 // viam_carto_stop/2 takes a viam_carto pointer
 //
 // On error: Returns a non 0 error code and mutates
 //
 // On success: Returns 0, stops work begun by viam_carto_start()
-extern int viam_carto_stop(viam_carto *vc // OUT
+extern int viam_carto_stop(viam_carto *vc  // OUT
 );
 
 // viam_carto_stop/2 takes a viam_carto pointer
@@ -169,7 +168,7 @@ extern int viam_carto_stop(viam_carto *vc // OUT
 //
 // On success: Returns 0, frees all resources aquired by
 // viam_carto_init/4
-extern int viam_carto_terminate(viam_carto **vc //
+extern int viam_carto_terminate(viam_carto **vc  //
 );
 
 // viam_carto_add_sensor_reading/3 takes a viam_carto pointer, a
@@ -180,8 +179,8 @@ extern int viam_carto_terminate(viam_carto **vc //
 // An expected error is VIAM_CARTO_UNABLE_TO_AQUIRE_LOCK(1)
 //
 // On success: Returns 0, adds lidar reading to cartographer's data model
-extern int viam_carto_add_sensor_reading(viam_carto *vc,               //
-                                         const viam_carto_sensor_reading *sr //
+extern int viam_carto_add_sensor_reading(viam_carto *vc,                      //
+                                         const viam_carto_sensor_reading *sr  //
 );
 
 // viam_carto_add_sensor_reading_destroy/2 takes a viam_carto pointer
@@ -189,8 +188,8 @@ extern int viam_carto_add_sensor_reading(viam_carto *vc,               //
 // On error: Returns a non 0 error code and mutates
 //
 // On success: Returns 0, frees the viam_carto_sensor_reading.
-extern int
-viam_carto_add_sensor_reading_destroy(viam_carto_sensor_reading *sr //
+extern int viam_carto_add_sensor_reading_destroy(
+    viam_carto_sensor_reading *sr  //
 );
 
 // viam_carto_get_position/3 takes a viam_carto pointer, a
@@ -200,8 +199,8 @@ viam_carto_add_sensor_reading_destroy(viam_carto_sensor_reading *sr //
 //
 // On success: Returns 0, mutates viam_carto_get_position_response
 // to contain the response
-extern int viam_carto_get_position(viam_carto *vc,               //
-                                   viam_carto_get_position_response *r // OUT
+extern int viam_carto_get_position(viam_carto *vc,                      //
+                                   viam_carto_get_position_response *r  // OUT
 );
 
 // viam_carto_get_position_response_destroy/2 takes a viam_carto pointer
@@ -209,8 +208,8 @@ extern int viam_carto_get_position(viam_carto *vc,               //
 // On error: Returns a non 0 error code and mutates
 //
 // On success: Returns 0, frees the viam_carto_get_position_response.
-extern int
-viam_carto_get_position_response_destroy(viam_carto_get_position_response *r //
+extern int viam_carto_get_position_response_destroy(
+    viam_carto_get_position_response *r  //
 );
 
 // viam_carto_get_point_cloud_map/3 takes a viam_carto pointer, a
@@ -221,8 +220,8 @@ viam_carto_get_position_response_destroy(viam_carto_get_position_response *r //
 // On success: Returns 0, mutates viam_carto_get_point_cloud_map_response
 // to contain the response
 extern int viam_carto_get_point_cloud_map(
-    viam_carto *vc,                      //
-    viam_carto_get_point_cloud_map_response *r // OUT
+    viam_carto *vc,                             //
+    viam_carto_get_point_cloud_map_response *r  // OUT
 );
 
 // viam_carto_get_point_cloud_map_response_destroy/2 takes a viam_carto pointer
@@ -231,7 +230,7 @@ extern int viam_carto_get_point_cloud_map(
 //
 // On success: Returns 0, frees the viam_carto_get_point_cloud_map_response.
 extern int viam_carto_get_point_cloud_map_response_destroy(
-    viam_carto_get_point_cloud_map_response *r //
+    viam_carto_get_point_cloud_map_response *r  //
 );
 
 // viam_carto_get_internal_state/3 takes a viam_carto pointer, a
@@ -241,9 +240,9 @@ extern int viam_carto_get_point_cloud_map_response_destroy(
 //
 // On success: Returns 0, mutates viam_carto_get_internal_state_response
 // to contain the response
-extern int
-viam_carto_get_internal_state(viam_carto *vc,                     //
-                              viam_carto_get_internal_state_response *r // OUT
+extern int viam_carto_get_internal_state(
+    viam_carto *vc,                            //
+    viam_carto_get_internal_state_response *r  // OUT
 );
 
 // viam_carto_get_internal_state_response_destroy/2 takes a viam_carto pointer
@@ -252,8 +251,7 @@ viam_carto_get_internal_state(viam_carto *vc,                     //
 //
 // On success: Returns 0, frees the viam_carto_get_internal_state_response.
 extern int viam_carto_get_internal_state_response_destroy(
-    viam_carto_get_internal_state_response *r
-);
+    viam_carto_get_internal_state_response *r);
 
 #ifdef __cplusplus
 }
@@ -272,12 +270,12 @@ static const int checkForShutdownIntervalMicroseconds = 1e5;
 static const double resolutionMeters = 0.05;
 
 typedef struct config {
-  std::vector<std::string> sensors;
-  int map_rate_sec;
-  std::string data_dir;
-  std::string component_reference;
-  viam_carto_MODE mode;
-  viam_carto_LIDAR_CONFIG lidar_config;
+    std::vector<std::string> sensors;
+    int map_rate_sec;
+    std::string data_dir;
+    std::string component_reference;
+    viam_carto_MODE mode;
+    viam_carto_LIDAR_CONFIG lidar_config;
 } config;
 
 // function to convert viam_carto_config into  viam::carto_facade::config
@@ -287,216 +285,216 @@ config from_viam_carto_config(viam_carto_config vcc);
 // std::string errorNoSubmaps = "No submaps to paint";
 
 class CartoFacade {
-public:
-  CartoFacade(viam_carto_lib *pVCL, const viam_carto_config c,
-              const viam_carto_algo_config ac);
-  // GetPosition returns the relative pose of the robot w.r.t the "origin"
-  // of the map, which is the starting point from where the map was initially
-  // created along with a component reference.
-  int GetPosition(viam_carto_get_position_response *r);
+   public:
+    CartoFacade(viam_carto_lib *pVCL, const viam_carto_config c,
+                const viam_carto_algo_config ac);
+    // GetPosition returns the relative pose of the robot w.r.t the "origin"
+    // of the map, which is the starting point from where the map was initially
+    // created along with a component reference.
+    int GetPosition(viam_carto_get_position_response *r);
 
-  // GetPointCloudMap returns a stream of the current sampled pointcloud
-  // derived from the painted map, using probability estimates in chunks with
-  // a max size of maximumGRPCByteChunkSize
-  int GetPointCloudMap(viam_carto_get_point_cloud_map_response *r);
+    // GetPointCloudMap returns a stream of the current sampled pointcloud
+    // derived from the painted map, using probability estimates in chunks with
+    // a max size of maximumGRPCByteChunkSize
+    int GetPointCloudMap(viam_carto_get_point_cloud_map_response *r);
 
-  // GetInternalState returns a stream of the current internal state of the
-  // map which is a pbstream for cartographer in chunks of size
-  // maximumGRPCByteChunkSize
-  int GetInternalState(viam_carto_get_internal_state_response *r);
+    // GetInternalState returns a stream of the current internal state of the
+    // map which is a pbstream for cartographer in chunks of size
+    // maximumGRPCByteChunkSize
+    int GetInternalState(viam_carto_get_internal_state_response *r);
 
-  int AddSensorReading(viam_carto_sensor_reading *sr);
+    int AddSensorReading(viam_carto_sensor_reading *sr);
 
-  int Start();
+    int Start();
 
-  int Stop();
+    int Stop();
 
-  // RunSLAM sets up and runs cartographer. It runs cartographer in
-  // the ActionMode mode: Either creating
-  // a new map, updating an apriori map, or localizing on an apriori map.
-  // void RunSLAM();
+    // RunSLAM sets up and runs cartographer. It runs cartographer in
+    // the ActionMode mode: Either creating
+    // a new map, updating an apriori map, or localizing on an apriori map.
+    // void RunSLAM();
 
-  // GetNextDataFile returns the next data file to be processed, determined
-  // by whether cartographer is running in offline or online mode.
-  // std::string GetNextDataFile();
+    // GetNextDataFile returns the next data file to be processed, determined
+    // by whether cartographer is running in offline or online mode.
+    // std::string GetNextDataFile();
 
-  // GetNextDataFileOffline returns the next data file in the directory.
-  // Returns an empty string if done processing files or if stop has been
-  // signaled.
-  // std::string GetNextDataFileOffline();
+    // GetNextDataFileOffline returns the next data file in the directory.
+    // Returns an empty string if done processing files or if stop has been
+    // signaled.
+    // std::string GetNextDataFileOffline();
 
-  // GetNextDataFileOnline returns the most recently generated data that has
-  // not been been processed, blocking if no new file is found. Returns an
-  // empty string if stop has been signaled.
-  // std::string GetNextDataFileOnline();
+    // GetNextDataFileOnline returns the most recently generated data that has
+    // not been been processed, blocking if no new file is found. Returns an
+    // empty string if stop has been signaled.
+    // std::string GetNextDataFileOnline();
 
-  // GetActionMode returns the slam action mode from the provided
-  // parameters.
-  // ActionMode GetActionMode();
+    // GetActionMode returns the slam action mode from the provided
+    // parameters.
+    // ActionMode GetActionMode();
 
-  // SetActionMode sets the slam action mode based on provided
-  // data and parameters.
-  // void SetActionMode();
+    // SetActionMode sets the slam action mode based on provided
+    // data and parameters.
+    // void SetActionMode();
 
-  // OverwriteMapBuilderParameters overwrites cartographer specific
-  // MapBuilder parameters.
-  // void OverwriteMapBuilderParameters();
+    // OverwriteMapBuilderParameters overwrites cartographer specific
+    // MapBuilder parameters.
+    // void OverwriteMapBuilderParameters();
 
-  // Getter functions for map_builder parameters (called: options)
-  // int GetOptimizeEveryNNodesFromMapBuilder();
-  // int GetNumRangeDataFromMapBuilder();
-  // float GetMissingDataRayLengthFromMapBuilder();
-  // float GetMaxRangeFromMapBuilder();
-  // float GetMinRangeFromMapBuilder();
-  // int GetMaxSubmapsToKeepFromMapBuilder();
-  // int GetFreshSubmapsCountFromMapBuilder();
-  // double GetMinCoveredAreaFromMapBuilder();
-  // int GetMinAddedSubmapsCountFromMapBuilder();
-  // double GetOccupiedSpaceWeightFromMapBuilder();
-  // double GetTranslationWeightFromMapBuilder();
-  // double GetRotationWeightFromMapBuilder();
+    // Getter functions for map_builder parameters (called: options)
+    // int GetOptimizeEveryNNodesFromMapBuilder();
+    // int GetNumRangeDataFromMapBuilder();
+    // float GetMissingDataRayLengthFromMapBuilder();
+    // float GetMaxRangeFromMapBuilder();
+    // float GetMinRangeFromMapBuilder();
+    // int GetMaxSubmapsToKeepFromMapBuilder();
+    // int GetFreshSubmapsCountFromMapBuilder();
+    // double GetMinCoveredAreaFromMapBuilder();
+    // int GetMinAddedSubmapsCountFromMapBuilder();
+    // double GetOccupiedSpaceWeightFromMapBuilder();
+    // double GetTranslationWeightFromMapBuilder();
+    // double GetRotationWeightFromMapBuilder();
 
-  // std::string path_to_data;
-  // std::string path_to_map;
-  // std::string configuration_directory;
-  // std::string config_params;
-  // std::string port;
-  // std::string camera_name;
-  // std::chrono::milliseconds data_rate_ms;
-  // std::chrono::seconds map_rate_sec;
-  // std::string slam_mode;
-  // std::atomic<bool> optimize_on_start{false};
-  // std::atomic<bool> use_live_data{false};
-  // bool delete_processed_data = false;
+    // std::string path_to_data;
+    // std::string path_to_map;
+    // std::string configuration_directory;
+    // std::string config_params;
+    // std::string port;
+    // std::string camera_name;
+    // std::chrono::milliseconds data_rate_ms;
+    // std::chrono::seconds map_rate_sec;
+    // std::string slam_mode;
+    // std::atomic<bool> optimize_on_start{false};
+    // std::atomic<bool> use_live_data{false};
+    // bool delete_processed_data = false;
 
-  // The size of the buffer has to be the same as
-  // dataBufferSize in RDK's builtin_test.go
-  // const int data_buffer_size = 4;
-  // int first_processed_file_index = -1;
+    // The size of the buffer has to be the same as
+    // dataBufferSize in RDK's builtin_test.go
+    // const int data_buffer_size = 4;
+    // int first_processed_file_index = -1;
 
-  // -- Cartographer specific config params:
-  // MAP_BUILDER.pose_graph
-  // int optimize_every_n_nodes = 3;
-  // TRAJECTORY_BUILDER.trajectory_builder_2d.submaps
-  // int num_range_data = 100;
-  // TRAJECTORY_BUILDER.trajectory_builder_2d
-  // float missing_data_ray_length = 25.0;
-  // float max_range = 25.0;
-  // float min_range = 0.2;
-  // TRAJECTORY_BUILDER.pure_localization_trimmer
-  // int max_submaps_to_keep = 3;  // LOCALIZATION only
-  // MAP_BUILDER.pose_graph.overlapping_submaps_trimmer_2d
-  // int fresh_submaps_count = 3;      // UPDATING only
-  // double min_covered_area = 1.0;    // UPDATING only
-  // int min_added_submaps_count = 1;  // UPDATING only
-  // MAP_BUILDER.pose_graph.constraint_builder.ceres_scan_matcher
-  // double occupied_space_weight = 20.0;
-  // double translation_weight = 10.0;
-  // double rotation_weight = 1.0;
+    // -- Cartographer specific config params:
+    // MAP_BUILDER.pose_graph
+    // int optimize_every_n_nodes = 3;
+    // TRAJECTORY_BUILDER.trajectory_builder_2d.submaps
+    // int num_range_data = 100;
+    // TRAJECTORY_BUILDER.trajectory_builder_2d
+    // float missing_data_ray_length = 25.0;
+    // float max_range = 25.0;
+    // float min_range = 0.2;
+    // TRAJECTORY_BUILDER.pure_localization_trimmer
+    // int max_submaps_to_keep = 3;  // LOCALIZATION only
+    // MAP_BUILDER.pose_graph.overlapping_submaps_trimmer_2d
+    // int fresh_submaps_count = 3;      // UPDATING only
+    // double min_covered_area = 1.0;    // UPDATING only
+    // int min_added_submaps_count = 1;  // UPDATING only
+    // MAP_BUILDER.pose_graph.constraint_builder.ceres_scan_matcher
+    // double occupied_space_weight = 20.0;
+    // double translation_weight = 10.0;
+    // double rotation_weight = 1.0;
 
-private:
-  viam_carto_lib *lib;
-  viam::carto_facade::config config;
-  viam_carto_algo_config algo_config;
-  // moved from namespace
-  // std::atomic<bool> b_continue_session;
-  // StartSaveMap starts the map saving process in a separate thread.
-  // void StartSaveMap();
+   private:
+    viam_carto_lib *lib;
+    viam::carto_facade::config config;
+    viam_carto_algo_config algo_config;
+    // moved from namespace
+    // std::atomic<bool> b_continue_session;
+    // StartSaveMap starts the map saving process in a separate thread.
+    // void StartSaveMap();
 
-  // StopSaveMap stops the map saving process that is running in a separate
-  // thread.
-  // void StopSaveMap();
+    // StopSaveMap stops the map saving process that is running in a separate
+    // thread.
+    // void StopSaveMap();
 
-  // SaveMapWithTimestamp saves maps with a filename that includes the
-  // timestamp of the time when the map is saved.
-  // void SaveMapWithTimestamp();
+    // SaveMapWithTimestamp saves maps with a filename that includes the
+    // timestamp of the time when the map is saved.
+    // void SaveMapWithTimestamp();
 
-  // ConvertSavedMapToStream converted the saved pbstream to the passed in
-  // string and deletes the file.
-  // void ConvertSavedMapToStream(const std::string filename_with_timestamp,
-  //                              std::string *buffer);
+    // ConvertSavedMapToStream converted the saved pbstream to the passed in
+    // string and deletes the file.
+    // void ConvertSavedMapToStream(const std::string filename_with_timestamp,
+    //                              std::string *buffer);
 
-  // TryFileClose attempts to close an opened ifstream, returning an error
-  // string if it fails.
-  // std::string TryFileClose(std::ifstream &file, std::string filename);
+    // TryFileClose attempts to close an opened ifstream, returning an error
+    // string if it fails.
+    // std::string TryFileClose(std::ifstream &file, std::string filename);
 
-  // ProcessDataAndStartSavingMaps processes the data in the data directory
-  // that is newer than the provided data_cutoff_time
-  // and starts the process to save maps in parallel. In offline mode,
-  // all data in the directory is processed. In online mode, the most
-  // recently generated data is processed until a shutdown signal is
-  // received.
-  // void ProcessDataAndStartSavingMaps(double data_cutoff_time);
+    // ProcessDataAndStartSavingMaps processes the data in the data directory
+    // that is newer than the provided data_cutoff_time
+    // and starts the process to save maps in parallel. In offline mode,
+    // all data in the directory is processed. In online mode, the most
+    // recently generated data is processed until a shutdown signal is
+    // received.
+    // void ProcessDataAndStartSavingMaps(double data_cutoff_time);
 
-  // SetUpMapBuilder loads the lua file with default cartographer config
-  // parameters depending on the action mode. Setting the correct action
-  // mode has to happen before calling this function.
-  // void SetUpMapBuilder();
+    // SetUpMapBuilder loads the lua file with default cartographer config
+    // parameters depending on the action mode. Setting the correct action
+    // mode has to happen before calling this function.
+    // void SetUpMapBuilder();
 
-  // SetUpSLAM sets the correct action mode, prepares the map builder and
-  // loads the right hyperparameters based on the action mode. Needs to be
-  // called before running slam.
-  // double SetUpSLAM();
+    // SetUpSLAM sets the correct action mode, prepares the map builder and
+    // loads the right hyperparameters based on the action mode. Needs to be
+    // called before running slam.
+    // double SetUpSLAM();
 
-  // GetLatestPaintedMapSlices paints and returns the current map of
-  // Cartographer
-  // cartographer::io::PaintSubmapSlicesResult GetLatestPaintedMapSlices();
+    // GetLatestPaintedMapSlices paints and returns the current map of
+    // Cartographer
+    // cartographer::io::PaintSubmapSlicesResult GetLatestPaintedMapSlices();
 
-  // GetLatestSampledPointCloudMapString paints and returns the latest map as
-  // a pcd string with probability estimates written to the color field. The
-  // pcd is generated from PaintedMapSlices() and sampled to fit the 32 MB
-  // limit on gRPC messages. The sampled behavior may change when moving to
-  // streamed point clouds.
-  // void GetLatestSampledPointCloudMapString(std::string &pointcloud);
+    // GetLatestSampledPointCloudMapString paints and returns the latest map as
+    // a pcd string with probability estimates written to the color field. The
+    // pcd is generated from PaintedMapSlices() and sampled to fit the 32 MB
+    // limit on gRPC messages. The sampled behavior may change when moving to
+    // streamed point clouds.
+    // void GetLatestSampledPointCloudMapString(std::string &pointcloud);
 
-  // BackupLatestMap extracts and saves the latest map as a backup in
-  // the respective member variables.
-  // void BackupLatestMap();
+    // BackupLatestMap extracts and saves the latest map as a backup in
+    // the respective member variables.
+    // void BackupLatestMap();
 
-  // If using the LOCALIZING action mode, cache a copy of the map before
-  // beginning to process data. If cartographer fails to do this,
-  // terminate the program.
-  // void CacheMapInLocalizationMode();
+    // If using the LOCALIZING action mode, cache a copy of the map before
+    // beginning to process data. If cartographer fails to do this,
+    // terminate the program.
+    // void CacheMapInLocalizationMode();
 
-  // ActionMode action_mode = ActionMode::MAPPING;
+    // ActionMode action_mode = ActionMode::MAPPING;
 
-  // const std::string configuration_mapping_basename = "mapping_new_map.lua";
-  // const std::string configuration_localization_basename =
-  //     "locating_in_map.lua";
-  // const std::string configuration_update_basename = "updating_a_map.lua";
+    // const std::string configuration_mapping_basename = "mapping_new_map.lua";
+    // const std::string configuration_localization_basename =
+    //     "locating_in_map.lua";
+    // const std::string configuration_update_basename = "updating_a_map.lua";
 
-  // std::vector<std::string> file_list_offline;
-  // size_t current_file_offline = 0;
-  // std::string current_file_online;
+    // std::vector<std::string> file_list_offline;
+    // size_t current_file_offline = 0;
+    // std::string current_file_online;
 
-  // If mutexes map_builder_mutex and optimization_shared_mutex are held
-  // concurrently, then optimization_shared_mutex must be taken
-  // before map_builder_mutex. No other mutexes are expected to
-  // be held concurrently.
-  // std::shared_mutex optimization_shared_mutex;
-  // std::mutex map_builder_mutex;
-  // mapping::MapBuilder map_builder;
+    // If mutexes map_builder_mutex and optimization_shared_mutex are held
+    // concurrently, then optimization_shared_mutex must be taken
+    // before map_builder_mutex. No other mutexes are expected to
+    // be held concurrently.
+    // std::shared_mutex optimization_shared_mutex;
+    // std::mutex map_builder_mutex;
+    // mapping::MapBuilder map_builder;
 
-  // std::atomic<bool> finished_processing_offline{false};
-  // std::thread *thread_save_map_with_timestamp;
+    // std::atomic<bool> finished_processing_offline{false};
+    // std::thread *thread_save_map_with_timestamp;
 
-  // std::mutex viam_response_mutex;
-  // cartographer::transform::Rigid3d latest_global_pose =
-  //     cartographer::transform::Rigid3d();
+    // std::mutex viam_response_mutex;
+    // cartographer::transform::Rigid3d latest_global_pose =
+    //     cartographer::transform::Rigid3d();
 
-  // The latest_pointcloud_map variable is used enable GetPointCloudMap to
-  // send the most recent map out while cartographer works on creating an
-  // optimized map. It is only updated right before the optimization is
-  // started.
-  // std::string latest_pointcloud_map;
-  // ---
+    // The latest_pointcloud_map variable is used enable GetPointCloudMap to
+    // send the most recent map out while cartographer works on creating an
+    // optimized map. It is only updated right before the optimization is
+    // started.
+    // std::string latest_pointcloud_map;
+    // ---
 };
-} // namespace carto_facade
-} // namespace viam
+}  // namespace carto_facade
+}  // namespace viam
 
 #else
 typedef struct CartoFacade CartoFacade;
 #endif
 // END C++ API
 
-#endif // CARTO_FACADE_H
+#endif  // CARTO_FACADE_H

--- a/viam-cartographer/src/carto_facade/carto_facade.h
+++ b/viam-cartographer/src/carto_facade/carto_facade.h
@@ -24,7 +24,8 @@ extern "C" {
 
 // Represents library level state
 typedef struct viam_carto_lib {
-    int initialized;
+    int minloglevel;
+    int verbose;
 } viam_carto_lib;
 
 // Represents carto instance level state
@@ -127,8 +128,8 @@ typedef struct viam_carto_config {
 //
 // On success: Returns 0 & mutates viam_carto_lib to contain a handle to
 // the initialized library state.
-extern int viam_carto_lib_init(viam_carto_lib **vcl  // OUT
-);
+extern int viam_carto_lib_init(viam_carto_lib **vcl,  // OUT
+                               int minloglevel, int verbose);
 
 // viam_carto_lib_terminate/4 takes a valid viam_carto_lib pointer to pointer
 // On error: Returns a non 0 error code

--- a/viam-cartographer/src/carto_facade/carto_facade_test.cc
+++ b/viam-cartographer/src/carto_facade/carto_facade_test.cc
@@ -1,9 +1,10 @@
 #include "carto_facade.h"
-#include "glog/logging.h"
 
 #include <boost/test/unit_test.hpp>
 #include <cstring>
 #include <exception>
+
+#include "glog/logging.h"
 
 namespace viam {
 namespace carto_facade {
@@ -82,10 +83,13 @@ BOOST_AUTO_TEST_CASE(CartoFacade_init_terminate) {
     struct viam_carto_config vcc = viam_carto_config_setup();
     struct viam_carto_algo_config ac = viam_carto_algo_config_setup();
     BOOST_TEST(viam_carto_init(nullptr, lib, vcc, ac) == VIAM_CARTO_VC_INVALID);
-    BOOST_TEST(viam_carto_init(nullptr, nullptr, vcc, ac) == VIAM_CARTO_VC_INVALID);
-    BOOST_TEST(viam_carto_init(&vc, nullptr, vcc, ac) == VIAM_CARTO_LIB_INVALID);
+    BOOST_TEST(viam_carto_init(nullptr, nullptr, vcc, ac) ==
+               VIAM_CARTO_VC_INVALID);
+    BOOST_TEST(viam_carto_init(&vc, nullptr, vcc, ac) ==
+               VIAM_CARTO_LIB_INVALID);
     lib->initialized = false;
-    BOOST_TEST(viam_carto_init(&vc, lib, vcc, ac) == VIAM_CARTO_LIB_NOT_INITIALIZED);
+    BOOST_TEST(viam_carto_init(&vc, lib, vcc, ac) ==
+               VIAM_CARTO_LIB_NOT_INITIALIZED);
     lib->initialized = true;
     BOOST_TEST(viam_carto_init(&vc, lib, vcc, ac) == VIAM_CARTO_SUCCESS);
 

--- a/viam-cartographer/src/carto_facade/carto_facade_test.cc
+++ b/viam-cartographer/src/carto_facade/carto_facade_test.cc
@@ -57,38 +57,51 @@ viam_carto_algo_config viam_carto_algo_config_setup() {
 
 BOOST_AUTO_TEST_SUITE(CartoFacadeCPPAPI)
 
+BOOST_AUTO_TEST_CASE(CartoFacade_lib_init_terminate) {
+    viam_carto_lib *lib;
+    BOOST_TEST(viam_carto_lib_init(&lib) == VIAM_CARTO_SUCCESS);
+    BOOST_TEST(lib != nullptr);
+    BOOST_TEST(lib->initialized == true);
+    BOOST_TEST(viam_carto_lib_terminate(&lib) == VIAM_CARTO_SUCCESS);
+    BOOST_TEST(lib == nullptr);
+}
+
 BOOST_AUTO_TEST_CASE(CartoFacade_init_terminate) {
-    char *errmsg = nullptr;
-    const viam_carto *vc;
+    // library init
+    viam_carto_lib *lib;
+    BOOST_TEST(viam_carto_lib_init(&lib) == VIAM_CARTO_SUCCESS);
+
+    viam_carto *vc;
     struct viam_carto_config vcc = viam_carto_config_setup();
     struct viam_carto_algo_config ac = viam_carto_algo_config_setup();
-    BOOST_TEST(viam_carto_init(&vc, vcc, ac, &errmsg) == VIAM_CARTO_SUCCESS);
-    BOOST_TEST(errmsg == nullptr);
+    BOOST_TEST(viam_carto_init(&vc, lib, vcc, ac) == VIAM_CARTO_SUCCESS);
 
-    BOOST_TEST(viam_carto_terminate(&vc, &errmsg) == VIAM_CARTO_SUCCESS);
-    BOOST_TEST(errmsg == nullptr);
+    BOOST_TEST(viam_carto_terminate(&vc) == VIAM_CARTO_SUCCESS);
     viam_carto_config_teardown(vcc);
+
+    // library terminate
+    BOOST_TEST(viam_carto_lib_terminate(&lib) == VIAM_CARTO_SUCCESS);
 }
 
 BOOST_AUTO_TEST_CASE(CartoFacade_demo) {
+    // library init
+    viam_carto_lib *lib;
+    BOOST_TEST(viam_carto_lib_init(&lib) == VIAM_CARTO_SUCCESS);
+
     // Setup
-    char *errmsg = nullptr;
-    const viam_carto *vc;
+    viam_carto *vc;
     struct viam_carto_config vcc = viam_carto_config_setup();
     struct viam_carto_algo_config ac = viam_carto_algo_config_setup();
-    BOOST_TEST(viam_carto_init(&vc, vcc, ac, &errmsg) == VIAM_CARTO_SUCCESS);
-    BOOST_TEST(errmsg == nullptr);
+    BOOST_TEST(viam_carto_init(&vc, lib, vcc, ac) == VIAM_CARTO_SUCCESS);
 
     // // Start
-    BOOST_TEST(viam_carto_start(&vc, &errmsg) == VIAM_CARTO_SUCCESS);
-    BOOST_TEST(errmsg == nullptr);
+    BOOST_TEST(viam_carto_start(vc) == VIAM_CARTO_SUCCESS);
 
     // // GetPosition
     viam_carto_get_position_response pr;
     // // Test
-    BOOST_TEST(viam_carto_get_position(&vc, &pr, &errmsg) ==
+    BOOST_TEST(viam_carto_get_position(vc, &pr) ==
                VIAM_CARTO_SUCCESS);
-    BOOST_TEST(errmsg == nullptr);
 
     BOOST_TEST(pr.x == 100);
     BOOST_TEST(pr.y == 200);
@@ -106,51 +119,49 @@ BOOST_AUTO_TEST_CASE(CartoFacade_demo) {
 
     // GetPosition Teardown
     BOOST_TEST(bdestroy(cr) == BSTR_OK);
-    BOOST_TEST(viam_carto_get_position_response_destroy(&pr, &errmsg) ==
+    BOOST_TEST(viam_carto_get_position_response_destroy(&pr) ==
                VIAM_CARTO_SUCCESS);
-    BOOST_TEST(errmsg == nullptr);
 
     // AddSensorReading
     viam_carto_sensor_reading sr;
-    BOOST_TEST(viam_carto_add_sensor_reading(&vc, &sr, &errmsg) ==
+    BOOST_TEST(viam_carto_add_sensor_reading(vc, &sr) ==
                VIAM_CARTO_SUCCESS);
-    BOOST_TEST(errmsg == nullptr);
 
-    BOOST_TEST(viam_carto_add_sensor_reading_destroy(&sr, &errmsg) ==
+    BOOST_TEST(viam_carto_add_sensor_reading_destroy(&sr) ==
                VIAM_CARTO_SUCCESS);
-    BOOST_TEST(errmsg == nullptr);
 
     // GetPointCloudMap
     viam_carto_get_point_cloud_map_response mr;
-    BOOST_TEST(viam_carto_get_point_cloud_map(&vc, &mr, &errmsg) ==
+    BOOST_TEST(viam_carto_get_point_cloud_map(vc, &mr) ==
                VIAM_CARTO_SUCCESS);
-    BOOST_TEST(errmsg == nullptr);
 
-    BOOST_TEST(viam_carto_get_point_cloud_map_response_destroy(&mr, &errmsg) ==
+    BOOST_TEST(viam_carto_get_point_cloud_map_response_destroy(&mr) ==
                VIAM_CARTO_SUCCESS);
-    BOOST_TEST(errmsg == nullptr);
 
     // GetInternalState
     viam_carto_get_internal_state_response isr;
-    BOOST_TEST(viam_carto_get_internal_state(&vc, &isr, &errmsg) ==
+    BOOST_TEST(viam_carto_get_internal_state(vc, &isr) ==
                VIAM_CARTO_SUCCESS);
-    BOOST_TEST(errmsg == nullptr);
 
-    BOOST_TEST(viam_carto_get_internal_state_response_destroy(&isr, &errmsg) ==
+    BOOST_TEST(viam_carto_get_internal_state_response_destroy(&isr) ==
                VIAM_CARTO_SUCCESS);
-    BOOST_TEST(errmsg == nullptr);
 
     // Stop
-    BOOST_TEST(viam_carto_stop(&vc, &errmsg) == VIAM_CARTO_SUCCESS);
-    BOOST_TEST(errmsg == nullptr);
+    BOOST_TEST(viam_carto_stop(vc) == VIAM_CARTO_SUCCESS);
 
     // Terminate
-    BOOST_TEST(viam_carto_terminate(&vc, &errmsg) == VIAM_CARTO_SUCCESS);
-    BOOST_TEST(errmsg == nullptr);
+    BOOST_TEST(viam_carto_terminate(&vc) == VIAM_CARTO_SUCCESS);
     viam_carto_config_teardown(vcc);
+
+    // library terminate
+    BOOST_TEST(viam_carto_lib_terminate(&lib) == VIAM_CARTO_SUCCESS);
 }
 
 BOOST_AUTO_TEST_CASE(CartoFacade_config) {
+    // library init
+    viam_carto_lib *lib;
+    BOOST_TEST(viam_carto_lib_init(&lib) == VIAM_CARTO_SUCCESS);
+
     struct viam_carto_config vcc = viam_carto_config_setup();
 
     struct config c = viam::carto_facade::from_viam_carto_config(vcc);
@@ -168,6 +179,9 @@ BOOST_AUTO_TEST_CASE(CartoFacade_config) {
     BOOST_TEST(c.sensors[4] == "sensor_5");
 
     viam_carto_config_teardown(vcc);
+
+    // library terminate
+    BOOST_TEST(viam_carto_lib_terminate(&lib) == VIAM_CARTO_SUCCESS);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/viam-cartographer/src/carto_facade/carto_facade_test.cc
+++ b/viam-cartographer/src/carto_facade/carto_facade_test.cc
@@ -82,22 +82,6 @@ BOOST_AUTO_TEST_CASE(CartoFacade_lib_init_terminate) {
     BOOST_TEST(FLAGS_minloglevel == 0);
 }
 
-BOOST_AUTO_TEST_CASE(CartoFacade_init_validate) {
-    viam_carto_lib *lib;
-    BOOST_TEST(viam_carto_lib_init(&lib, 0, 0) == VIAM_CARTO_SUCCESS);
-
-    viam_carto *vc;
-    struct viam_carto_config vcc = viam_carto_config_no_sensors_setup();
-    struct viam_carto_algo_config ac = viam_carto_algo_config_setup();
-
-    BOOST_TEST(viam_carto_init(&vc, lib, vcc, ac) ==
-               VIAM_CARTO_SENSORS_LIST_EMPTY);
-
-    viam_carto_config_teardown(vcc);
-
-    BOOST_TEST(viam_carto_lib_terminate(&lib) == VIAM_CARTO_SUCCESS);
-}
-
 BOOST_AUTO_TEST_CASE(CartoFacade_init_terminate) {
     // library init
     viam_carto_lib *lib;

--- a/viam-cartographer/src/carto_facade/carto_facade_test.cc
+++ b/viam-cartographer/src/carto_facade/carto_facade_test.cc
@@ -100,8 +100,7 @@ BOOST_AUTO_TEST_CASE(CartoFacade_demo) {
     // // GetPosition
     viam_carto_get_position_response pr;
     // // Test
-    BOOST_TEST(viam_carto_get_position(vc, &pr) ==
-               VIAM_CARTO_SUCCESS);
+    BOOST_TEST(viam_carto_get_position(vc, &pr) == VIAM_CARTO_SUCCESS);
 
     BOOST_TEST(pr.x == 100);
     BOOST_TEST(pr.y == 200);
@@ -124,24 +123,21 @@ BOOST_AUTO_TEST_CASE(CartoFacade_demo) {
 
     // AddSensorReading
     viam_carto_sensor_reading sr;
-    BOOST_TEST(viam_carto_add_sensor_reading(vc, &sr) ==
-               VIAM_CARTO_SUCCESS);
+    BOOST_TEST(viam_carto_add_sensor_reading(vc, &sr) == VIAM_CARTO_SUCCESS);
 
     BOOST_TEST(viam_carto_add_sensor_reading_destroy(&sr) ==
                VIAM_CARTO_SUCCESS);
 
     // GetPointCloudMap
     viam_carto_get_point_cloud_map_response mr;
-    BOOST_TEST(viam_carto_get_point_cloud_map(vc, &mr) ==
-               VIAM_CARTO_SUCCESS);
+    BOOST_TEST(viam_carto_get_point_cloud_map(vc, &mr) == VIAM_CARTO_SUCCESS);
 
     BOOST_TEST(viam_carto_get_point_cloud_map_response_destroy(&mr) ==
                VIAM_CARTO_SUCCESS);
 
     // GetInternalState
     viam_carto_get_internal_state_response isr;
-    BOOST_TEST(viam_carto_get_internal_state(vc, &isr) ==
-               VIAM_CARTO_SUCCESS);
+    BOOST_TEST(viam_carto_get_internal_state(vc, &isr) == VIAM_CARTO_SUCCESS);
 
     BOOST_TEST(viam_carto_get_internal_state_response_destroy(&isr) ==
                VIAM_CARTO_SUCCESS);

--- a/viam-cartographer/src/carto_facade/carto_facade_test.cc
+++ b/viam-cartographer/src/carto_facade/carto_facade_test.cc
@@ -1,4 +1,5 @@
 #include "carto_facade.h"
+#include "glog/logging.h"
 
 #include <boost/test/unit_test.hpp>
 #include <cstring>
@@ -59,21 +60,33 @@ BOOST_AUTO_TEST_SUITE(CartoFacadeCPPAPI)
 
 BOOST_AUTO_TEST_CASE(CartoFacade_lib_init_terminate) {
     viam_carto_lib *lib;
+    BOOST_TEST(FLAGS_logtostderr == 0);
+    BOOST_TEST(viam_carto_lib_init(nullptr) == VIAM_CARTO_LIB_INVALID);
+    BOOST_TEST(FLAGS_logtostderr == 0);
     BOOST_TEST(viam_carto_lib_init(&lib) == VIAM_CARTO_SUCCESS);
+    BOOST_TEST(FLAGS_logtostderr == 1);
     BOOST_TEST(lib != nullptr);
     BOOST_TEST(lib->initialized == true);
     BOOST_TEST(viam_carto_lib_terminate(&lib) == VIAM_CARTO_SUCCESS);
     BOOST_TEST(lib == nullptr);
+    BOOST_TEST(FLAGS_logtostderr == 0);
 }
 
 BOOST_AUTO_TEST_CASE(CartoFacade_init_terminate) {
     // library init
     viam_carto_lib *lib;
     BOOST_TEST(viam_carto_lib_init(&lib) == VIAM_CARTO_SUCCESS);
+    BOOST_TEST(lib->initialized == true);
 
     viam_carto *vc;
     struct viam_carto_config vcc = viam_carto_config_setup();
     struct viam_carto_algo_config ac = viam_carto_algo_config_setup();
+    BOOST_TEST(viam_carto_init(nullptr, lib, vcc, ac) == VIAM_CARTO_VC_INVALID);
+    BOOST_TEST(viam_carto_init(nullptr, nullptr, vcc, ac) == VIAM_CARTO_VC_INVALID);
+    BOOST_TEST(viam_carto_init(&vc, nullptr, vcc, ac) == VIAM_CARTO_LIB_INVALID);
+    lib->initialized = false;
+    BOOST_TEST(viam_carto_init(&vc, lib, vcc, ac) == VIAM_CARTO_LIB_NOT_INITIALIZED);
+    lib->initialized = true;
     BOOST_TEST(viam_carto_init(&vc, lib, vcc, ac) == VIAM_CARTO_SUCCESS);
 
     BOOST_TEST(viam_carto_terminate(&vc) == VIAM_CARTO_SUCCESS);
@@ -92,6 +105,7 @@ BOOST_AUTO_TEST_CASE(CartoFacade_demo) {
     viam_carto *vc;
     struct viam_carto_config vcc = viam_carto_config_setup();
     struct viam_carto_algo_config ac = viam_carto_algo_config_setup();
+
     BOOST_TEST(viam_carto_init(&vc, lib, vcc, ac) == VIAM_CARTO_SUCCESS);
 
     // // Start

--- a/viam-cartographer/src/carto_facade/carto_facade_test.cc
+++ b/viam-cartographer/src/carto_facade/carto_facade_test.cc
@@ -62,22 +62,46 @@ BOOST_AUTO_TEST_SUITE(CartoFacadeCPPAPI)
 BOOST_AUTO_TEST_CASE(CartoFacade_lib_init_terminate) {
     viam_carto_lib *lib;
     BOOST_TEST(FLAGS_logtostderr == 0);
-    BOOST_TEST(viam_carto_lib_init(nullptr) == VIAM_CARTO_LIB_INVALID);
+    BOOST_TEST(viam_carto_lib_init(nullptr, 0, 0) == VIAM_CARTO_LIB_INVALID);
     BOOST_TEST(FLAGS_logtostderr == 0);
-    BOOST_TEST(viam_carto_lib_init(&lib) == VIAM_CARTO_SUCCESS);
-    BOOST_TEST(FLAGS_logtostderr == 1);
+    BOOST_TEST(FLAGS_v == 0);
+    BOOST_TEST(FLAGS_minloglevel == 0);
+    BOOST_TEST(viam_carto_lib_init(&lib, 2, 3) == VIAM_CARTO_SUCCESS);
     BOOST_TEST(lib != nullptr);
-    BOOST_TEST(lib->initialized == true);
+    BOOST_TEST(lib->minloglevel == 2);
+    BOOST_TEST(lib->verbose == 3);
+    // begin global side effects
+    BOOST_TEST(FLAGS_logtostderr == 1);
+    BOOST_TEST(FLAGS_minloglevel == 2);
+    BOOST_TEST(FLAGS_v == 3);
+    // end global side effects
     BOOST_TEST(viam_carto_lib_terminate(&lib) == VIAM_CARTO_SUCCESS);
     BOOST_TEST(lib == nullptr);
     BOOST_TEST(FLAGS_logtostderr == 0);
+    BOOST_TEST(FLAGS_v == 0);
+    BOOST_TEST(FLAGS_minloglevel == 0);
+}
+
+BOOST_AUTO_TEST_CASE(CartoFacade_init_validate) {
+    viam_carto_lib *lib;
+    BOOST_TEST(viam_carto_lib_init(&lib, 0, 0) == VIAM_CARTO_SUCCESS);
+
+    viam_carto *vc;
+    struct viam_carto_config vcc = viam_carto_config_no_sensors_setup();
+    struct viam_carto_algo_config ac = viam_carto_algo_config_setup();
+
+    BOOST_TEST(viam_carto_init(&vc, lib, vcc, ac) ==
+               VIAM_CARTO_SENSORS_LIST_EMPTY);
+
+    viam_carto_config_teardown(vcc);
+
+    BOOST_TEST(viam_carto_lib_terminate(&lib) == VIAM_CARTO_SUCCESS);
 }
 
 BOOST_AUTO_TEST_CASE(CartoFacade_init_terminate) {
     // library init
     viam_carto_lib *lib;
-    BOOST_TEST(viam_carto_lib_init(&lib) == VIAM_CARTO_SUCCESS);
-    BOOST_TEST(lib->initialized == true);
+    BOOST_TEST(viam_carto_lib_init(&lib, 0, 0) == VIAM_CARTO_SUCCESS);
 
     viam_carto *vc;
     struct viam_carto_config vcc = viam_carto_config_setup();
@@ -87,10 +111,6 @@ BOOST_AUTO_TEST_CASE(CartoFacade_init_terminate) {
                VIAM_CARTO_VC_INVALID);
     BOOST_TEST(viam_carto_init(&vc, nullptr, vcc, ac) ==
                VIAM_CARTO_LIB_INVALID);
-    lib->initialized = false;
-    BOOST_TEST(viam_carto_init(&vc, lib, vcc, ac) ==
-               VIAM_CARTO_LIB_NOT_INITIALIZED);
-    lib->initialized = true;
     BOOST_TEST(viam_carto_init(&vc, lib, vcc, ac) == VIAM_CARTO_SUCCESS);
 
     BOOST_TEST(viam_carto_terminate(&vc) == VIAM_CARTO_SUCCESS);
@@ -103,7 +123,7 @@ BOOST_AUTO_TEST_CASE(CartoFacade_init_terminate) {
 BOOST_AUTO_TEST_CASE(CartoFacade_demo) {
     // library init
     viam_carto_lib *lib;
-    BOOST_TEST(viam_carto_lib_init(&lib) == VIAM_CARTO_SUCCESS);
+    BOOST_TEST(viam_carto_lib_init(&lib, 0, 0) == VIAM_CARTO_SUCCESS);
 
     // Setup
     viam_carto *vc;
@@ -174,7 +194,7 @@ BOOST_AUTO_TEST_CASE(CartoFacade_demo) {
 BOOST_AUTO_TEST_CASE(CartoFacade_config) {
     // library init
     viam_carto_lib *lib;
-    BOOST_TEST(viam_carto_lib_init(&lib) == VIAM_CARTO_SUCCESS);
+    BOOST_TEST(viam_carto_lib_init(&lib, 0, 0) == VIAM_CARTO_SUCCESS);
 
     struct viam_carto_config vcc = viam_carto_config_setup();
 

--- a/viam-cartographer/src/main_test.cc
+++ b/viam-cartographer/src/main_test.cc
@@ -3,7 +3,7 @@
 
 #include "glog/logging.h"
 
-struct GlobalFixture {
-    void setup() { google::InitGoogleLogging("main_test"); }
-};
-BOOST_TEST_GLOBAL_FIXTURE(GlobalFixture);
+/* struct GlobalFixture { */
+/*     void setup() { google::InitGoogleLogging("main_test"); } */
+/* }; */
+/* BOOST_TEST_GLOBAL_FIXTURE(GlobalFixture); */

--- a/viam-cartographer/src/main_test.cc
+++ b/viam-cartographer/src/main_test.cc
@@ -1,9 +1,2 @@
 #define BOOST_TEST_MODULE cartographer tests
 #include <boost/test/included/unit_test.hpp>
-
-#include "glog/logging.h"
-
-/* struct GlobalFixture { */
-/*     void setup() { google::InitGoogleLogging("main_test"); } */
-/* }; */
-/* BOOST_TEST_GLOBAL_FIXTURE(GlobalFixture); */


### PR DESCRIPTION
[Ticket](https://viam.atlassian.net/browse/RSDK-3430)

1. Create viam_carto_lib_init & viam_carto_lib_terminate C APIs. init performs any global state setup which is required for the library to function & provides the caller with a struct that can in the future be provided to viam_carto_init initialization as proof that library initialization was performed prior to initialization of a given cartographer instance. terminate leaves the system in the same state it was in before init was called.
2. Convert functions to take a non const `viam_carto` pointer (or pointer to pointer)
3. Converts functions which don't change the viam_carto pointer to only take a pointer with a single level of indirection rather than 2
4. Remove `char **errmsg` from C API. I realized that b/c the carto C API is not intended to be a generic library for anyone to use cartographer, rather it is intended to only be used by cartographer-module, and b/c cartographer logs to stderr already, it doesn't make a lot of sense to have every function call take char **errmsg.