### PR TITLE
update-makefile-dont-buf-every-time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,10 +27,16 @@ $(TOOL_BIN)/protoc-gen-grpc-cpp:
 	mkdir -p "$(TOOL_BIN)"
 	which grpc_cpp_plugin && ln -sf `which grpc_cpp_plugin` $(TOOL_BIN)/protoc-gen-grpc-cpp
 
-buf: $(TOOL_BIN)/buf $(TOOL_BIN)/protoc-gen-grpc-cpp
+grpc/buf: $(TOOL_BIN)/buf $(TOOL_BIN)/protoc-gen-grpc-cpp
 	buf generate --template ./buf/buf.gen.yaml buf.build/viamrobotics/api
 	buf generate --template ./buf/buf.grpc.gen.yaml buf.build/viamrobotics/api
 	buf generate --template ./buf/buf.gen.yaml buf.build/googleapis/googleapis
+	# Touch this file so that we don't regenerate the buf compiled C++ files
+	# every time we build
+	@touch grpc/buf
+
+grpc/buf_clean:
+	rm -rf grpc
 
 clean:
 	rm -rf grpc bin viam-cartographer/build
@@ -89,7 +95,7 @@ else
 	$(error "Unsupported system. Only apt and brew currently supported.")
 endif
 
-build: ensure-submodule-initialized buf build-module
+build: ensure-submodule-initialized grpc/buf build-module
 	cd viam-cartographer && cmake -Bbuild -G Ninja ${EXTRA_CMAKE_FLAGS} && cmake --build build
 
 build-debug: EXTRA_CMAKE_FLAGS += -DCMAKE_BUILD_TYPE=Debug -DFORCE_DEBUG_BUILD=True


### PR DESCRIPTION
I noticed after the update to streamline CMake & the Makefile that running any make command that depends on `buf` runs `make buf` every time, which results in all the GRPC C++ classes being compiled every time, which dramatically slows down the workflow of incremental C++ builds (when doing TDD for example).

This PR makes it so that `buf` (now called `grpc/buf` will touch a file called `grpc/buf` once it succeeds which should make it so that this commend doesn't continue to get run once it succeeds once. 