### PR TITLE
hotfix-fix-mac-sensor-reading-test-failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,9 @@ endif
 build: ensure-submodule-initialized buf build-module
 	cd viam-cartographer && cmake -Bbuild -G Ninja ${EXTRA_CMAKE_FLAGS} && cmake --build build
 
-build-debug: EXTRA_CMAKE_FLAGS += -DCMAKE_BUILD_TYPE=Debug -DFORCE_DEBUG_BUILD=True
+build-debug: ASAN_OPTIONS="detect_leaks=1 detect_stack_use_after_return=true"
+build-debug: EXTRA_CMAKE_FLAGS += -DCMAKE_BUILD_TYPE=Debug -DFORCE_DEBUG_BUILD=True -DCMAKE_CXXFLAGS="-fno-omit-frame-pointer -fsanitize=address -fsanitize-address-use-after-scope -O1" -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address"
+
 build-debug: build
 
 build-module:

--- a/Makefile
+++ b/Makefile
@@ -98,8 +98,14 @@ endif
 build: ensure-submodule-initialized grpc/buf build-module
 	cd viam-cartographer && cmake -Bbuild -G Ninja ${EXTRA_CMAKE_FLAGS} && cmake --build build
 
+# Ideally build-asan would be added build-debug, but can't yet 
+# as these options they fail on arm64 linux. This is b/c that 
+# platform currently uses gcc as opposed to clang & gcc doesn't
+# support using asan in this way (more work would be needed to get it to work there).
+# Ticket: https://viam.atlassian.net/browse/RSDK-3538 is the ticket to 
+# add full asan support
 build-asan: EXTRA_CMAKE_FLAGS += -DCMAKE_CXXFLAGS="-fno-omit-frame-pointer -fsanitize=address -fsanitize-address-use-after-scope -O1" -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address"
-build-asan: ASAN_OPTIONS="detect_leaks=1 detect_stack_use_after_return=true"
+build-asan: export ASAN_OPTIONS="detect_leaks=1 detect_stack_use_after_return=true"
 build-asan: build-debug
 
 build-debug: EXTRA_CMAKE_FLAGS += -DCMAKE_BUILD_TYPE=Debug -DFORCE_DEBUG_BUILD=True

--- a/Makefile
+++ b/Makefile
@@ -92,8 +92,11 @@ endif
 build: ensure-submodule-initialized buf build-module
 	cd viam-cartographer && cmake -Bbuild -G Ninja ${EXTRA_CMAKE_FLAGS} && cmake --build build
 
-build-debug: EXTRA_CMAKE_FLAGS += -DCMAKE_BUILD_TYPE=Debug -DFORCE_DEBUG_BUILD=True
+build-asan: EXTRA_CMAKE_FLAGS += -DCMAKE_CXXFLAGS="-fno-omit-frame-pointer -fsanitize=address -fsanitize-address-use-after-scope -O1" -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address"
+build-asan: ASAN_OPTIONS="detect_leaks=1 detect_stack_use_after_return=true"
+build-asan: build-debug
 
+build-debug: EXTRA_CMAKE_FLAGS += -DCMAKE_BUILD_TYPE=Debug -DFORCE_DEBUG_BUILD=True
 build-debug: build
 
 build-module:

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ build: ensure-submodule-initialized grpc/buf build-module
 # Ticket: https://viam.atlassian.net/browse/RSDK-3538 is the ticket to 
 # add full asan support
 build-asan: EXTRA_CMAKE_FLAGS += -DCMAKE_CXXFLAGS="-fno-omit-frame-pointer -fsanitize=address -fsanitize-address-use-after-scope -O1" -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address"
-build-asan: export ASAN_OPTIONS="detect_leaks=1 detect_stack_use_after_return=true"
+build-asan: export ASAN_OPTIONS= detect_leaks=1 detect_stack_use_after_return=true
 build-asan: build-debug
 
 build-debug: EXTRA_CMAKE_FLAGS += -DCMAKE_BUILD_TYPE=Debug -DFORCE_DEBUG_BUILD=True

--- a/Makefile
+++ b/Makefile
@@ -92,8 +92,7 @@ endif
 build: ensure-submodule-initialized buf build-module
 	cd viam-cartographer && cmake -Bbuild -G Ninja ${EXTRA_CMAKE_FLAGS} && cmake --build build
 
-build-debug: ASAN_OPTIONS="detect_leaks=1 detect_stack_use_after_return=true"
-build-debug: EXTRA_CMAKE_FLAGS += -DCMAKE_BUILD_TYPE=Debug -DFORCE_DEBUG_BUILD=True -DCMAKE_CXXFLAGS="-fno-omit-frame-pointer -fsanitize=address -fsanitize-address-use-after-scope -O1" -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address"
+build-debug: EXTRA_CMAKE_FLAGS += -DCMAKE_BUILD_TYPE=Debug -DFORCE_DEBUG_BUILD=True
 
 build-debug: build
 

--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ endif
 build: ensure-submodule-initialized grpc/buf build-module
 	cd viam-cartographer && cmake -Bbuild -G Ninja ${EXTRA_CMAKE_FLAGS} && cmake --build build
 
-# Ideally build-asan would be added build-debug, but can't yet 
+# Ideally build-asan would be added to build-debug, but can't yet 
 # as these options they fail on arm64 linux. This is b/c that 
 # platform currently uses gcc as opposed to clang & gcc doesn't
 # support using asan in this way (more work would be needed to get it to work there).

--- a/viam-cartographer/src/carto_facade/util.cc
+++ b/viam-cartographer/src/carto_facade/util.cc
@@ -64,59 +64,60 @@ int read_pcd(std::string pcd, pcl::PCLPointCloud2 &blob) {
         LOG(ERROR) << "Failed to parse header";
         return res;
     } else if (blob.data.size() == 0) {
-        LOG(ERROR) << "Failed to parse header: header has no points";
+        LOG(ERROR) << "Failed to parse header: pcd has no points";
         return -1;
-    } else {
-        switch (data_type) {
-            // ascii
-            case 0:
-                VLOG(1) << "parsing as ascii";
-                pcd_stream.seekg(data_idx);
-                res = p.readBodyASCII(pcd_stream, blob, pcd_version);
-                break;
-            // binary
-            case 1: {
-                VLOG(1) << "parsing as binary";
-                // This block exists b/c otherwise
-                // map is counterintuitively visible
-                // to the rest of the case
-                // statement branches
-                std::size_t expected_size = data_idx + blob.data.size();
-                std::size_t size = pcd.length();
-                if (expected_size > size) {
-                    LOG(ERROR) << "Corrupted PCD file. The file is smaller "
-                                  "than expected! Expected: "
-                               << expected_size << "actual: " << size;
-                    return -1;
-                }
-                const unsigned char *map =
-                    reinterpret_cast<const unsigned char *>(pcd.c_str());
-                res = p.readBodyBinary(map, blob, pcd_version, false, data_idx);
-            } break;
-            // binary compressed
-            case 2:
-                VLOG(1) << "parsing as binary compressed";
-                LOG(ERROR) << "compressed PCDs are not currently supported";
-                res = -1;
-                break;
-            default:
-                LOG(ERROR) << "PCD classified as an unsupported data type: "
-                           << data_type;
-                res = -1;
-        }
-        if (res != 0) {
-            LOG(ERROR) << "Failed to parse PCD body";
-            return res;
-        } else {
-            double total_time = tt.toc();
-            VLOG(1) << "[viam::carto_facade::io::read_pcd] Loaded as a "
-                    << (blob.is_dense ? "dense" : "non-dense") << "blob in "
-                    << total_time << "ms with " << blob.width * blob.height
-                    << "points. Available dimensions: "
-                    << pcl::getFieldsList(blob).c_str();
-            return res;
-        }
     }
+    switch (data_type) {
+        // ascii
+        case 0:
+            VLOG(1) << "parsing as ascii";
+            pcd_stream.seekg(data_idx);
+            res = p.readBodyASCII(pcd_stream, blob, pcd_version);
+            if (res != 0) {
+                LOG(ERROR) << "Failed to parse ascii PCD body";
+                return res;
+            }
+            break;
+        // binary
+        case 1: {
+            VLOG(1) << "parsing as binary";
+            // This block exists b/c otherwise
+            // map is counterintuitively visible
+            // to the rest of the case
+            // statement branches
+            std::size_t expected_size = data_idx + blob.data.size();
+            std::size_t size = pcd.length();
+            if (expected_size > size) {
+                LOG(ERROR) << "Corrupted PCD file. The file is smaller "
+                              "than expected! Expected: "
+                           << expected_size << "actual: " << size;
+                return -1;
+            }
+            const unsigned char *map =
+                reinterpret_cast<const unsigned char *>(pcd.c_str());
+            res = p.readBodyBinary(map, blob, pcd_version, false, data_idx);
+            if (res != 0) {
+                LOG(ERROR) << "Failed to parse binary PCD body";
+                return res;
+            }
+        } break;
+        // binary compressed
+        case 2:
+            LOG(ERROR) << "compressed PCDs are not currently supported";
+            return -1;
+            break;
+        default:
+            LOG(ERROR) << "PCD classified as an unsupported data type: "
+                       << data_type;
+            return -1;
+    }
+    double total_time = tt.toc();
+    VLOG(1) << "[viam::carto_facade::io::read_pcd] Loaded as a "
+            << (blob.is_dense ? "dense" : "non-dense") << "blob in "
+            << total_time << "ms with " << blob.width * blob.height
+            << "points. Available dimensions: "
+            << pcl::getFieldsList(blob).c_str();
+    return res;
 }
 
 std::tuple<bool, cartographer::sensor::TimedPointCloudData>

--- a/viam-cartographer/src/carto_facade/util.cc
+++ b/viam-cartographer/src/carto_facade/util.cc
@@ -63,10 +63,13 @@ int read_pcd(std::string pcd, pcl::PCLPointCloud2 &blob) {
     if (res != 0) {
         LOG(ERROR) << "Failed to parse header";
         return res;
-    } else if (blob.data.size() == 0) {
+    }
+
+    if (blob.data.size() == 0) {
         LOG(ERROR) << "Failed to parse header: pcd has no points";
         return -1;
     }
+
     switch (data_type) {
         // ascii
         case 0:


### PR DESCRIPTION
Fixes a bug caused by reading invalid memory in mac due to the fact that brew installs PCL on version 1.13.1 & apt installs pcl on version 1.11.1 and there are differences in behavior between the two versions.

[1.11.1](https://github.com/PointCloudLibrary/pcl/blob/pcl-1.11.1/io/src/pcd_io.cpp#L108) readHeader reports an invalid header as an error and [1.13.1 ](https://github.com/PointCloudLibrary/pcl/blob/pcl-1.13.1/io/src/pcd_io.cpp#L108)does not. 

This resulted in our code accessing invalid memory.

This PR also adds a `make build-asan` target which we can use on platforms that support low config asan builds (like osx) during local development (which is how I was able to figure out where the problem was). Full asan support should be added as part of https://viam.atlassian.net/browse/RSDK-3538

https://viam.atlassian.net/browse/RSDK-3791 is a ticket to unify pcl library versions across platforms 

```
➜  viam-cartographer git:(main) cd cartofacade
➜  cartofacade git:(main)
➜  cartofacade git:(main) ^T
➜  cartofacade git:(main) go test -v
...
[pcl::PCDReader::readHeader] No points to read
[pcl::PCDReader::readHeader] no HEIGHT given, setting to 1 (unorganized).
fatal error: unexpected signal during runtime execution
[signal SIGSEGV: segmentation violation code=0x2 addr=0x17 pc=0x18de7f9f8]

runtime stack:
runtime.throw({0x1037a5db8?, 0x16d52e8b8?})
        /opt/homebrew/Cellar/go/1.20.5/libexec/src/runtime/panic.go:1047 +0x40 fp=0x16d52dfc0 sp=0x16d52df90 pc=0x102908600
runtime.sigpanic()
        /opt/homebrew/Cellar/go/1.20.5/libexec/src/runtime/signal_unix.go:825 +0x244 fp=0x16d52e000 sp=0x16d52dfc0 pc=0x1029203d4

goroutine 52 [syscall]:
runtime.cgocall(0x1032526c8, 0x1400002bb08)
        /opt/homebrew/Cellar/go/1.20.5/libexec/src/runtime/cgocall.go:157 +0x54 fp=0x1400002bad0 sp=0x1400002ba90 pc=0x1028d5cb4
github.com/viamrobotics/viam-cartographer/cartofacade._Cfunc_viam_carto_add_sensor_reading(0x600002c94f20, 0x1400000e810)
        _cgo_gotypes.go:336 +0x38 fp=0x1400002bb00 sp=0x1400002bad0 pc=0x10324e0c8
github.com/viamrobotics/viam-cartographer/cartofacade.(*Carto).AddSensorReading.func1(0x1037729c6?, 0x8?)
        /Users/nicksanford/viam-cartographer/cartofacade/cgo_api.go:182 +0x80 fp=0x1400002bb40 sp=0x1400002bb00 pc=0x10324f550
github.com/viamrobotics/viam-cartographer/cartofacade.(*Carto).AddSensorReading(0x103c27630?, {0x1037729c6, 0x8}, {0x140000486c0, 0x6, 0x6}, {0x1?, 0x1?, 0x1047cca60?})
        /Users/nicksanford/viam-cartographer/cartofacade/cgo_api.go:182 +0xc8 fp=0x1400002bbc0 sp=0x1400002bb40 pc=0x10324f3b8
github.com/viamrobotics/viam-cartographer/cartofacade.TestCGoAPI.func1(0x0?)
        /Users/nicksanford/viam-cartographer/cartofacade/cgo_api_test.go:164 +0x7b8 fp=0x1400002bf60 sp=0x1400002bbc0 pc=0x10324cf98
testing.tRunner(0x14000643d40, 0x1400009a2c0)

```