### PR TITLE
[RSDK-3541] CartoFacade GetPosition

### DIFF
--- a/cartofacade/capi.go
+++ b/cartofacade/capi.go
@@ -65,11 +65,6 @@ type GetPosition struct {
 	Y float64
 	Z float64
 
-	Ox    float64
-	Oy    float64
-	Oz    float64
-	Theta float64
-
 	Real float64
 	Imag float64
 	Jmag float64
@@ -295,15 +290,10 @@ func getTestGetPositionResponse() C.viam_carto_get_position_response {
 	gpr.y = C.double(200)
 	gpr.z = C.double(300)
 
-	gpr.o_x = C.double(400)
-	gpr.o_y = C.double(500)
-	gpr.o_z = C.double(600)
-
 	gpr.imag = C.double(700)
 	gpr.jmag = C.double(800)
 	gpr.kmag = C.double(900)
 
-	gpr.theta = C.double(1000)
 	gpr.real = C.double(1100)
 
 	gpr.component_reference = goStringToBstring("C++ component reference")
@@ -382,11 +372,6 @@ func toGetPositionResponse(value C.viam_carto_get_position_response) GetPosition
 		X: float64(value.x),
 		Y: float64(value.y),
 		Z: float64(value.z),
-
-		Ox:    float64(value.o_x),
-		Oy:    float64(value.o_y),
-		Oz:    float64(value.o_z),
-		Theta: float64(value.theta),
 
 		Real: float64(value.real),
 		Imag: float64(value.imag),

--- a/cartofacade/capi.go
+++ b/cartofacade/capi.go
@@ -354,7 +354,6 @@ func getConfig(cfg CartoConfig) (C.viam_carto_config, error) {
 	vcc.sensors_len = C.int(sz)
 	vcc.map_rate_sec = C.int(cfg.MapRateSecond)
 	vcc.data_dir = goStringToBstring(cfg.DataDir)
-	vcc.component_reference = goStringToBstring(cfg.ComponentReference)
 	vcc.lidar_config = lidarCfg
 
 	return vcc, nil

--- a/cartofacade/capi_test.go
+++ b/cartofacade/capi_test.go
@@ -29,8 +29,6 @@ func TestGetConfig(t *testing.T) {
 		dataDir := bstringToGoString(vcc.data_dir)
 		test.That(t, dataDir, test.ShouldResemble, dir)
 
-		componentReference := bstringToGoString(vcc.component_reference)
-		test.That(t, componentReference, test.ShouldResemble, "component")
 		freeBstringArray(vcc.sensors, vcc.sensors_len)
 
 		test.That(t, vcc.lidar_config, test.ShouldEqual, twoD)
@@ -161,23 +159,23 @@ func TestCGoAPI(t *testing.T) {
 		holder, err := vc.getPosition()
 
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, holder.ComponentReference, test.ShouldEqual, "C++ component reference")
+		test.That(t, holder.ComponentReference, test.ShouldEqual, "mysensor")
 
-		test.That(t, holder.X, test.ShouldEqual, 100)
-		test.That(t, holder.X, test.ShouldEqual, 100)
-		test.That(t, holder.Y, test.ShouldEqual, 200)
-		test.That(t, holder.Z, test.ShouldEqual, 300)
+		test.That(t, holder.X, test.ShouldEqual, 0)
+		test.That(t, holder.X, test.ShouldEqual, 0)
+		test.That(t, holder.Y, test.ShouldEqual, 0)
+		test.That(t, holder.Z, test.ShouldEqual, 0)
 
-		test.That(t, holder.Ox, test.ShouldEqual, 400)
-		test.That(t, holder.Oy, test.ShouldEqual, 500)
-		test.That(t, holder.Oz, test.ShouldEqual, 600)
+		test.That(t, holder.Ox, test.ShouldEqual, 0)
+		test.That(t, holder.Oy, test.ShouldEqual, 0)
+		test.That(t, holder.Oz, test.ShouldEqual, 0)
 
-		test.That(t, holder.Imag, test.ShouldEqual, 700)
-		test.That(t, holder.Jmag, test.ShouldEqual, 800)
-		test.That(t, holder.Kmag, test.ShouldEqual, 900)
+		test.That(t, holder.Imag, test.ShouldEqual, 0)
+		test.That(t, holder.Jmag, test.ShouldEqual, 0)
+		test.That(t, holder.Kmag, test.ShouldEqual, 0)
 
-		test.That(t, holder.Theta, test.ShouldEqual, 1000)
-		test.That(t, holder.Real, test.ShouldEqual, 1100)
+		test.That(t, holder.Theta, test.ShouldEqual, 0)
+		test.That(t, holder.Real, test.ShouldEqual, 0)
 
 		// test getPointCloudMap
 		_, err = vc.getPointCloudMap()

--- a/cartofacade/capi_test.go
+++ b/cartofacade/capi_test.go
@@ -44,16 +44,9 @@ func TestGetPositionResponse(t *testing.T) {
 		test.That(t, holder.X, test.ShouldEqual, 100)
 		test.That(t, holder.Y, test.ShouldEqual, 200)
 		test.That(t, holder.Z, test.ShouldEqual, 300)
-
-		test.That(t, holder.Ox, test.ShouldEqual, 400)
-		test.That(t, holder.Oy, test.ShouldEqual, 500)
-		test.That(t, holder.Oz, test.ShouldEqual, 600)
-
 		test.That(t, holder.Imag, test.ShouldEqual, 700)
 		test.That(t, holder.Jmag, test.ShouldEqual, 800)
 		test.That(t, holder.Kmag, test.ShouldEqual, 900)
-
-		test.That(t, holder.Theta, test.ShouldEqual, 1000)
 		test.That(t, holder.Real, test.ShouldEqual, 1100)
 	})
 }
@@ -162,20 +155,13 @@ func TestCGoAPI(t *testing.T) {
 		test.That(t, holder.ComponentReference, test.ShouldEqual, "mysensor")
 
 		test.That(t, holder.X, test.ShouldEqual, 0)
-		test.That(t, holder.X, test.ShouldEqual, 0)
 		test.That(t, holder.Y, test.ShouldEqual, 0)
 		test.That(t, holder.Z, test.ShouldEqual, 0)
-
-		test.That(t, holder.Ox, test.ShouldEqual, 0)
-		test.That(t, holder.Oy, test.ShouldEqual, 0)
-		test.That(t, holder.Oz, test.ShouldEqual, 0)
 
 		test.That(t, holder.Imag, test.ShouldEqual, 0)
 		test.That(t, holder.Jmag, test.ShouldEqual, 0)
 		test.That(t, holder.Kmag, test.ShouldEqual, 0)
-
-		test.That(t, holder.Theta, test.ShouldEqual, 0)
-		test.That(t, holder.Real, test.ShouldEqual, 0)
+		test.That(t, holder.Real, test.ShouldEqual, 1)
 
 		// test getPointCloudMap
 		_, err = vc.getPointCloudMap()

--- a/viam-cartographer/src/carto_facade/carto_facade.cc
+++ b/viam-cartographer/src/carto_facade/carto_facade.cc
@@ -552,12 +552,6 @@ int CartoFacade::GetPosition(viam_carto_get_position_response *r) {
     r->jmag = pos_quat.y();
     r->kmag = pos_quat.z();
     r->component_reference = bstrcpy(config.component_reference);
-    // currently unset
-    r->o_x = 0;
-    r->o_y = 0;
-    r->o_z = 0;
-    r->theta = 0;
-    r->real = 0;
 
     return VIAM_CARTO_SUCCESS;
 };

--- a/viam-cartographer/src/carto_facade/carto_facade.cc
+++ b/viam-cartographer/src/carto_facade/carto_facade.cc
@@ -949,14 +949,7 @@ extern int viam_carto_get_point_cloud_map(
 
 extern int viam_carto_get_point_cloud_map_response_destroy(
     viam_carto_get_point_cloud_map_response *r) {
-    int return_code = VIAM_CARTO_SUCCESS;
-    int rc = BSTR_OK;
-    rc = bdestroy(r->point_cloud_pcd);
-    if (rc != BSTR_OK) {
-        return_code = VIAM_CARTO_DESTRUCTOR_ERROR;
-    }
-    r->point_cloud_pcd = nullptr;
-    return return_code;
+    return VIAM_CARTO_SUCCESS;
 };
 
 extern int viam_carto_get_internal_state(

--- a/viam-cartographer/src/carto_facade/carto_facade.cc
+++ b/viam-cartographer/src/carto_facade/carto_facade.cc
@@ -554,11 +554,10 @@ void CartoFacade::GetPosition(viam_carto_get_position_response *r) {
     r->component_reference = bstrcpy(config.component_reference);
 };
 
-void CartoFacade::GetPointCloudMap(viam_carto_get_point_cloud_map_response *r) {
-};
+void CartoFacade::GetPointCloudMap(
+    viam_carto_get_point_cloud_map_response *r){};
 
-void CartoFacade::GetInternalState(viam_carto_get_internal_state_response *r) {
-};
+void CartoFacade::GetInternalState(viam_carto_get_internal_state_response *r){};
 
 void CartoFacade::Start() {
     started = true;
@@ -627,9 +626,7 @@ void CartoFacade::SaveInternalStateOnInterval() {
     }
 }
 
-void CartoFacade::Stop() {
-    StopSaveInternalState();
-};
+void CartoFacade::Stop() { StopSaveInternalState(); };
 
 void CartoFacade::AddSensorReading(const viam_carto_sensor_reading *sr) {
     if (biseq(config.component_reference, sr->sensor) == false) {
@@ -822,8 +819,8 @@ extern int viam_carto_stop(viam_carto *vc) {
     }
 
     try {
-      viam::carto_facade::CartoFacade *cf =
-          static_cast<viam::carto_facade::CartoFacade *>(vc->carto_obj);
+        viam::carto_facade::CartoFacade *cf =
+            static_cast<viam::carto_facade::CartoFacade *>(vc->carto_obj);
         cf->Stop();
     } catch (int err) {
         return err;
@@ -860,8 +857,8 @@ extern int viam_carto_add_sensor_reading(viam_carto *vc,
     }
 
     try {
-      viam::carto_facade::CartoFacade *cf =
-          static_cast<viam::carto_facade::CartoFacade *>(vc->carto_obj);
+        viam::carto_facade::CartoFacade *cf =
+            static_cast<viam::carto_facade::CartoFacade *>(vc->carto_obj);
         cf->AddSensorReading(sr);
     } catch (int err) {
         return err;

--- a/viam-cartographer/src/carto_facade/carto_facade.h
+++ b/viam-cartographer/src/carto_facade/carto_facade.h
@@ -105,6 +105,8 @@ typedef enum viam_carto_LIDAR_CONFIG {
 #define VIAM_CARTO_SENSOR_NOT_IN_SENSOR_LIST 19
 #define VIAM_CARTO_SENSOR_READING_EMPTY 20
 #define VIAM_CARTO_SENSOR_READING_INVALID 21
+#define VIAM_CARTO_GET_POSITION_RESPONSE_INVALID 22
+#define VIAM_CARTO_POINTCLOUD_MAP_EMPTY 23
 
 typedef struct viam_carto_algo_config {
     bool optimize_on_start;
@@ -325,23 +327,23 @@ class CartoFacade {
     // GetPosition returns the relative pose of the robot w.r.t the "origin"
     // of the map, which is the starting point from where the map was initially
     // created along with a component reference.
-    int GetPosition(viam_carto_get_position_response *r);
+    void GetPosition(viam_carto_get_position_response *r);
 
     // GetPointCloudMap returns a stream of the current sampled pointcloud
     // derived from the painted map, using probability estimates in chunks with
     // a max size of maximumGRPCByteChunkSize
-    int GetPointCloudMap(viam_carto_get_point_cloud_map_response *r);
+    void GetPointCloudMap(viam_carto_get_point_cloud_map_response *r);
 
     // GetInternalState returns a stream of the current internal state of the
     // map which is a pbstream for cartographer in chunks of size
     // maximumGRPCByteChunkSize
-    int GetInternalState(viam_carto_get_internal_state_response *r);
+    void GetInternalState(viam_carto_get_internal_state_response *r);
 
     void AddSensorReading(const viam_carto_sensor_reading *sr);
 
-    int Start();
+    void Start();
 
-    int Stop();
+    void Stop();
 
     // non api methods
     void CacheLatestMap();

--- a/viam-cartographer/src/carto_facade/carto_facade.h
+++ b/viam-cartographer/src/carto_facade/carto_facade.h
@@ -50,14 +50,6 @@ typedef struct viam_carto_get_position_response {
     double y;
     // millimeters from the origin
     double z;
-    // z component of a vector defining axis of rotation
-    double o_x;
-    // x component of a vector defining axis of rotation
-    double o_y;
-    // y component of a vector defining axis of rotation
-    double o_z;
-    // degrees
-    double theta;
 
     // Quaternian information
     double real;

--- a/viam-cartographer/src/carto_facade/carto_facade.h
+++ b/viam-cartographer/src/carto_facade/carto_facade.h
@@ -135,7 +135,6 @@ typedef struct viam_carto_config {
     int sensors_len;
     int map_rate_sec;
     bstring data_dir;
-    bstring component_reference;
     viam_carto_LIDAR_CONFIG lidar_config;
 } viam_carto_config;
 

--- a/viam-cartographer/src/carto_facade/carto_facade.h
+++ b/viam-cartographer/src/carto_facade/carto_facade.h
@@ -282,6 +282,7 @@ extern int viam_carto_get_internal_state_response_destroy(
 #ifdef __cplusplus
 namespace viam {
 namespace carto_facade {
+std::string to_std_string(bstring b_str);
 enum class ActionMode { MAPPING, LOCALIZING, UPDATING };
 std::ostream &operator<<(std::ostream &os, const ActionMode &action_mode);
 static const int checkForShutdownIntervalMicroseconds = 1e5;
@@ -295,7 +296,7 @@ typedef struct config {
     std::vector<std::string> sensors;
     std::chrono::seconds map_rate_sec;
     std::string data_dir;
-    std::string component_reference;
+    bstring component_reference;
     viam_carto_LIDAR_CONFIG lidar_config;
 } config;
 
@@ -316,6 +317,7 @@ class CartoFacade {
    public:
     CartoFacade(viam_carto_lib *pVCL, const viam_carto_config c,
                 const viam_carto_algo_config ac);
+    ~CartoFacade();
 
     // IOInit:
     // 1. detects if the data_dir has a deprecated format & throws if it does

--- a/viam-cartographer/src/carto_facade/carto_facade_test.cc
+++ b/viam-cartographer/src/carto_facade/carto_facade_test.cc
@@ -580,13 +580,9 @@ BOOST_AUTO_TEST_CASE(CartoFacade_demo) {
 
     // unable to aquire lock
     {
-        viam_carto_sensor_reading sr;
-        // must be they first sensor in the sensor list
-        sr.sensor = bfromcstr("sensor_1");
-        std::string pcd = help::binary_pcd(points);
-        sr.sensor_reading = blk2bstr(pcd.c_str(), pcd.length());
-        BOOST_TEST(sr.sensor_reading != nullptr);
-        sr.sensor_reading_time_unix_micro = 1687900042085694;
+        viam_carto_sensor_reading sr = new_test_sensor_reading(
+            "sensor_1", ".artifact/data/viam-cartographer/mock_lidar/0.pcd",
+            1687900053773475);
         viam::carto_facade::CartoFacade *cf =
             static_cast<viam::carto_facade::CartoFacade *>(vc->carto_obj);
         std::lock_guard<std::mutex> lk(cf->map_builder_mutex);

--- a/viam-cartographer/src/carto_facade/carto_facade_test.cc
+++ b/viam-cartographer/src/carto_facade/carto_facade_test.cc
@@ -481,9 +481,12 @@ BOOST_AUTO_TEST_CASE(CartoFacade_demo) {
     BOOST_TEST(viam_carto_start(vc) == VIAM_CARTO_SUCCESS);
 
     // GetPosition
-    BOOST_TEST(viam_carto_get_position(nullptr, nullptr) == VIAM_CARTO_VC_INVALID);
-    BOOST_TEST(viam_carto_get_position(vc, nullptr) == VIAM_CARTO_GET_POSITION_RESPONSE_INVALID);
-    BOOST_TEST(viam_carto_get_position_response_destroy(nullptr) == VIAM_CARTO_GET_POSITION_RESPONSE_INVALID);
+    BOOST_TEST(viam_carto_get_position(nullptr, nullptr) ==
+               VIAM_CARTO_VC_INVALID);
+    BOOST_TEST(viam_carto_get_position(vc, nullptr) ==
+               VIAM_CARTO_GET_POSITION_RESPONSE_INVALID);
+    BOOST_TEST(viam_carto_get_position_response_destroy(nullptr) ==
+               VIAM_CARTO_GET_POSITION_RESPONSE_INVALID);
     {
         viam_carto_get_position_response pr;
         // Test get position before any data is provided

--- a/viam-cartographer/src/carto_facade/carto_facade_test.cc
+++ b/viam-cartographer/src/carto_facade/carto_facade_test.cc
@@ -488,14 +488,10 @@ BOOST_AUTO_TEST_CASE(CartoFacade_demo) {
         BOOST_TEST(pr.x == 0);
         BOOST_TEST(pr.y == 0);
         BOOST_TEST(pr.z == 0);
-        BOOST_TEST(pr.o_x == 0);
-        BOOST_TEST(pr.o_y == 0);
-        BOOST_TEST(pr.o_z == 0);
         BOOST_TEST(pr.imag == 0);
         BOOST_TEST(pr.jmag == 0);
         BOOST_TEST(pr.kmag == 0);
-        BOOST_TEST(pr.theta == 0);
-        BOOST_TEST(pr.real == 0);
+        BOOST_TEST(pr.real == 1);
         BOOST_TEST(to_std_string(pr.component_reference) == "sensor_1");
 
         BOOST_TEST(viam_carto_get_position_response_destroy(&pr) ==
@@ -601,14 +597,10 @@ BOOST_AUTO_TEST_CASE(CartoFacade_demo) {
         BOOST_TEST(pr.x == 0);
         BOOST_TEST(pr.y == 0);
         BOOST_TEST(pr.z == 0);
-        BOOST_TEST(pr.o_x == 0);
-        BOOST_TEST(pr.o_y == 0);
-        BOOST_TEST(pr.o_z == 0);
         BOOST_TEST(pr.imag == 0);
         BOOST_TEST(pr.jmag == 0);
         BOOST_TEST(pr.kmag == 0);
-        BOOST_TEST(pr.theta == 0);
-        BOOST_TEST(pr.real == 0);
+        BOOST_TEST(pr.real == 1);
         BOOST_TEST(to_std_string(pr.component_reference) == "sensor_1");
 
         BOOST_TEST(viam_carto_get_position_response_destroy(&pr) ==
@@ -644,14 +636,10 @@ BOOST_AUTO_TEST_CASE(CartoFacade_demo) {
         BOOST_TEST(pr.x == 0);
         BOOST_TEST(pr.y == 0);
         BOOST_TEST(pr.z == 0);
-        BOOST_TEST(pr.o_x == 0);
-        BOOST_TEST(pr.o_y == 0);
-        BOOST_TEST(pr.o_z == 0);
         BOOST_TEST(pr.imag == 0);
         BOOST_TEST(pr.jmag == 0);
         BOOST_TEST(pr.kmag == 0);
-        BOOST_TEST(pr.theta == 0);
-        BOOST_TEST(pr.real == 0);
+        BOOST_TEST(pr.real == 1);
         BOOST_TEST(to_std_string(pr.component_reference) == "sensor_1");
 
         BOOST_TEST(viam_carto_get_position_response_destroy(&pr) ==
@@ -678,14 +666,10 @@ BOOST_AUTO_TEST_CASE(CartoFacade_demo) {
         BOOST_TEST(pr.x == 0);
         BOOST_TEST(pr.y == 0);
         BOOST_TEST(pr.z == 0);
-        BOOST_TEST(pr.o_x == 0);
-        BOOST_TEST(pr.o_y == 0);
-        BOOST_TEST(pr.o_z == 0);
         BOOST_TEST(pr.imag == 0);
         BOOST_TEST(pr.jmag == 0);
         BOOST_TEST(pr.kmag == 0);
-        BOOST_TEST(pr.theta == 0);
-        BOOST_TEST(pr.real == 0);
+        BOOST_TEST(pr.real == 1);
         BOOST_TEST(to_std_string(pr.component_reference) == "sensor_1");
 
         BOOST_TEST(viam_carto_get_position_response_destroy(&pr) ==
@@ -713,14 +697,10 @@ BOOST_AUTO_TEST_CASE(CartoFacade_demo) {
         BOOST_TEST(pr.x == -1.4367625864016951, tt::tolerance(0.001));
         BOOST_TEST(pr.y == -1.5307342301548705, tt::tolerance(0.001));
         BOOST_TEST(pr.z == 0);
-        BOOST_TEST(pr.o_x == 0);
-        BOOST_TEST(pr.o_y == 0);
-        BOOST_TEST(pr.o_z == 0);
         BOOST_TEST(pr.imag == 0);
         BOOST_TEST(pr.jmag == 0);
         BOOST_TEST(pr.kmag == 0.01372519815822075, tt::tolerance(0.001));
-        BOOST_TEST(pr.theta == 0);
-        BOOST_TEST(pr.real == 0);
+        BOOST_TEST(pr.real == 0.9999058050314128, tt::tolerance(0.001));
         BOOST_TEST(to_std_string(pr.component_reference) == "sensor_1");
 
         BOOST_TEST(viam_carto_get_position_response_destroy(&pr) ==

--- a/viam-cartographer/src/carto_facade/carto_facade_test.cc
+++ b/viam-cartographer/src/carto_facade/carto_facade_test.cc
@@ -86,6 +86,9 @@ BOOST_AUTO_TEST_CASE(CartoFacade_lib_init_terminate) {
     viam_carto_lib *lib;
     BOOST_TEST(FLAGS_logtostderr == 0);
     BOOST_TEST(viam_carto_lib_init(nullptr, 0, 0) == VIAM_CARTO_LIB_INVALID);
+    BOOST_TEST(viam_carto_lib_terminate(nullptr) == VIAM_CARTO_LIB_INVALID);
+    viam_carto_lib *invalidlib = nullptr;
+    BOOST_TEST(viam_carto_lib_terminate(&invalidlib) == VIAM_CARTO_LIB_INVALID);
 
     BOOST_TEST(FLAGS_logtostderr == 0);
     BOOST_TEST(FLAGS_v == 0);
@@ -182,6 +185,12 @@ BOOST_AUTO_TEST_CASE(CartoFacade_init_validate) {
                VIAM_CARTO_VC_INVALID);
     BOOST_TEST(viam_carto_init(&vc, nullptr, vcc, ac) ==
                VIAM_CARTO_LIB_INVALID);
+
+    // invalid invalid terminate
+    BOOST_TEST(viam_carto_terminate(nullptr) == VIAM_CARTO_VC_INVALID);
+    viam_carto *invalidvc = nullptr;
+    BOOST_TEST(viam_carto_terminate(&invalidvc) == VIAM_CARTO_VC_INVALID);
+
     BOOST_TEST(viam_carto_init(&vc, lib, vcc, ac) == VIAM_CARTO_SUCCESS);
     BOOST_TEST(viam_carto_terminate(&vc) == VIAM_CARTO_SUCCESS);
 
@@ -468,10 +477,13 @@ BOOST_AUTO_TEST_CASE(CartoFacade_demo) {
 
     BOOST_TEST(viam_carto_init(&vc, lib, vcc, ac) == VIAM_CARTO_SUCCESS);
 
-    // // Start
+    // Start
     BOOST_TEST(viam_carto_start(vc) == VIAM_CARTO_SUCCESS);
 
-    // // GetPosition
+    // GetPosition
+    BOOST_TEST(viam_carto_get_position(nullptr, nullptr) == VIAM_CARTO_VC_INVALID);
+    BOOST_TEST(viam_carto_get_position(vc, nullptr) == VIAM_CARTO_GET_POSITION_RESPONSE_INVALID);
+    BOOST_TEST(viam_carto_get_position_response_destroy(nullptr) == VIAM_CARTO_GET_POSITION_RESPONSE_INVALID);
     {
         viam_carto_get_position_response pr;
         // Test get position before any data is provided
@@ -505,6 +517,8 @@ BOOST_AUTO_TEST_CASE(CartoFacade_demo) {
         BOOST_TEST(viam_carto_add_sensor_reading(vc, nullptr) ==
                    VIAM_CARTO_SENSOR_READING_INVALID);
     }
+    BOOST_TEST(viam_carto_add_sensor_reading_destroy(nullptr) ==
+               VIAM_CARTO_SENSOR_READING_INVALID);
 
     {
         viam_carto_sensor_reading sr;

--- a/viam-cartographer/src/carto_facade/carto_facade_test.cc
+++ b/viam-cartographer/src/carto_facade/carto_facade_test.cc
@@ -622,8 +622,6 @@ BOOST_AUTO_TEST_CASE(CartoFacade_demo) {
 
     {
         viam_carto_get_position_response pr;
-        // Test get position before any data is provided
-        // it should be all zeroed out
         BOOST_TEST(viam_carto_get_position(vc, &pr) == VIAM_CARTO_SUCCESS);
         BOOST_TEST(pr.x == 0);
         BOOST_TEST(pr.y == 0);
@@ -652,8 +650,6 @@ BOOST_AUTO_TEST_CASE(CartoFacade_demo) {
 
     {
         viam_carto_get_position_response pr;
-        // Test get position before any data is provided
-        // it should be all zeroed out
         BOOST_TEST(viam_carto_get_position(vc, &pr) == VIAM_CARTO_SUCCESS);
         BOOST_TEST(pr.x == 0);
         BOOST_TEST(pr.y == 0);
@@ -683,8 +679,6 @@ BOOST_AUTO_TEST_CASE(CartoFacade_demo) {
     // GetPosition changed from binary AddSensorReading request
     {
         viam_carto_get_position_response pr;
-        // Test get position before any data is provided
-        // it should be all zeroed out
         BOOST_TEST(viam_carto_get_position(vc, &pr) == VIAM_CARTO_SUCCESS);
         BOOST_TEST(pr.x == -1.4367625864016951, tol);
         BOOST_TEST(pr.y == -1.5307342301548705, tol);

--- a/viam-cartographer/src/carto_facade/carto_facade_test.cc
+++ b/viam-cartographer/src/carto_facade/carto_facade_test.cc
@@ -19,6 +19,7 @@ namespace tt = boost::test_tools;
 namespace fs = std::filesystem;
 namespace bfs = boost::filesystem;
 namespace help = viam::carto_facade::test_helpers;
+const auto tol = tt::tolerance(0.001);
 
 namespace viam {
 namespace carto_facade {
@@ -230,19 +231,17 @@ BOOST_AUTO_TEST_CASE(CartoFacade_init_derive_action_mode) {
         BOOST_TEST(cf1->map_builder.GetNumRangeData() == ac.num_range_data);
         BOOST_TEST(cf1->map_builder.GetMissingDataRayLength() ==
                        ac.missing_data_ray_length,
-                   tt::tolerance(0.001));
-        BOOST_TEST(cf1->map_builder.GetMaxRange() == ac.max_range,
-                   tt::tolerance(0.001));
-        BOOST_TEST(cf1->map_builder.GetMinRange() == ac.min_range,
-                   tt::tolerance(0.001));
+                   tol);
+        BOOST_TEST(cf1->map_builder.GetMaxRange() == ac.max_range, tol);
+        BOOST_TEST(cf1->map_builder.GetMinRange() == ac.min_range, tol);
         BOOST_TEST(cf1->map_builder.GetOccupiedSpaceWeight() ==
                        ac.occupied_space_weight,
-                   tt::tolerance(0.001));
+                   tol);
         BOOST_TEST(
             cf1->map_builder.GetTranslationWeight() == ac.translation_weight,
-            tt::tolerance(0.001));
+            tol);
         BOOST_TEST(cf1->map_builder.GetRotationWeight() == ac.rotation_weight,
-                   tt::tolerance(0.001));
+                   tol);
         // END TEST
         BOOST_TEST(viam_carto_terminate(&vc1) == VIAM_CARTO_SUCCESS);
         viam_carto_config_teardown(vcc_mapping);
@@ -291,25 +290,23 @@ BOOST_AUTO_TEST_CASE(CartoFacade_init_derive_action_mode) {
         BOOST_TEST(cf2->map_builder.GetNumRangeData() == ac.num_range_data);
         BOOST_TEST(cf2->map_builder.GetMissingDataRayLength() ==
                        ac.missing_data_ray_length,
-                   tt::tolerance(0.001));
-        BOOST_TEST(cf2->map_builder.GetMaxRange() == ac.max_range,
-                   tt::tolerance(0.001));
-        BOOST_TEST(cf2->map_builder.GetMinRange() == ac.min_range,
-                   tt::tolerance(0.001));
+                   tol);
+        BOOST_TEST(cf2->map_builder.GetMaxRange() == ac.max_range, tol);
+        BOOST_TEST(cf2->map_builder.GetMinRange() == ac.min_range, tol);
         BOOST_TEST(cf2->map_builder.GetFreshSubmapsCount() ==
                    ac.fresh_submaps_count);
         BOOST_TEST(cf2->map_builder.GetMinCoveredArea() == ac.min_covered_area,
-                   tt::tolerance(0.001));
+                   tol);
         BOOST_TEST(cf2->map_builder.GetMinAddedSubmapsCount() ==
                    ac.min_added_submaps_count);
         BOOST_TEST(cf2->map_builder.GetOccupiedSpaceWeight() ==
                        ac.occupied_space_weight,
-                   tt::tolerance(0.001));
+                   tol);
         BOOST_TEST(
             cf2->map_builder.GetTranslationWeight() == ac.translation_weight,
-            tt::tolerance(0.001));
+            tol);
         BOOST_TEST(cf2->map_builder.GetRotationWeight() == ac.rotation_weight,
-                   tt::tolerance(0.001));
+                   tol);
         BOOST_TEST(viam_carto_terminate(&vc2) == VIAM_CARTO_SUCCESS);
         viam_carto_config_teardown(vcc_updating);
     }
@@ -347,21 +344,19 @@ BOOST_AUTO_TEST_CASE(CartoFacade_init_derive_action_mode) {
         BOOST_TEST(cf3->map_builder.GetNumRangeData() == ac.num_range_data);
         BOOST_TEST(cf3->map_builder.GetMissingDataRayLength() ==
                        ac.missing_data_ray_length,
-                   tt::tolerance(0.001));
-        BOOST_TEST(cf3->map_builder.GetMaxRange() == ac.max_range,
-                   tt::tolerance(0.001));
-        BOOST_TEST(cf3->map_builder.GetMinRange() == ac.min_range,
-                   tt::tolerance(0.001));
+                   tol);
+        BOOST_TEST(cf3->map_builder.GetMaxRange() == ac.max_range, tol);
+        BOOST_TEST(cf3->map_builder.GetMinRange() == ac.min_range, tol);
         BOOST_TEST(cf3->map_builder.GetMaxSubmapsToKeep() ==
                    ac.max_submaps_to_keep);
         BOOST_TEST(cf3->map_builder.GetOccupiedSpaceWeight() ==
                        ac.occupied_space_weight,
-                   tt::tolerance(0.001));
+                   tol);
         BOOST_TEST(
             cf3->map_builder.GetTranslationWeight() == ac.translation_weight,
-            tt::tolerance(0.001));
+            tol);
         BOOST_TEST(cf3->map_builder.GetRotationWeight() == ac.rotation_weight,
-                   tt::tolerance(0.001));
+                   tol);
         BOOST_TEST(viam_carto_terminate(&vc4) == VIAM_CARTO_SUCCESS);
         viam_carto_config_teardown(vcc_localizing);
     }
@@ -422,19 +417,16 @@ BOOST_AUTO_TEST_CASE(CartoFacade_init_terminate) {
     BOOST_TEST((cf->algo_config.optimize_on_start) == false);
     BOOST_TEST((cf->algo_config.optimize_every_n_nodes) == 3);
     BOOST_TEST((cf->algo_config.num_range_data) == 100);
-    BOOST_TEST((cf->algo_config.missing_data_ray_length) == 25,
-               tt::tolerance(0.001));
-    BOOST_TEST((cf->algo_config.max_range) == 25, tt::tolerance(0.001));
-    BOOST_TEST((cf->algo_config.min_range) == 0.2, tt::tolerance(0.001));
+    BOOST_TEST((cf->algo_config.missing_data_ray_length) == 25, tol);
+    BOOST_TEST((cf->algo_config.max_range) == 25, tol);
+    BOOST_TEST((cf->algo_config.min_range) == 0.2, tol);
     BOOST_TEST((cf->algo_config.max_submaps_to_keep) == 3);
     BOOST_TEST((cf->algo_config.fresh_submaps_count) == 3);
-    BOOST_TEST((cf->algo_config.min_covered_area) == 1, tt::tolerance(0.001));
+    BOOST_TEST((cf->algo_config.min_covered_area) == 1, tol);
     BOOST_TEST((cf->algo_config.min_added_submaps_count) == 1);
-    BOOST_TEST((cf->algo_config.occupied_space_weight) == 20,
-               tt::tolerance(0.001));
-    BOOST_TEST((cf->algo_config.translation_weight) == 10,
-               tt::tolerance(0.001));
-    BOOST_TEST((cf->algo_config.rotation_weight) == 1, tt::tolerance(0.001));
+    BOOST_TEST((cf->algo_config.occupied_space_weight) == 20, tol);
+    BOOST_TEST((cf->algo_config.translation_weight) == 10, tol);
+    BOOST_TEST((cf->algo_config.rotation_weight) == 1, tol);
     auto path_to_internal_state = tmp_dir / fs::path("internal_state");
 
     BOOST_TEST((cf->path_to_internal_state) == path_to_internal_state.string());
@@ -694,13 +686,13 @@ BOOST_AUTO_TEST_CASE(CartoFacade_demo) {
         // Test get position before any data is provided
         // it should be all zeroed out
         BOOST_TEST(viam_carto_get_position(vc, &pr) == VIAM_CARTO_SUCCESS);
-        BOOST_TEST(pr.x == -1.4367625864016951, tt::tolerance(0.001));
-        BOOST_TEST(pr.y == -1.5307342301548705, tt::tolerance(0.001));
+        BOOST_TEST(pr.x == -1.4367625864016951, tol);
+        BOOST_TEST(pr.y == -1.5307342301548705, tol);
         BOOST_TEST(pr.z == 0);
         BOOST_TEST(pr.imag == 0);
         BOOST_TEST(pr.jmag == 0);
-        BOOST_TEST(pr.kmag == 0.01372519815822075, tt::tolerance(0.001));
-        BOOST_TEST(pr.real == 0.9999058050314128, tt::tolerance(0.001));
+        BOOST_TEST(pr.kmag == 0.01372519815822075, tol);
+        BOOST_TEST(pr.real == 0.9999058050314128, tol);
         BOOST_TEST(to_std_string(pr.component_reference) == "sensor_1");
 
         BOOST_TEST(viam_carto_get_position_response_destroy(&pr) ==

--- a/viam-cartographer/src/carto_facade/test_helpers.cc
+++ b/viam-cartographer/src/carto_facade/test_helpers.cc
@@ -7,6 +7,13 @@
 namespace viam {
 namespace carto_facade {
 namespace test_helpers {
+std::string read_file(std::string file_path) {
+    std::ifstream t(file_path);
+    std::stringstream buffer;
+    buffer << t.rdbuf();
+    return buffer.str();
+}
+
 void timed_pcd_contains(cartographer::sensor::TimedPointCloudData timed_pcd,
                         std::vector<std::vector<double>> points) {
     auto tolerance = boost::test_tools::tolerance(0.00001);

--- a/viam-cartographer/src/carto_facade/test_helpers.h
+++ b/viam-cartographer/src/carto_facade/test_helpers.h
@@ -9,6 +9,8 @@
 namespace viam {
 namespace carto_facade {
 namespace test_helpers {
+std::string read_file(std::string file_path);
+
 void timed_pcd_contains(cartographer::sensor::TimedPointCloudData timed_pcd,
                         std::vector<std::vector<double>> points);
 


### PR DESCRIPTION
[Ticket](https://viam.atlassian.net/browse/RSDK-3541)

1. Change CartoFacade::GetPosition() to return the actual pose from cartographer, which is updated when CartoFacade::AddSensorReading is called.
2. Remove unused fields from viam_carto_get_position_response (those which are needed for the GetPositionResponse protobuf type but which are filled in using the go spatial math library, which is not available to the cartographer C++ code. 
3. Remove component_reference from the `viam_carto_config` C type. This was done b/c it was previously assumed to be equal to the first element of the sensors list without adding any additional information. Removing it make sit clear that the component_reference is assumed to be the first element of the sensors list (which is the behavior of cartographer-module prior to full mod). 
4. Make it so that the CartoFacade.component_reference member is now a bstrting which is copied GetPosition responses are returned. This was done to not need to convert from bstring to std string only to then do another copy. This change also required adding a destructor to CartoFacade to clean up CartoFacade.component_reference  which is a C type that doesn't obey RAII.
5.  Add handling of nullptrs in C API
