### PR TITLE
hotfix-fix-compile-error-on-mac

### DIFF
--- a/viam-cartographer/src/carto_facade/carto_facade_test.cc
+++ b/viam-cartographer/src/carto_facade/carto_facade_test.cc
@@ -470,7 +470,7 @@ BOOST_AUTO_TEST_CASE(CartoFacade_demo) {
     fs::path tmp_dir =
         fs::temp_directory_path() / fs::path(bfs::unique_path().string());
     struct viam_carto_config vcc =
-        viam_carto_config_setup(1, VIAM_CARTO_THREE_D, tmp_dir.string(),
+        viam_carto_config_setup(60, VIAM_CARTO_THREE_D, tmp_dir.string(),
 
                                 sensors_vec);
     struct viam_carto_algo_config ac = viam_carto_algo_config_setup();

--- a/viam-cartographer/src/carto_facade/test_helpers.cc
+++ b/viam-cartographer/src/carto_facade/test_helpers.cc
@@ -1,9 +1,9 @@
 #include "test_helpers.h"
 
 #include <boost/test/unit_test.hpp>
+#include <fstream>
 
 #include "util.h"
-#include <fstream>
 
 namespace viam {
 namespace carto_facade {

--- a/viam-cartographer/src/carto_facade/test_helpers.cc
+++ b/viam-cartographer/src/carto_facade/test_helpers.cc
@@ -3,6 +3,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include "util.h"
+#include <fstream>
 
 namespace viam {
 namespace carto_facade {


### PR DESCRIPTION
I forgot to add a header include: https://github.com/viamrobotics/viam-cartographer/pull/160/files#diff-49d4a9777ef7773792665e3523fe1c5032de5373119d778dd3e461329a60399fR10 

This apparently is only caught by clang, which is only used on mac, which we don't test in CI.

Detected in this PR:
https://github.com/viamrobotics/viam-cartographer/pull/170/files#diff-49d4a9777ef7773792665e3523fe1c5032de5373119d778dd3e461329a60399fR4

This also changes the map_rate_sec from 1 to 60 to prevent flakey tests failures if it takes longer than a second to add all the lidar data which may cause add_lidar_reading to fail unexpectedly as the lock is held by the background thread which saves internal state to disk: https://github.com/viamrobotics/viam-cartographer/actions/runs/5414901563/jobs/9842617172?pr=179