### PR TITLE
RSDK-3786 - use-cartofacade-for-init-and-term

### DIFF
--- a/cartofacade/capi.go
+++ b/cartofacade/capi.go
@@ -77,7 +77,7 @@ type GetPosition struct {
 type LidarConfig int64
 
 const (
-	twoD LidarConfig = iota
+	TwoD LidarConfig = iota
 	threeD
 )
 
@@ -313,7 +313,7 @@ func goStringToBstring(goStr string) C.bstring {
 
 func toLidarConfig(lidarConfig LidarConfig) (C.viam_carto_LIDAR_CONFIG, error) {
 	switch lidarConfig {
-	case twoD:
+	case TwoD:
 		return C.VIAM_CARTO_TWO_D, nil
 	case threeD:
 		return C.VIAM_CARTO_THREE_D, nil

--- a/cartofacade/capi_test.go
+++ b/cartofacade/capi_test.go
@@ -31,7 +31,7 @@ func TestGetConfig(t *testing.T) {
 
 		freeBstringArray(vcc.sensors, vcc.sensors_len)
 
-		test.That(t, vcc.lidar_config, test.ShouldEqual, twoD)
+		test.That(t, vcc.lidar_config, test.ShouldEqual, TwoD)
 	})
 }
 

--- a/cartofacade/carto_facade.go
+++ b/cartofacade/carto_facade.go
@@ -9,6 +9,7 @@ import (
 	"time"
 )
 
+var Lib CartoLib
 var emptyRequestParams = map[RequestParamType]interface{}{}
 
 // Initialize calls into the cartofacade C code.

--- a/cartofacade/testhelpers.go
+++ b/cartofacade/testhelpers.go
@@ -16,7 +16,7 @@ func GetTestConfig(sensor string) (CartoConfig, string, error) {
 		MapRateSecond:      5,
 		DataDir:            dir,
 		ComponentReference: "component",
-		LidarConfig:        twoD,
+		LidarConfig:        TwoD,
 	}, dir, nil
 }
 
@@ -24,7 +24,7 @@ func GetTestConfig(sensor string) (CartoConfig, string, error) {
 func GetBadTestConfig() CartoConfig {
 	return CartoConfig{
 		Sensors:     []string{"rplidar", "imu"},
-		LidarConfig: twoD,
+		LidarConfig: TwoD,
 	}
 }
 

--- a/viam-cartographer.go
+++ b/viam-cartographer.go
@@ -171,12 +171,12 @@ func New(
 			Sensors:            svcConfig.Sensors,
 			MapRateSecond:      dataRateMsec * 1000,
 			DataDir:            svcConfig.DataDirectory,
-			ComponentReference: svcConfig.Sensors[0], // Can this be removed?
-			LidarConfig:        cartofacade.TwoD,     // Should this come from somewhere or is hardcoded ok for now?
+			ComponentReference: svcConfig.Sensors[0],
+			LidarConfig:        cartofacade.TwoD,
 		}
 
 		// Get the algo config
-		cartoAlgoCfg := cartofacade.CartoAlgoConfig{} // Where are algo config params being set
+		cartoAlgoCfg := cartofacade.CartoAlgoConfig{}
 
 		// Initialize cartofacade
 		cf := cartofacade.New(&cartofacade.Lib, cartoCfg, cartoAlgoCfg)

--- a/viam-cartographer.go
+++ b/viam-cartographer.go
@@ -44,7 +44,7 @@ const (
 	defaultSensorValidationIntervalSec   = 1
 	parsePortMaxTimeoutSec               = 60
 	localhost0                           = "localhost:0"
-	Timeout                              = 5 * time.Second // I think this is the last place we can bubble this up, thoughts on what the actual value should be?
+	Timeout                              = 5 * time.Second
 )
 
 // SubAlgo defines the cartographer specific sub-algorithms that we support.


### PR DESCRIPTION
[Ticket](https://viam.atlassian.net/browse/RSDK-3786)

Changes to `New`:
- If `modularizationV2Enabled == true`
    - initialize cartofacade library
    - initialize cartofacade
    - start background goroutine that enforces a single call into C at a time

Changes to `Close`:
- If `modularizationV2Enabled == true`
    - stop background goroutine (this will happen when `cartoSvc.cancelFunc()` is called)
    - terminate cartofacade
    - terminate cartofacade library