### PR TITLE
RSDK-3950 - call into cgo for getPosition

### DIFF
--- a/viam-cartographer.go
+++ b/viam-cartographer.go
@@ -521,7 +521,14 @@ func (cartoSvc *cartographerService) getPositionModularizationV2(ctx context.Con
 	}
 
 	pose := spatialmath.NewPoseFromPoint(r3.Vector{X: pos.X, Y: pos.Y, Z: pos.Z})
-	returnedExt := map[string]interface{}{"quat": map[string]interface{}{"real": pos.Real, "imag": pos.Imag, "jmag": pos.Jmag, "kmag": pos.Kmag}}
+	returnedExt := map[string]interface{}{
+		"quat": map[string]interface{}{
+			"real": pos.Real,
+			"imag": pos.Imag,
+			"jmag": pos.Jmag,
+			"kmag": pos.Kmag,
+		},
+	}
 	return vcUtils.CheckQuaternionFromClientAlgo(pose, cartoSvc.primarySensorName, returnedExt)
 }
 

--- a/viam-cartographer.go
+++ b/viam-cartographer.go
@@ -517,7 +517,7 @@ func (cartoSvc *cartographerService) GetPosition(ctx context.Context) (spatialma
 func (cartoSvc *cartographerService) getPositionModularizationV2(ctx context.Context) (spatialmath.Pose, string, error) {
 	pos, err := cartoSvc.cartofacade.GetPosition(ctx, cartoSvc.cartoFacadeTimeout)
 	if err != nil {
-		return spatialmath.NewZeroPose(), "", err
+		return nil, "", err
 	}
 
 	pose := spatialmath.NewPoseFromPoint(r3.Vector{X: pos.X, Y: pos.Y, Z: pos.Z})

--- a/viam-cartographer.go
+++ b/viam-cartographer.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/edaniels/golog"
+	"github.com/golang/geo/r3"
 	"github.com/pkg/errors"
 	"go.opencensus.io/trace"
 	"go.uber.org/zap/zapcore"
@@ -455,7 +456,7 @@ type cartographerService struct {
 	useLiveData bool
 
 	modularizationV2Enabled bool
-	cartofacade             *cartofacade.CartoFacade
+	cartofacade             cartofacade.Interface
 	cartoFacadeTimeout      time.Duration
 
 	// deprecated
@@ -496,6 +497,10 @@ func (cartoSvc *cartographerService) GetPosition(ctx context.Context) (spatialma
 	ctx, span := trace.StartSpan(ctx, "viamcartographer::cartographerService::GetPosition")
 	defer span.End()
 
+	if cartoSvc.modularizationV2Enabled {
+		return cartoSvc.getPositionModularizationV2(ctx)
+	}
+
 	req := &pb.GetPositionRequest{Name: cartoSvc.Name().ShortName()}
 
 	resp, err := cartoSvc.clientAlgo.GetPosition(ctx, req)
@@ -507,6 +512,17 @@ func (cartoSvc *cartographerService) GetPosition(ctx context.Context) (spatialma
 	returnedExt := resp.Extra.AsMap()
 
 	return vcUtils.CheckQuaternionFromClientAlgo(pose, componentReference, returnedExt)
+}
+
+func (cartoSvc *cartographerService) getPositionModularizationV2(ctx context.Context) (spatialmath.Pose, string, error) {
+	pos, err := cartoSvc.cartofacade.GetPosition(ctx, cartoSvc.cartoFacadeTimeout)
+	if err != nil {
+		return spatialmath.NewPose(r3.Vector{}, spatialmath.NewOrientationVector()), "", err
+	}
+
+	pose := spatialmath.NewPoseFromPoint(r3.Vector{X: pos.X, Y: pos.Y, Z: pos.Z})
+	returnedExt := map[string]interface{}{"quat": map[string]interface{}{"real": pos.Real, "imag": pos.Imag, "jmag": pos.Jmag, "kmag": pos.Kmag}}
+	return vcUtils.CheckQuaternionFromClientAlgo(pose, cartoSvc.primarySensorName, returnedExt)
 }
 
 // GetPointCloudMap creates a request, recording the time, calls the slam algorithms GetPointCloudMap endpoint and returns a callback

--- a/viam-cartographer.go
+++ b/viam-cartographer.go
@@ -517,7 +517,7 @@ func (cartoSvc *cartographerService) GetPosition(ctx context.Context) (spatialma
 func (cartoSvc *cartographerService) getPositionModularizationV2(ctx context.Context) (spatialmath.Pose, string, error) {
 	pos, err := cartoSvc.cartofacade.GetPosition(ctx, cartoSvc.cartoFacadeTimeout)
 	if err != nil {
-		return spatialmath.NewPose(r3.Vector{}, spatialmath.NewOrientationVector()), "", err
+		return spatialmath.NewZeroPose(), "", err
 	}
 
 	pose := spatialmath.NewPoseFromPoint(r3.Vector{X: pos.X, Y: pos.Y, Z: pos.Z})

--- a/viam-cartographer_internal_test.go
+++ b/viam-cartographer_internal_test.go
@@ -244,7 +244,6 @@ func TestGetPositionEndpoint(t *testing.T) {
 	})
 }
 
-//nolint:dupl
 func TestGetPositionModularizationV2Endpoint(t *testing.T) {
 	svc := &cartographerService{Named: resource.NewName(slam.API, "test").AsNamed()}
 	mockCartoFacade := &cartofacade.Mock{}
@@ -308,6 +307,22 @@ func TestGetPositionModularizationV2Endpoint(t *testing.T) {
 			makeQuaternionFromGenericMap(inputQuat),
 		)
 		test.That(t, pose, test.ShouldResemble, expectedPose)
+	})
+
+	t.Run("error case", func(t *testing.T) {
+		mockCartoFacade.GetPositionFunc = func(
+			ctx context.Context,
+			timeout time.Duration,
+		) (cartofacade.GetPosition, error) {
+			return cartofacade.GetPosition{}, errors.New("testError")
+		}
+
+		inputPose = commonv1.Pose{X: 0, Y: 0, Z: 0, OX: 0, OY: 0, OZ: 1, Theta: 0}
+		inputQuat = map[string]interface{}{"real": 1.0, "imag": 0.0, "jmag": 0.0, "kmag": 0.0}
+		pose, _, err := svc.GetPosition(context.Background())
+
+		test.That(t, err, test.ShouldBeError, errors.New("testError"))
+		test.That(t, pose, test.ShouldBeNil)
 	})
 }
 

--- a/viam-cartographer_internal_test.go
+++ b/viam-cartographer_internal_test.go
@@ -254,62 +254,60 @@ func TestGetPositionModularizationV2Endpoint(t *testing.T) {
 	var inputPose commonv1.Pose
 	var inputQuat map[string]interface{}
 
-	t.Run("successful client", func(t *testing.T) {
-		t.Run("origin pose success", func(t *testing.T) {
-			mockCartoFacade.GetPositionFunc = func(
-				ctx context.Context,
-				timeout time.Duration,
-			) (cartofacade.GetPosition, error) {
-				return cartofacade.GetPosition{
-						X:    0,
-						Y:    0,
-						Z:    0,
-						Real: 1.0,
-						Imag: 0.0,
-						Jmag: 0.0,
-						Kmag: 0.0,
-					},
-					nil
-			}
+	t.Run("origin pose success", func(t *testing.T) {
+		mockCartoFacade.GetPositionFunc = func(
+			ctx context.Context,
+			timeout time.Duration,
+		) (cartofacade.GetPosition, error) {
+			return cartofacade.GetPosition{
+					X:    0,
+					Y:    0,
+					Z:    0,
+					Real: 1.0,
+					Imag: 0.0,
+					Jmag: 0.0,
+					Kmag: 0.0,
+				},
+				nil
+		}
 
-			inputPose = commonv1.Pose{X: 0, Y: 0, Z: 0, OX: 0, OY: 0, OZ: 1, Theta: 0}
-			inputQuat = map[string]interface{}{"real": 1.0, "imag": 0.0, "jmag": 0.0, "kmag": 0.0}
-			pose, _, err := svc.GetPosition(context.Background())
-			test.That(t, err, test.ShouldBeNil)
-			expectedPose := spatialmath.NewPose(
-				r3.Vector{X: inputPose.X, Y: inputPose.Y, Z: inputPose.Z},
-				makeQuaternionFromGenericMap(inputQuat),
-			)
-			test.That(t, pose, test.ShouldResemble, expectedPose)
-		})
+		inputPose = commonv1.Pose{X: 0, Y: 0, Z: 0, OX: 0, OY: 0, OZ: 1, Theta: 0}
+		inputQuat = map[string]interface{}{"real": 1.0, "imag": 0.0, "jmag": 0.0, "kmag": 0.0}
+		pose, _, err := svc.GetPosition(context.Background())
+		test.That(t, err, test.ShouldBeNil)
+		expectedPose := spatialmath.NewPose(
+			r3.Vector{X: inputPose.X, Y: inputPose.Y, Z: inputPose.Z},
+			makeQuaternionFromGenericMap(inputQuat),
+		)
+		test.That(t, pose, test.ShouldResemble, expectedPose)
+	})
 
-		t.Run("non origin pose success", func(t *testing.T) {
-			mockCartoFacade.GetPositionFunc = func(
-				ctx context.Context,
-				timeout time.Duration,
-			) (cartofacade.GetPosition, error) {
-				return cartofacade.GetPosition{
-						X:    5,
-						Y:    5,
-						Z:    5,
-						Real: 1.0,
-						Imag: 1.0,
-						Jmag: 0.0,
-						Kmag: 0.0,
-					},
-					nil
-			}
+	t.Run("non origin pose success", func(t *testing.T) {
+		mockCartoFacade.GetPositionFunc = func(
+			ctx context.Context,
+			timeout time.Duration,
+		) (cartofacade.GetPosition, error) {
+			return cartofacade.GetPosition{
+					X:    5,
+					Y:    5,
+					Z:    5,
+					Real: 1.0,
+					Imag: 1.0,
+					Jmag: 0.0,
+					Kmag: 0.0,
+				},
+				nil
+		}
 
-			inputPose = commonv1.Pose{X: 5, Y: 5, Z: 5, OX: 0, OY: 0, OZ: 1, Theta: 0}
-			inputQuat = map[string]interface{}{"real": 1.0, "imag": 1.0, "jmag": 0.0, "kmag": 0.0}
-			pose, _, err := svc.GetPosition(context.Background())
-			test.That(t, err, test.ShouldBeNil)
-			expectedPose := spatialmath.NewPose(
-				r3.Vector{X: inputPose.X, Y: inputPose.Y, Z: inputPose.Z},
-				makeQuaternionFromGenericMap(inputQuat),
-			)
-			test.That(t, pose, test.ShouldResemble, expectedPose)
-		})
+		inputPose = commonv1.Pose{X: 5, Y: 5, Z: 5, OX: 0, OY: 0, OZ: 1, Theta: 0}
+		inputQuat = map[string]interface{}{"real": 1.0, "imag": 1.0, "jmag": 0.0, "kmag": 0.0}
+		pose, _, err := svc.GetPosition(context.Background())
+		test.That(t, err, test.ShouldBeNil)
+		expectedPose := spatialmath.NewPose(
+			r3.Vector{X: inputPose.X, Y: inputPose.Y, Z: inputPose.Z},
+			makeQuaternionFromGenericMap(inputQuat),
+		)
+		test.That(t, pose, test.ShouldResemble, expectedPose)
 	})
 }
 

--- a/viam-cartographer_internal_test.go
+++ b/viam-cartographer_internal_test.go
@@ -244,6 +244,7 @@ func TestGetPositionEndpoint(t *testing.T) {
 	})
 }
 
+//nolint:dupl
 func TestGetPositionModularizationV2Endpoint(t *testing.T) {
 	svc := &cartographerService{Named: resource.NewName(slam.API, "test").AsNamed()}
 	mockCartoFacade := &cartofacade.Mock{}
@@ -254,13 +255,21 @@ func TestGetPositionModularizationV2Endpoint(t *testing.T) {
 	var inputQuat map[string]interface{}
 
 	t.Run("successful client", func(t *testing.T) {
-
 		t.Run("origin pose success", func(t *testing.T) {
 			mockCartoFacade.GetPositionFunc = func(
 				ctx context.Context,
 				timeout time.Duration,
 			) (cartofacade.GetPosition, error) {
-				return cartofacade.GetPosition{X: 0, Y: 0, Z: 0, Real: 1.0, Imag: 0.0, Jmag: 0.0, Kmag: 0.0}, nil
+				return cartofacade.GetPosition{
+						X:    0,
+						Y:    0,
+						Z:    0,
+						Real: 1.0,
+						Imag: 0.0,
+						Jmag: 0.0,
+						Kmag: 0.0,
+					},
+					nil
 			}
 
 			inputPose = commonv1.Pose{X: 0, Y: 0, Z: 0, OX: 0, OY: 0, OZ: 1, Theta: 0}
@@ -279,7 +288,16 @@ func TestGetPositionModularizationV2Endpoint(t *testing.T) {
 				ctx context.Context,
 				timeout time.Duration,
 			) (cartofacade.GetPosition, error) {
-				return cartofacade.GetPosition{X: 5, Y: 5, Z: 5, Real: 1.0, Imag: 1.0, Jmag: 0.0, Kmag: 0.0}, nil
+				return cartofacade.GetPosition{
+						X:    5,
+						Y:    5,
+						Z:    5,
+						Real: 1.0,
+						Imag: 1.0,
+						Jmag: 0.0,
+						Kmag: 0.0,
+					},
+					nil
 			}
 
 			inputPose = commonv1.Pose{X: 5, Y: 5, Z: 5, OX: 0, OY: 0, OZ: 1, Theta: 0}

--- a/viam-cartographer_internal_test.go
+++ b/viam-cartographer_internal_test.go
@@ -244,6 +244,7 @@ func TestGetPositionEndpoint(t *testing.T) {
 	})
 }
 
+//nolint:dupl
 func TestGetPositionModularizationV2Endpoint(t *testing.T) {
 	svc := &cartographerService{Named: resource.NewName(slam.API, "test").AsNamed()}
 	mockCartoFacade := &cartofacade.Mock{}
@@ -253,7 +254,8 @@ func TestGetPositionModularizationV2Endpoint(t *testing.T) {
 	var inputPose commonv1.Pose
 	var inputQuat map[string]interface{}
 
-	t.Run("origin pose success", func(t *testing.T) {
+	t.Run("empty component reference success", func(t *testing.T) {
+		svc.primarySensorName = ""
 		mockCartoFacade.GetPositionFunc = func(
 			ctx context.Context,
 			timeout time.Duration,
@@ -272,16 +274,48 @@ func TestGetPositionModularizationV2Endpoint(t *testing.T) {
 
 		inputPose = commonv1.Pose{X: 0, Y: 0, Z: 0, OX: 0, OY: 0, OZ: 1, Theta: 0}
 		inputQuat = map[string]interface{}{"real": 1.0, "imag": 0.0, "jmag": 0.0, "kmag": 0.0}
-		pose, _, err := svc.GetPosition(context.Background())
+		pose, componentReference, err := svc.GetPosition(context.Background())
 		test.That(t, err, test.ShouldBeNil)
 		expectedPose := spatialmath.NewPose(
 			r3.Vector{X: inputPose.X, Y: inputPose.Y, Z: inputPose.Z},
 			makeQuaternionFromGenericMap(inputQuat),
 		)
 		test.That(t, pose, test.ShouldResemble, expectedPose)
+		test.That(t, componentReference, test.ShouldEqual, "")
+	})
+
+	t.Run("origin pose success", func(t *testing.T) {
+		svc.primarySensorName = "primarySensor1"
+		mockCartoFacade.GetPositionFunc = func(
+			ctx context.Context,
+			timeout time.Duration,
+		) (cartofacade.GetPosition, error) {
+			return cartofacade.GetPosition{
+					X:    0,
+					Y:    0,
+					Z:    0,
+					Real: 1.0,
+					Imag: 0.0,
+					Jmag: 0.0,
+					Kmag: 0.0,
+				},
+				nil
+		}
+
+		inputPose = commonv1.Pose{X: 0, Y: 0, Z: 0, OX: 0, OY: 0, OZ: 1, Theta: 0}
+		inputQuat = map[string]interface{}{"real": 1.0, "imag": 0.0, "jmag": 0.0, "kmag": 0.0}
+		pose, componentReference, err := svc.GetPosition(context.Background())
+		test.That(t, err, test.ShouldBeNil)
+		expectedPose := spatialmath.NewPose(
+			r3.Vector{X: inputPose.X, Y: inputPose.Y, Z: inputPose.Z},
+			makeQuaternionFromGenericMap(inputQuat),
+		)
+		test.That(t, pose, test.ShouldResemble, expectedPose)
+		test.That(t, componentReference, test.ShouldEqual, "primarySensor1")
 	})
 
 	t.Run("non origin pose success", func(t *testing.T) {
+		svc.primarySensorName = "primarySensor2"
 		mockCartoFacade.GetPositionFunc = func(
 			ctx context.Context,
 			timeout time.Duration,
@@ -300,16 +334,18 @@ func TestGetPositionModularizationV2Endpoint(t *testing.T) {
 
 		inputPose = commonv1.Pose{X: 5, Y: 5, Z: 5, OX: 0, OY: 0, OZ: 1, Theta: 0}
 		inputQuat = map[string]interface{}{"real": 1.0, "imag": 1.0, "jmag": 0.0, "kmag": 0.0}
-		pose, _, err := svc.GetPosition(context.Background())
+		pose, componentReference, err := svc.GetPosition(context.Background())
 		test.That(t, err, test.ShouldBeNil)
 		expectedPose := spatialmath.NewPose(
 			r3.Vector{X: inputPose.X, Y: inputPose.Y, Z: inputPose.Z},
 			makeQuaternionFromGenericMap(inputQuat),
 		)
 		test.That(t, pose, test.ShouldResemble, expectedPose)
+		test.That(t, componentReference, test.ShouldEqual, "primarySensor2")
 	})
 
 	t.Run("error case", func(t *testing.T) {
+		svc.primarySensorName = "primarySensor3"
 		mockCartoFacade.GetPositionFunc = func(
 			ctx context.Context,
 			timeout time.Duration,
@@ -319,10 +355,11 @@ func TestGetPositionModularizationV2Endpoint(t *testing.T) {
 
 		inputPose = commonv1.Pose{X: 0, Y: 0, Z: 0, OX: 0, OY: 0, OZ: 1, Theta: 0}
 		inputQuat = map[string]interface{}{"real": 1.0, "imag": 0.0, "jmag": 0.0, "kmag": 0.0}
-		pose, _, err := svc.GetPosition(context.Background())
+		pose, componentReference, err := svc.GetPosition(context.Background())
 
 		test.That(t, err, test.ShouldBeError, errors.New("testError"))
 		test.That(t, pose, test.ShouldBeNil)
+		test.That(t, componentReference, test.ShouldEqual, "")
 	})
 }
 

--- a/viam-cartographer_internal_test.go
+++ b/viam-cartographer_internal_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"testing"
+	"time"
 
 	"github.com/edaniels/golog"
 	"github.com/golang/geo/r3"
@@ -239,6 +240,57 @@ func TestGetPositionEndpoint(t *testing.T) {
 			test.That(t, err.Error(), test.ShouldContainSubstring, "no GetPositionFunc defined for injected SLAM service client")
 			test.That(t, pose, test.ShouldBeNil)
 			test.That(t, componentRef, test.ShouldEqual, "")
+		})
+	})
+}
+
+func TestGetPositionModularizationV2Endpoint(t *testing.T) {
+	svc := &cartographerService{Named: resource.NewName(slam.API, "test").AsNamed()}
+	mockCartoFacade := &cartofacade.Mock{}
+	svc.cartofacade = mockCartoFacade
+	svc.modularizationV2Enabled = true
+
+	var inputPose commonv1.Pose
+	var inputQuat map[string]interface{}
+
+	t.Run("successful client", func(t *testing.T) {
+
+		t.Run("origin pose success", func(t *testing.T) {
+			mockCartoFacade.GetPositionFunc = func(
+				ctx context.Context,
+				timeout time.Duration,
+			) (cartofacade.GetPosition, error) {
+				return cartofacade.GetPosition{X: 0, Y: 0, Z: 0, Real: 1.0, Imag: 0.0, Jmag: 0.0, Kmag: 0.0}, nil
+			}
+
+			inputPose = commonv1.Pose{X: 0, Y: 0, Z: 0, OX: 0, OY: 0, OZ: 1, Theta: 0}
+			inputQuat = map[string]interface{}{"real": 1.0, "imag": 0.0, "jmag": 0.0, "kmag": 0.0}
+			pose, _, err := svc.GetPosition(context.Background())
+			test.That(t, err, test.ShouldBeNil)
+			expectedPose := spatialmath.NewPose(
+				r3.Vector{X: inputPose.X, Y: inputPose.Y, Z: inputPose.Z},
+				makeQuaternionFromGenericMap(inputQuat),
+			)
+			test.That(t, pose, test.ShouldResemble, expectedPose)
+		})
+
+		t.Run("non origin pose success", func(t *testing.T) {
+			mockCartoFacade.GetPositionFunc = func(
+				ctx context.Context,
+				timeout time.Duration,
+			) (cartofacade.GetPosition, error) {
+				return cartofacade.GetPosition{X: 5, Y: 5, Z: 5, Real: 1.0, Imag: 1.0, Jmag: 0.0, Kmag: 0.0}, nil
+			}
+
+			inputPose = commonv1.Pose{X: 5, Y: 5, Z: 5, OX: 0, OY: 0, OZ: 1, Theta: 0}
+			inputQuat = map[string]interface{}{"real": 1.0, "imag": 1.0, "jmag": 0.0, "kmag": 0.0}
+			pose, _, err := svc.GetPosition(context.Background())
+			test.That(t, err, test.ShouldBeNil)
+			expectedPose := spatialmath.NewPose(
+				r3.Vector{X: inputPose.X, Y: inputPose.Y, Z: inputPose.Z},
+				makeQuaternionFromGenericMap(inputQuat),
+			)
+			test.That(t, pose, test.ShouldResemble, expectedPose)
 		})
 	})
 }


### PR DESCRIPTION
[RSDK-3950](https://viam.atlassian.net/browse/RSDK-3950)

- If the modularizationV2Enabled feature flag is true, call into the new cartofacade API for getPosition
- Write unit tests to ensure new conversion returns the same values as the old conversions would have

[RSDK-3950]: https://viam.atlassian.net/browse/RSDK-3950?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ