### PR TITLE
[RSDK-3545] add sensor process

### DIFF
--- a/cartofacade/capi.go
+++ b/cartofacade/capi.go
@@ -407,7 +407,7 @@ func toError(status C.int) error {
 	case C.VIAM_CARTO_SUCCESS:
 		return nil
 	case C.VIAM_CARTO_UNABLE_TO_ACQUIRE_LOCK:
-		return errors.New("VIAM_CARTO_UNABLE_TO_ACQUIRE_LOCK")
+		return ErrUnableToAcquireLock
 	case C.VIAM_CARTO_VC_INVALID:
 		return errors.New("VIAM_CARTO_VC_INVALID")
 	case C.VIAM_CARTO_OUT_OF_MEMORY:

--- a/cartofacade/carto_facade_mock.go
+++ b/cartofacade/carto_facade_mock.go
@@ -1,7 +1,13 @@
 // Package cartofacade is used to mock a cartofacade.
 package cartofacade
 
-// RequestMock represents a fake instance of cartofacade.
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// RequestMock represents a fake instance of a request.
 type RequestMock struct {
 	Request
 	doWorkFunc func(cf *CartoFacade) (interface{}, error)
@@ -13,4 +19,171 @@ func (r *RequestMock) doWork(cf *CartoFacade) (interface{}, error) {
 		return r.Request.doWork(cf)
 	}
 	return r.doWorkFunc(cf)
+}
+
+// Mock represents a fake instance of cartofacade.
+type Mock struct {
+	CartoFacade
+	requestFunc func(
+		ctxParent context.Context,
+		requestType RequestType,
+		inputs map[RequestParamType]interface{},
+		timeout time.Duration,
+	) (interface{}, error)
+	startCGoRoutineFunc func(
+		ctx context.Context,
+		activeBackgroundWorkers *sync.WaitGroup,
+	)
+
+	InitializeFunc func(
+		ctx context.Context,
+		timeout time.Duration, activeBackgroundWorkers *sync.WaitGroup,
+	) error
+	StartFunc func(
+		ctx context.Context,
+		timeout time.Duration,
+	) error
+	StopFunc func(
+		ctx context.Context,
+		timeout time.Duration,
+	) error
+	TerminateFunc func(
+		ctx context.Context,
+		timeout time.Duration,
+	) error
+	AddSensorReadingFunc func(
+		ctx context.Context,
+		timeout time.Duration,
+		sensorName string,
+		currentReading []byte,
+		readingTimestamp time.Time,
+	) error
+	GetPositionFunc func(
+		ctx context.Context,
+		timeout time.Duration,
+	) (GetPosition, error)
+	GetInternalStateFunc func(
+		ctx context.Context,
+		timeout time.Duration,
+	) ([]byte, error)
+	GetPointCloudMapFunc func(
+		ctx context.Context,
+		timeout time.Duration,
+	) ([]byte, error)
+}
+
+// request calls the injected requestFunc or the real version.
+func (cf *Mock) request(
+	ctxParent context.Context,
+	requestType RequestType,
+	inputs map[RequestParamType]interface{},
+	timeout time.Duration,
+) (interface{}, error) {
+	if cf.requestFunc == nil {
+		return cf.CartoFacade.request(ctxParent, requestType, inputs, timeout)
+	}
+	return cf.requestFunc(ctxParent, requestType, inputs, timeout)
+}
+
+// start calls the injected startCGoRoutineFunc or the real version.
+func (cf *Mock) startCGoroutine(
+	ctx context.Context,
+	activeBackgroundWorkers *sync.WaitGroup,
+) {
+	if cf.startCGoRoutineFunc == nil {
+		cf.CartoFacade.startCGoroutine(ctx, activeBackgroundWorkers)
+	}
+	cf.startCGoRoutineFunc(ctx, activeBackgroundWorkers)
+}
+
+// Initialize calls the injected InitializeFunc or the real version.
+func (cf *Mock) Initialize(
+	ctx context.Context,
+	timeout time.Duration,
+	activeBackgroundWorkers *sync.WaitGroup,
+) error {
+	if cf.InitializeFunc == nil {
+		return cf.CartoFacade.Initialize(ctx, timeout, activeBackgroundWorkers)
+	}
+	return cf.InitializeFunc(ctx, timeout, activeBackgroundWorkers)
+}
+
+// Start calls the injected StartFunc or the real version.
+func (cf *Mock) Start(
+	ctx context.Context,
+	timeout time.Duration,
+) error {
+	if cf.StartFunc == nil {
+		return cf.CartoFacade.Start(ctx, timeout)
+	}
+	return cf.StartFunc(ctx, timeout)
+}
+
+// Stop calls the Stop StopFunc or the real version.
+func (cf *Mock) Stop(
+	ctx context.Context,
+	timeout time.Duration,
+) error {
+	if cf.StopFunc == nil {
+		return cf.CartoFacade.Stop(ctx, timeout)
+	}
+	return cf.StopFunc(ctx, timeout)
+}
+
+// Terminate calls the injected TerminateFunc or the real version.
+func (cf *Mock) Terminate(
+	ctx context.Context,
+	timeout time.Duration,
+) error {
+	if cf.TerminateFunc == nil {
+		return cf.CartoFacade.Terminate(ctx, timeout)
+	}
+	return cf.TerminateFunc(ctx, timeout)
+}
+
+// AddSensorReading calls the injected AddSensorReadingFunc or the real version.
+func (cf *Mock) AddSensorReading(
+	ctx context.Context,
+	timeout time.Duration,
+	sensorName string,
+	currentReading []byte,
+	readingTimestamp time.Time,
+) error {
+	if cf.AddSensorReadingFunc == nil {
+		return cf.CartoFacade.AddSensorReading(ctx, timeout, sensorName, currentReading, readingTimestamp)
+	}
+	return cf.AddSensorReadingFunc(ctx, timeout, sensorName, currentReading, readingTimestamp)
+}
+
+// GetPosition calls the injected GetPositionFunc or the real version.
+func (cf *Mock) GetPosition(
+	ctx context.Context,
+	timeout time.Duration,
+) (GetPosition, error) {
+	if cf.GetPositionFunc == nil {
+		return cf.CartoFacade.GetPosition(ctx, timeout)
+	}
+	return cf.GetPositionFunc(ctx, timeout)
+}
+
+// GetInternalState calls the injected GetInternalStateFunc or the real version.
+func (cf *Mock) GetInternalState(
+	ctx context.Context,
+	timeout time.Duration,
+) ([]byte, error) {
+	if cf.GetInternalStateFunc == nil {
+		return cf.CartoFacade.GetInternalState(ctx, timeout)
+	}
+	return cf.GetInternalStateFunc(ctx, timeout)
+}
+
+// GetPointCloudMap calls the injected GetPointCloudMapFunc or the real version.
+func (cf *Mock) GetPointCloudMap(
+	ctx context.Context,
+	timeout time.Duration,
+) ([]byte, error) {
+	if cf.GetPointCloudMapFunc == nil {
+		return cf.CartoFacade.GetPointCloudMap(ctx, timeout)
+	}
+	return cf.GetPointCloudMapFunc(ctx, timeout)
 }

--- a/internal/testhelper/testhelper.go
+++ b/internal/testhelper/testhelper.go
@@ -45,6 +45,8 @@ const (
 	testDialMaxTimeoutSec              = 1
 	// TestTime can be used to test specific timestamps provided by a replay sensor.
 	TestTime = "2006-01-02T15:04:05.9999Z"
+	// BadTime can be used to represent something that should cause an error while parsing it as a time.
+	BadTime = "NOT A TIME"
 )
 
 // IntegrationLidarReleasePointCloudChan is the lidar pointcloud release
@@ -72,7 +74,9 @@ func SetupDeps(sensors []string) resource.Dependencies {
 		case "good_lidar":
 			deps[camera.Named(sensor)] = getGoodLidar()
 		case "replay_sensor":
-			deps[camera.Named(sensor)] = getReplaySensor()
+			deps[camera.Named(sensor)] = getReplaySensor(TestTime)
+		case "invalid_replay_sensor":
+			deps[camera.Named(sensor)] = getReplaySensor(BadTime)
 		case "invalid_sensor":
 			deps[camera.Named(sensor)] = getInvalidSensor()
 		case "gibberish":
@@ -103,12 +107,12 @@ func getGoodLidar() *inject.Camera {
 	return cam
 }
 
-func getReplaySensor() *inject.Camera {
+func getReplaySensor(testTime string) *inject.Camera {
 	cam := &inject.Camera{}
 	cam.NextPointCloudFunc = func(ctx context.Context) (pointcloud.PointCloud, error) {
 		md := ctx.Value(contextutils.MetadataContextKey)
 		if mdMap, ok := md.(map[string][]string); ok {
-			mdMap[contextutils.TimeRequestedMetadataKey] = []string{TestTime}
+			mdMap[contextutils.TimeRequestedMetadataKey] = []string{testTime}
 		}
 		return pointcloud.New(), nil
 	}

--- a/sensorprocess/sensorprocess.go
+++ b/sensorprocess/sensorprocess.go
@@ -1,0 +1,123 @@
+// Package sensorprocess contains the logic to add lidar or replay sensor readings to cartographer's mapbuilder
+package sensorprocess
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"math"
+	"time"
+
+	"github.com/edaniels/golog"
+	"go.viam.com/rdk/pointcloud"
+	"go.viam.com/rdk/utils/contextutils"
+
+	"github.com/viamrobotics/viam-cartographer/cartofacade"
+	"github.com/viamrobotics/viam-cartographer/sensors/lidar"
+)
+
+// Config holds config needed throughout the process of adding a sensor reading to the mapbuilder.
+type Config struct {
+	CartoFacade      cartofacade.Interface
+	Lidar            lidar.Lidar
+	LidarName        string
+	DataRateMs       int
+	Timeout          time.Duration
+	Logger           golog.Logger
+	TelemetryEnabled bool
+}
+
+// Start polls the lidar to get the next sensor reading and adds it to the mapBuilder.
+// stops when the context is Done.
+func Start(
+	ctx context.Context,
+	config Config,
+) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+			addSensorReading(ctx, config)
+		}
+	}
+}
+
+// addSensorReading adds a lidar reading to the mapbuilder.
+func addSensorReading(
+	parentCtx context.Context,
+	config Config,
+) {
+	ctxWithMetadata, md := contextutils.ContextWithMetadata(parentCtx)
+	readingPc, err := config.Lidar.GetData(ctxWithMetadata)
+	if err != nil {
+		config.Logger.Warnw("Skipping sensor reading due to error getting lidar reading", "error", err)
+		return
+	}
+	readingTime := time.Now().UTC()
+
+	buf := new(bytes.Buffer)
+	err = pointcloud.ToPCD(readingPc, buf, pointcloud.PCDBinary)
+	if err != nil {
+		config.Logger.Warnw("Skipping sensor reading due to error converting lidar reading to PCD", "error", err)
+		return
+	}
+
+	timeRequestedMetadata, ok := md[contextutils.TimeRequestedMetadataKey]
+	if ok {
+		readingTime, err = time.Parse(time.RFC3339Nano, timeRequestedMetadata[0])
+		if err != nil {
+			config.Logger.Warnw("Skipping sensor reading due to error converting replay sensor timestamp to RFC3339Nano", "error", err)
+			return
+		}
+		addSensorReadingFromReplaySensor(ctxWithMetadata, buf.Bytes(), readingTime, config)
+	} else {
+		timeToSleep := addSensorReadingFromLiveReadings(ctxWithMetadata, buf.Bytes(), readingTime, config)
+		time.Sleep(time.Duration(timeToSleep) * time.Millisecond)
+	}
+}
+
+// addSensorReadingFromReplaySensor adds a reading from a replay sensor to the cartofacade
+// retries on error.
+func addSensorReadingFromReplaySensor(ctx context.Context, reading []byte, readingTime time.Time, config Config) {
+	/*
+		while add sensor reading fails, keep trying to add the same reading - in offline mode
+		we want to process each reading so if we cannot acquire the lock we should try again
+	*/
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+			err := config.CartoFacade.AddSensorReading(ctx, config.Timeout, config.LidarName, reading, readingTime)
+			if err == nil {
+				// TODO: increment telemetry counter success
+				return
+			}
+			if !errors.Is(err, cartofacade.ErrUnableToAcquireLock) {
+				// TODO: increment telemetry counter unexpected error
+				config.Logger.Warnw("Skipping sensor reading due to error from cartofacade", "error", err)
+			}
+			// TODO: increment telemetry counter unable to acquire lock
+		}
+	}
+}
+
+// addSensorReadingFromLiveReadings adds a reading from a live lidar to the carto facade
+// does not retry.
+func addSensorReadingFromLiveReadings(ctx context.Context, reading []byte, readingTime time.Time, config Config) int {
+	startTime := time.Now()
+	err := config.CartoFacade.AddSensorReading(ctx, config.Timeout, config.LidarName, reading, readingTime)
+	if err != nil {
+		if errors.Is(err, cartofacade.ErrUnableToAcquireLock) {
+			config.Logger.Debugw("Skipping sensor reading due to lock contention in cartofacade", "error", err)
+			// TODO: increment telemetry counter unable to acquire lock
+		} else {
+			config.Logger.Warnw("Skipping sensor reading due to error from cartofacade", "error", err)
+			// TODO: increment telemetry counter unexpected error
+		}
+	}
+	// TODO: increment telemetry counter success
+	timeElapsedMs := int(time.Since(startTime).Milliseconds())
+	return int(math.Max(0, float64(config.DataRateMs-timeElapsedMs)))
+}

--- a/sensorprocess/sensorprocess_test.go
+++ b/sensorprocess/sensorprocess_test.go
@@ -1,0 +1,411 @@
+package sensorprocess
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/edaniels/golog"
+	"go.viam.com/test"
+
+	"github.com/viamrobotics/viam-cartographer/cartofacade"
+	"github.com/viamrobotics/viam-cartographer/internal/testhelper"
+	"github.com/viamrobotics/viam-cartographer/sensors/lidar"
+)
+
+type addSensorReadingArgs struct {
+	timeout          time.Duration
+	sensorName       string
+	currentReading   []byte
+	readingTimestamp time.Time
+}
+
+var (
+	expectedPCD = []byte(`VERSION .7
+FIELDS x y z
+SIZE 4 4 4
+TYPE F F F
+COUNT 1 1 1
+WIDTH 0
+HEIGHT 1
+VIEWPOINT 0 0 0 1 0 0 0
+POINTS 0
+DATA binary
+`)
+	errUnknown = errors.New("unknown error")
+)
+
+func TestAddSensorReadingReplaySensor(t *testing.T) {
+	logger := golog.NewTestLogger(t)
+	reading := []byte("12345")
+	readingTimestamp := time.Now().UTC()
+	cf := cartofacade.Mock{}
+	config := Config{
+		Logger:      logger,
+		CartoFacade: &cf,
+		LidarName:   "good_lidar",
+		DataRateMs:  200,
+		Timeout:     10 * time.Second,
+	}
+	t.Run("When addSensorReading returns successfully, no infinite loop", func(t *testing.T) {
+		cf.AddSensorReadingFunc = func(
+			ctx context.Context,
+			timeout time.Duration,
+			sensorName string,
+			currentReading []byte,
+			readingTimestamp time.Time,
+		) error {
+			return nil
+		}
+		addSensorReadingFromReplaySensor(context.Background(), reading, readingTimestamp, config)
+	})
+
+	t.Run("AddSensorReading returns UNABLE_TO_ACQUIRE_LOCK error and the context is cancelled, no infinite loop", func(t *testing.T) {
+		cf.AddSensorReadingFunc = func(
+			ctx context.Context,
+			timeout time.Duration,
+			sensorName string,
+			currentReading []byte,
+			readingTimestamp time.Time,
+		) error {
+			return cartofacade.ErrUnableToAcquireLock
+		}
+
+		cancelCtx, cancelFunc := context.WithCancel(context.Background())
+		cancelFunc()
+		addSensorReadingFromReplaySensor(cancelCtx, reading, readingTimestamp, config)
+	})
+
+	t.Run("When AddSensorReading returns a different error and the context is cancelled, no infinite loop", func(t *testing.T) {
+		cf.AddSensorReadingFunc = func(
+			ctx context.Context,
+			timeout time.Duration,
+			sensorName string,
+			currentReading []byte,
+			readingTimestamp time.Time,
+		) error {
+			return errUnknown
+		}
+
+		cancelCtx, cancelFunc := context.WithCancel(context.Background())
+		cancelFunc()
+		addSensorReadingFromReplaySensor(cancelCtx, reading, readingTimestamp, config)
+	})
+
+	t.Run("When AddSensorReading hits errors a few times, retries, and then succeeds", func(t *testing.T) {
+		cancelCtx, cancelFunc := context.WithCancel(context.Background())
+
+		var calls []addSensorReadingArgs
+
+		cf.AddSensorReadingFunc = func(
+			ctx context.Context,
+			timeout time.Duration,
+			sensorName string,
+			currentReading []byte,
+			readingTimestamp time.Time,
+		) error {
+			args := addSensorReadingArgs{
+				timeout:          timeout,
+				sensorName:       sensorName,
+				currentReading:   currentReading,
+				readingTimestamp: readingTimestamp,
+			}
+			calls = append(calls, args)
+			if len(calls) == 1 {
+				return errUnknown
+			}
+			if len(calls) < 4 {
+				return cartofacade.ErrUnableToAcquireLock
+			}
+			return nil
+		}
+		addSensorReadingFromReplaySensor(cancelCtx, reading, readingTimestamp, config)
+		test.That(t, len(calls), test.ShouldEqual, 4)
+		for i, args := range calls {
+			t.Logf("addSensorReadingArgsHistory %d", i)
+			test.That(t, args.timeout, test.ShouldEqual, config.Timeout)
+			test.That(t, args.sensorName, test.ShouldEqual, config.LidarName)
+			test.That(t, args.currentReading, test.ShouldResemble, reading)
+			test.That(t, args.readingTimestamp, test.ShouldResemble, readingTimestamp)
+		}
+		cancelFunc()
+	})
+}
+
+func TestAddSensorReadingLiveReadings(t *testing.T) {
+	logger := golog.NewTestLogger(t)
+	cf := cartofacade.Mock{}
+	reading := []byte("12345")
+	readingTimestamp := time.Now().UTC()
+	config := Config{
+		Logger:      logger,
+		CartoFacade: &cf,
+		LidarName:   "good_lidar",
+		DataRateMs:  200,
+		Timeout:     10 * time.Second,
+	}
+
+	t.Run("When AddSensorReading blocks for more than the DataRateMs and succeeds, time to sleep is 0", func(t *testing.T) {
+		cf.AddSensorReadingFunc = func(
+			ctx context.Context,
+			timeout time.Duration,
+			sensorName string,
+			currentReading []byte,
+			readingTimestamp time.Time,
+		) error {
+			time.Sleep(1 * time.Second)
+			return nil
+		}
+
+		timeToSleep := addSensorReadingFromLiveReadings(context.Background(), reading, readingTimestamp, config)
+		test.That(t, timeToSleep, test.ShouldEqual, 0)
+	})
+
+	t.Run("AddSensorReading slower than DataRateMs and returns lock error, time to sleep is 0", func(t *testing.T) {
+		cf.AddSensorReadingFunc = func(
+			ctx context.Context,
+			timeout time.Duration,
+			sensorName string,
+			currentReading []byte,
+			readingTimestamp time.Time,
+		) error {
+			time.Sleep(1 * time.Second)
+			return cartofacade.ErrUnableToAcquireLock
+		}
+
+		timeToSleep := addSensorReadingFromLiveReadings(context.Background(), reading, readingTimestamp, config)
+		test.That(t, timeToSleep, test.ShouldEqual, 0)
+	})
+
+	t.Run("When AddSensorReading blocks for more than the DataRateMs and returns an unexpected error, time to sleep is 0", func(t *testing.T) {
+		cf.AddSensorReadingFunc = func(
+			ctx context.Context,
+			timeout time.Duration,
+			sensorName string,
+			currentReading []byte,
+			readingTimestamp time.Time,
+		) error {
+			time.Sleep(1 * time.Second)
+			return errUnknown
+		}
+
+		timeToSleep := addSensorReadingFromLiveReadings(context.Background(), reading, readingTimestamp, config)
+		test.That(t, timeToSleep, test.ShouldEqual, 0)
+	})
+
+	t.Run("AddSensorReading faster than the DataRateMs and succeeds, time to sleep is <= DataRateMs", func(t *testing.T) {
+		cf.AddSensorReadingFunc = func(
+			ctx context.Context,
+			timeout time.Duration,
+			sensorName string,
+			currentReading []byte,
+			readingTimestamp time.Time,
+		) error {
+			return nil
+		}
+
+		timeToSleep := addSensorReadingFromLiveReadings(context.Background(), reading, readingTimestamp, config)
+		test.That(t, timeToSleep, test.ShouldBeGreaterThan, 0)
+		test.That(t, timeToSleep, test.ShouldBeLessThanOrEqualTo, config.DataRateMs)
+	})
+
+	t.Run("AddSensorReading faster than the DataRateMs and returns lock error, time to sleep is <= DataRateMs", func(t *testing.T) {
+		cf.AddSensorReadingFunc = func(
+			ctx context.Context,
+			timeout time.Duration,
+			sensorName string,
+			currentReading []byte,
+			readingTimestamp time.Time,
+		) error {
+			return cartofacade.ErrUnableToAcquireLock
+		}
+
+		timeToSleep := addSensorReadingFromLiveReadings(context.Background(), reading, readingTimestamp, config)
+		test.That(t, timeToSleep, test.ShouldBeGreaterThan, 0)
+		test.That(t, timeToSleep, test.ShouldBeLessThanOrEqualTo, config.DataRateMs)
+	})
+
+	t.Run("AddSensorReading faster than DataRateMs and returns unexpected error, time to sleep is <= DataRateMs", func(t *testing.T) {
+		cf.AddSensorReadingFunc = func(
+			ctx context.Context,
+			timeout time.Duration,
+			sensorName string,
+			currentReading []byte,
+			readingTimestamp time.Time,
+		) error {
+			return errUnknown
+		}
+
+		timeToSleep := addSensorReadingFromLiveReadings(context.Background(), reading, readingTimestamp, config)
+		test.That(t, timeToSleep, test.ShouldBeGreaterThan, 0)
+		test.That(t, timeToSleep, test.ShouldBeLessThanOrEqualTo, config.DataRateMs)
+	})
+}
+
+func TestAddSensorReading(t *testing.T) {
+	logger := golog.NewTestLogger(t)
+	cf := cartofacade.Mock{}
+
+	config := Config{
+		Logger:      logger,
+		CartoFacade: &cf,
+		DataRateMs:  200,
+		Timeout:     10 * time.Second,
+	}
+	ctx := context.Background()
+
+	t.Run("returns error when lidar GetData returns error, doesn't try to add sensor data", func(t *testing.T) {
+		sensors := []string{"invalid_sensor"}
+		invalidReplaySensor, err := lidar.New(testhelper.SetupDeps(sensors), sensors, 0)
+		test.That(t, err, test.ShouldBeNil)
+
+		var calls []addSensorReadingArgs
+		cf.AddSensorReadingFunc = func(
+			ctx context.Context,
+			timeout time.Duration,
+			sensorName string,
+			currentReading []byte,
+			readingTimestamp time.Time,
+		) error {
+			args := addSensorReadingArgs{
+				timeout:          timeout,
+				sensorName:       sensorName,
+				currentReading:   currentReading,
+				readingTimestamp: readingTimestamp,
+			}
+			calls = append(calls, args)
+			return nil
+		}
+		config.Lidar = invalidReplaySensor
+		config.LidarName = invalidReplaySensor.Name
+
+		addSensorReading(ctx, config)
+		test.That(t, len(calls), test.ShouldEqual, 0)
+	})
+
+	t.Run("returns error when replay sensor timestamp is invalid, doesn't try to add sensor data", func(t *testing.T) {
+		sensors := []string{"invalid_replay_sensor"}
+		invalidReplaySensor, err := lidar.New(testhelper.SetupDeps(sensors), sensors, 0)
+		test.That(t, err, test.ShouldBeNil)
+
+		var calls []addSensorReadingArgs
+		cf.AddSensorReadingFunc = func(
+			ctx context.Context,
+			timeout time.Duration,
+			sensorName string,
+			currentReading []byte,
+			readingTimestamp time.Time,
+		) error {
+			args := addSensorReadingArgs{
+				timeout:          timeout,
+				sensorName:       sensorName,
+				currentReading:   currentReading,
+				readingTimestamp: readingTimestamp,
+			}
+			calls = append(calls, args)
+			return nil
+		}
+		config.Lidar = invalidReplaySensor
+		config.LidarName = invalidReplaySensor.Name
+
+		addSensorReading(ctx, config)
+		test.That(t, len(calls), test.ShouldEqual, 0)
+	})
+
+	t.Run("replay sensor adds sensor data until success", func(t *testing.T) {
+		sensors := []string{"replay_sensor"}
+		replaySensor, err := lidar.New(testhelper.SetupDeps(sensors), sensors, 0)
+		test.That(t, err, test.ShouldBeNil)
+
+		var calls []addSensorReadingArgs
+		cf.AddSensorReadingFunc = func(
+			ctx context.Context,
+			timeout time.Duration,
+			sensorName string,
+			currentReading []byte,
+			readingTimestamp time.Time,
+		) error {
+			args := addSensorReadingArgs{
+				timeout:          timeout,
+				sensorName:       sensorName,
+				currentReading:   currentReading,
+				readingTimestamp: readingTimestamp,
+			}
+			calls = append(calls, args)
+			if len(calls) == 1 {
+				return errUnknown
+			}
+			if len(calls) == 2 {
+				return cartofacade.ErrUnableToAcquireLock
+			}
+			return nil
+		}
+		config.Lidar = replaySensor
+		config.LidarName = replaySensor.Name
+
+		addSensorReading(ctx, config)
+		test.That(t, len(calls), test.ShouldEqual, 3)
+
+		firstTimestamp := calls[0].readingTimestamp
+		for i, call := range calls {
+			t.Logf("call %d", i)
+			test.That(t, call.sensorName, test.ShouldResemble, "replay_sensor")
+			test.That(t, call.currentReading, test.ShouldResemble, expectedPCD)
+			test.That(t, call.timeout, test.ShouldEqual, config.Timeout)
+			test.That(t, call.readingTimestamp, test.ShouldEqual, firstTimestamp)
+		}
+	})
+
+	t.Run("live sensor adds sensor reading once and ignores errors", func(t *testing.T) {
+		sensors := []string{"good_lidar"}
+		liveSensor, err := lidar.New(testhelper.SetupDeps(sensors), sensors, 0)
+		test.That(t, err, test.ShouldBeNil)
+
+		var calls []addSensorReadingArgs
+		cf.AddSensorReadingFunc = func(
+			ctx context.Context,
+			timeout time.Duration,
+			sensorName string,
+			currentReading []byte,
+			readingTimestamp time.Time,
+		) error {
+			args := addSensorReadingArgs{
+				timeout:          timeout,
+				sensorName:       sensorName,
+				currentReading:   currentReading,
+				readingTimestamp: readingTimestamp,
+			}
+			calls = append(calls, args)
+			if len(calls) == 1 {
+				return errUnknown
+			}
+			if len(calls) == 2 {
+				return cartofacade.ErrUnableToAcquireLock
+			}
+			return nil
+		}
+		config.Lidar = liveSensor
+		config.LidarName = liveSensor.Name
+
+		addSensorReading(ctx, config)
+		test.That(t, len(calls), test.ShouldEqual, 1)
+
+		addSensorReading(ctx, config)
+		test.That(t, len(calls), test.ShouldEqual, 2)
+
+		addSensorReading(ctx, config)
+		test.That(t, len(calls), test.ShouldEqual, 3)
+
+		for i, call := range calls {
+			t.Logf("call %d", i)
+			test.That(t, call.sensorName, test.ShouldResemble, "good_lidar")
+			// the lidar test fixture happens to always return the same pcd currently
+			// in reality it could be a new pcd every time
+			test.That(t, call.currentReading, test.ShouldResemble, expectedPCD)
+			test.That(t, call.timeout, test.ShouldEqual, config.Timeout)
+		}
+		test.That(t, calls[0].readingTimestamp.Before(calls[1].readingTimestamp), test.ShouldBeTrue)
+		test.That(t, calls[1].readingTimestamp.Before(calls[2].readingTimestamp), test.ShouldBeTrue)
+	})
+}


### PR DESCRIPTION
[Ticket](https://viam.atlassian.net/browse/RSDK-3545)

- `sensorprocess.Start` polls the lidar to get the next sensor reading and adds it to the mapBuilder by calling `addSensorReading` in a loop and exits if the context provided is canceled. 
- `addSensorReading` checks if the metadata from the GRPC call has a timestamp, if it does it calls `addSensorReadingFromReplaySensor` otherwise It calls `addSensorReadingFromLiveReadings`
- `addSensorReadingFromReplaySensor` continuously calls `cartofacade.AddSensorReading` until it succeeds 
- `addSensorReadingFromLiveReadings` calls cartofacade.AddSensorReading once and skips the reading if it does not succeed
- There is also a change to the testhelper file so that we can mock a replay sensor that returns a corrupted time stamp that would not be able to be parsed

Follow-up tickets:
[Add telemetry for sensorprocess](https://viam.atlassian.net/browse/RSDK-3920)
[ Ensure the lidar is healthy before booting the SensorProcess go routine](https://viam.atlassian.net/browse/RSDK-3921)

Based on https://github.com/viamrobotics/viam-cartographer/pull/177