### PR TITLE
Hotfix run app update fix stale dep

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Main Branch Update
+name: hotfix-run-app-update-fix-stale-dep Branch Update
 
 concurrency: 
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -6,7 +6,7 @@ concurrency:
 on:
   workflow_dispatch:
   push:
-    branches: [ 'main' ]
+    branches: [ 'hotfix-run-app-update-fix-stale-dep' ]
     paths-ignore:
       - 'README.md'
     tags:
@@ -14,16 +14,16 @@ on:
       - 'v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+'
 
 # To test workflow updates you need to work in a branch directly on viamrobotics/viam-cartographer
-# and tag your working branch instead of @main in any viamrobotics/viam-cartographer "uses" below.
-# Don't forget to tag back to @main before merge.
+# and tag your working branch instead of @hotfix-run-app-update-fix-stale-dep in any viamrobotics/viam-cartographer "uses" below.
+# Don't forget to tag back to @hotfix-run-app-update-fix-stale-dep before merge.
 
 jobs:
   test:
-    uses: viamrobotics/viam-cartographer/.github/workflows/test.yml@main
+    uses: viamrobotics/viam-cartographer/.github/workflows/test.yml@hotfix-run-app-update-fix-stale-dep
 
   appimage:
     needs: test
-    uses: viamrobotics/viam-cartographer/.github/workflows/appimage.yml@main
+    uses: viamrobotics/viam-cartographer/.github/workflows/appimage.yml@hotfix-run-app-update-fix-stale-dep
     secrets:
       GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ concurrency:
 on:
   workflow_dispatch:
   push:
-    branches: [ 'main' ]
+    branches: [ 'blank-pr' ]
     paths-ignore:
       - 'README.md'
     tags:
@@ -14,16 +14,16 @@ on:
       - 'v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+'
 
 # To test workflow updates you need to work in a branch directly on viamrobotics/viam-cartographer
-# and tag your working branch instead of @main in any viamrobotics/viam-cartographer "uses" below.
-# Don't forget to tag back to @main before merge.
+# and tag your working branch instead of @blank-pr in any viamrobotics/viam-cartographer "uses" below.
+# Don't forget to tag back to @blank-pr before merge.
 
 jobs:
   test:
-    uses: viamrobotics/viam-cartographer/.github/workflows/test.yml@main
+    uses: viamrobotics/viam-cartographer/.github/workflows/test.yml@blank-pr
 
   appimage:
     needs: test
-    uses: viamrobotics/viam-cartographer/.github/workflows/appimage.yml@main
+    uses: viamrobotics/viam-cartographer/.github/workflows/appimage.yml@blank-pr
     secrets:
       GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ concurrency:
 on:
   workflow_dispatch:
   push:
-    branches: [ 'blank-pr' ]
+    branches: [ 'main' ]
     paths-ignore:
       - 'README.md'
     tags:
@@ -14,16 +14,16 @@ on:
       - 'v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+'
 
 # To test workflow updates you need to work in a branch directly on viamrobotics/viam-cartographer
-# and tag your working branch instead of @blank-pr in any viamrobotics/viam-cartographer "uses" below.
-# Don't forget to tag back to @blank-pr before merge.
+# and tag your working branch instead of @main in any viamrobotics/viam-cartographer "uses" below.
+# Don't forget to tag back to @main before merge.
 
 jobs:
   test:
-    uses: viamrobotics/viam-cartographer/.github/workflows/test.yml@blank-pr
+    uses: viamrobotics/viam-cartographer/.github/workflows/test.yml@main
 
   appimage:
     needs: test
-    uses: viamrobotics/viam-cartographer/.github/workflows/appimage.yml@blank-pr
+    uses: viamrobotics/viam-cartographer/.github/workflows/appimage.yml@main
     secrets:
       GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,6 +55,10 @@ jobs:
         ref: ${{ github.event.pull_request.head.sha }}
         submodules: recursive
 
+    - name: apt update
+      run: |
+        sudo -u testbot bash -lc 'apt update'
+
     - name: Verify no uncommitted changes from make lint
       run: |
         git init

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,7 @@ jobs:
 
     - name: apt update
       run: |
-        sudo -u testbot bash -lc 'apt update'
+        sudo -u testbot bash -lc 'sudo apt update'
 
     - name: Verify no uncommitted changes from make lint
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,7 @@ jobs:
 
     - name: apt update
       run: |
-        sudo -u testbot bash -lc 'sudo apt update'
+        sudo apt update
 
     - name: Verify no uncommitted changes from make lint
       run: |

--- a/viam-cartographer.go
+++ b/viam-cartographer.go
@@ -2,6 +2,8 @@
 // This is an Experimental package.
 package viamcartographer
 
+// blank
+
 import (
 	"bufio"
 	"context"

--- a/viam-cartographer.go
+++ b/viam-cartographer.go
@@ -2,8 +2,6 @@
 // This is an Experimental package.
 package viamcartographer
 
-// blank
-
 import (
 	"bufio"
 	"context"


### PR DESCRIPTION
This PR is not on a feature branch so that I can use this branch's main.yml definition, as otherwise tests won't pass. 

A follow up PR will be put up after this one is merged which will change main.yml back to what it was before.

Run `sudo apt update` during github workflow before any apt commands are run to ensure stale packages are not being used.

Fixes this error:
https://github.com/viamrobotics/viam-cartographer/actions/runs/5270469128/jobs/9530014193?pr=145
```
sudo apt-get install -y protobuf-compiler-grpc libgrpc-dev libgrpc++-dev || brew install grpc openssl --quiet
Reading package lists...
Building dependency tree...
Reading state information...
The following additional packages will be installed:
  libabsl20200923 libc-ares2 libgrpc++1 libgrpc10 libprotoc23
The following NEW packages will be installed:
  libabsl20200923 libc-ares2 libgrpc++-dev libgrpc++1 libgrpc-dev libgrpc10
  libprotoc23 protobuf-compiler-grpc
0 upgraded, 8 newly installed, 0 to remove and 0 not upgraded.
Need to get 4431 kB of archives.
After this operation, 33.6 MB of additional disk space will be used.
Get:1 http://deb.debian.org/debian bullseye/main arm64 libabsl20200923 arm64 0~20200923.3-2 [319 kB]
Ign:2 http://deb.debian.org/debian bullseye/main arm64 libc-ares2 arm64 1.17.1-1+deb11u1
Get:3 http://deb.debian.org/debian bullseye/main arm64 libgrpc10 arm64 1.30.2-3 [1296 kB]
Get:4 http://deb.debian.org/debian bullseye/main arm64 libgrpc++1 arm64 1.30.2-3 [363 kB]
Get:5 http://deb.debian.org/debian bullseye/main arm64 libgrpc-dev arm64 1.30.2-3 [987 kB]
Get:6 http://deb.debian.org/debian bullseye/main arm64 libgrpc++-dev arm64 1.30.2-3 [5[16](https://github.com/viamrobotics/viam-cartographer/actions/runs/5270469128/jobs/9530014193?pr=145#step:9:17) kB]
Get:7 http://deb.debian.org/debian bullseye/main arm64 libprotoc23 arm64 3.12.4-1 [703 kB]
Get:8 http://deb.debian.org/debian bullseye/main arm64 protobuf-compiler-grpc arm64 1.30.2-3 [147 kB]
Err:2 http://deb.debian.org/debian bullseye/main arm64 libc-ares2 arm64 1.[17](https://github.com/viamrobotics/viam-cartographer/actions/runs/5270469128/jobs/9530014193?pr=145#step:9:18).1-1+deb11u1
  404  Not Found [IP: [19](https://github.com/viamrobotics/viam-cartographer/actions/runs/5270469128/jobs/9530014193?pr=145#step:9:20)9.[23](https://github.com/viamrobotics/viam-cartographer/actions/runs/5270469128/jobs/9530014193?pr=145#step:9:24)2.162.132 80]
Fetched 4331 kB in 0s (11.3 MB/s)
E: Failed to fetch http://deb.debian.org/debian-security/pool/updates/main/c/c-ares/libc-ares2_1.17.1-1%2bdeb11u1_arm64.deb  404  Not Found [IP: 199.232.162.132 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
/bin/sh: 1: brew: not found
make: *** [Makefile:14: bufinstall] Error 1[27](https://github.com/viamrobotics/viam-cartographer/actions/runs/5270469128/jobs/9530014193?pr=145#step:9:28)
Error: Child_process exited with error code 2
```