### PR TITLE
RSDK-3372 Remove Testing From Appimage Workflow

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -65,20 +65,6 @@ jobs:
       run: |
         sudo -u testbot bash -lc 'cd viam-cartographer && make install-lua-files'
 
-    - name: make test
-      run: |
-        sudo -u testbot bash -lc 'cd viam-cartographer && make test'
-
-    - name: Copy carto_grpc_server binary
-      if: matrix.platform == 'linux/amd64'
-      run: |
-        sudo cp viam-cartographer/viam-cartographer/build/carto_grpc_server /usr/local/bin/carto_grpc_server
-
-    - name: Run viam-cartographer cartographer integration tests
-      if: matrix.platform == 'linux/amd64'
-      run: |
-        sudo -u testbot bash -lc 'cd viam-cartographer && sudo go test -v -race -run TestCartographerIntegration'
-
     - name: Build AppImage (PR)
       if: contains(github.event.pull_request.labels.*.name, 'appimage') || contains(github.event.pull_request.labels.*.name, 'appimage-ignore-tests')
       run: |


### PR DESCRIPTION
This PR removes redundant testing from appimage workflows.

**Testing:** Tests have been removed and appimage creation still succeeds
https://github.com/viamrobotics/viam-cartographer/actions/runs/5247914392/jobs/9478709060?pr=134

**JIRA ticket:** https://viam.atlassian.net/browse/RSDK-3372