### PR TITLE
[RSDK-3677] Add apt update to appimage workflow

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -41,6 +41,10 @@ jobs:
         submodules: recursive
         path: viam-cartographer
 
+    - name: apt update
+      run: |
+        sudo apt update
+
     - name: make clean
       run: |
         chown -R testbot:testbot .


### PR DESCRIPTION
Add sudo apt update step to appimage.yml to ensure cartographer builds properly when using the "appimage-ignore-tests" flag.