### PR TITLE
[RSDK-2854] make-close-atomic-and-idempotent

### DIFF
--- a/viam-cartographer.go
+++ b/viam-cartographer.go
@@ -675,7 +675,7 @@ func (cartoSvc *cartographerService) Close(ctx context.Context) error {
 	cartoSvc.mu.Lock()
 	defer cartoSvc.mu.Unlock()
 	if cartoSvc.closed {
-		cartoSvc.logger.Warn("Close() called muliple times")
+		cartoSvc.logger.Warn("Close() called multiple times")
 		return nil
 	}
 	// TODO: Make this atomic & idempotent

--- a/viam-cartographer.go
+++ b/viam-cartographer.go
@@ -580,7 +580,7 @@ func (cartoSvc *cartographerService) GetLatestMapInfo(ctx context.Context) (time
 
 	if cartoSvc.closed {
 		cartoSvc.logger.Warn("GetLatestMapInfo called after closed")
-		return cartoSvc.mapTimestamp, ErrClosed
+		return time.Time{}, ErrClosed
 	}
 
 	return cartoSvc.mapTimestamp, nil

--- a/viam-cartographer.go
+++ b/viam-cartographer.go
@@ -683,7 +683,6 @@ func (cartoSvc *cartographerService) Close(ctx context.Context) error {
 		cartoSvc.logger.Warn("Close() called multiple times")
 		return nil
 	}
-	// TODO: Make this atomic & idempotent
 	if cartoSvc.modularizationV2Enabled {
 		// stop sensor process workers
 		cartoSvc.cancelSensorProcessFunc()

--- a/viam-cartographer_test.go
+++ b/viam-cartographer_test.go
@@ -629,7 +629,7 @@ func TestClose(t *testing.T) {
 	logger := golog.NewTestLogger(t)
 	ctx := context.Background()
 
-	t.Run("is idempotent and makes all endpoints return errors", func(t *testing.T) {
+	t.Run("is idempotent and makes all endpoints return closed errors", func(t *testing.T) {
 		dataDir, err := internaltesthelper.CreateTempFolderArchitecture(logger)
 		test.That(t, err, test.ShouldBeNil)
 
@@ -672,7 +672,7 @@ func TestClose(t *testing.T) {
 		test.That(t, err, test.ShouldBeError, viamcartographer.ErrClosed)
 	})
 
-	t.Run("is idempotent when feature flag enabled", func(t *testing.T) {
+	t.Run("is idempotent and makes all endpoints return closed errors when feature flag enabled", func(t *testing.T) {
 		termFunc := initTestCL(t, logger)
 		defer termFunc()
 

--- a/viam-cartographer_test.go
+++ b/viam-cartographer_test.go
@@ -647,6 +647,7 @@ func TestClose(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 
 		grpcServer.Stop()
+		// call twice, assert result is the same to prove idempotence
 		test.That(t, svc.Close(context.Background()), test.ShouldBeNil)
 		test.That(t, svc.Close(context.Background()), test.ShouldBeNil)
 
@@ -692,6 +693,7 @@ func TestClose(t *testing.T) {
 		svc, err := internaltesthelper.CreateSLAMService(t, attrCfg, logger, false, testExecutableName)
 		test.That(t, err, test.ShouldBeNil)
 
+		// call twice, assert result is the same to prove idempotence
 		test.That(t, svc.Close(context.Background()), test.ShouldBeNil)
 		test.That(t, svc.Close(context.Background()), test.ShouldBeNil)
 

--- a/viam-cartographer_test.go
+++ b/viam-cartographer_test.go
@@ -663,8 +663,9 @@ func TestClose(t *testing.T) {
 		test.That(t, gisF, test.ShouldBeNil)
 		test.That(t, err, test.ShouldBeError, viamcartographer.ErrClosed)
 
-		_, err = svc.GetLatestMapInfo(ctx)
+		mapTime, err := svc.GetLatestMapInfo(ctx)
 		test.That(t, err, test.ShouldBeError, viamcartographer.ErrClosed)
+		test.That(t, mapTime, test.ShouldResemble, time.Time{})
 
 		cmd := map[string]interface{}{}
 		resp, err := svc.DoCommand(ctx, cmd)
@@ -707,8 +708,9 @@ func TestClose(t *testing.T) {
 		test.That(t, gisF, test.ShouldBeNil)
 		test.That(t, err, test.ShouldBeError, viamcartographer.ErrClosed)
 
-		_, err = svc.GetLatestMapInfo(ctx)
+		mapTime, err := svc.GetLatestMapInfo(ctx)
 		test.That(t, err, test.ShouldBeError, viamcartographer.ErrClosed)
+		test.That(t, mapTime, test.ShouldResemble, time.Time{})
 
 		cmd := map[string]interface{}{}
 		resp, err := svc.DoCommand(ctx, cmd)

--- a/viam-cartographer_test.go
+++ b/viam-cartographer_test.go
@@ -83,7 +83,6 @@ func TestNew(t *testing.T) {
 
 	t.Run("Successful creation of cartographer slam service with no sensor", func(t *testing.T) {
 		grpcServer, port := setupTestGRPCServer(t)
-		test.That(t, err, test.ShouldBeNil)
 		attrCfg := &vcConfig.Config{
 			Sensors:       []string{},
 			ConfigParams:  map[string]string{"mode": "2d"},
@@ -101,7 +100,6 @@ func TestNew(t *testing.T) {
 
 	t.Run("Failed creation of cartographer slam service with more than one sensor", func(t *testing.T) {
 		grpcServer, port := setupTestGRPCServer(t)
-		test.That(t, err, test.ShouldBeNil)
 		attrCfg := &vcConfig.Config{
 			Sensors:       []string{"lidar", "one-too-many"},
 			ConfigParams:  map[string]string{"mode": "2d"},
@@ -625,6 +623,98 @@ func TestSLAMProcess(t *testing.T) {
 	})
 
 	internaltesthelper.ClearDirectory(t, dataDir)
+}
+
+func TestClose(t *testing.T) {
+	logger := golog.NewTestLogger(t)
+	ctx := context.Background()
+
+	t.Run("is idempotent and makes all endpoints return errors", func(t *testing.T) {
+		dataDir, err := internaltesthelper.CreateTempFolderArchitecture(logger)
+		test.That(t, err, test.ShouldBeNil)
+
+		grpcServer, port := setupTestGRPCServer(t)
+		test.That(t, err, test.ShouldBeNil)
+		attrCfg := &vcConfig.Config{
+			Sensors:       []string{},
+			ConfigParams:  map[string]string{"mode": "2d"},
+			DataDirectory: dataDir,
+			Port:          "localhost:" + strconv.Itoa(port),
+			UseLiveData:   &_false,
+		}
+
+		svc, err := internaltesthelper.CreateSLAMService(t, attrCfg, logger, false, testExecutableName)
+		test.That(t, err, test.ShouldBeNil)
+
+		grpcServer.Stop()
+		test.That(t, svc.Close(context.Background()), test.ShouldBeNil)
+		test.That(t, svc.Close(context.Background()), test.ShouldBeNil)
+
+		pose, componentRef, err := svc.GetPosition(ctx)
+		test.That(t, pose, test.ShouldBeNil)
+		test.That(t, componentRef, test.ShouldBeEmpty)
+		test.That(t, err, test.ShouldBeError, viamcartographer.ErrClosed)
+
+		gpcmF, err := svc.GetPointCloudMap(ctx)
+		test.That(t, gpcmF, test.ShouldBeNil)
+		test.That(t, err, test.ShouldBeError, viamcartographer.ErrClosed)
+
+		gisF, err := svc.GetInternalState(ctx)
+		test.That(t, gisF, test.ShouldBeNil)
+		test.That(t, err, test.ShouldBeError, viamcartographer.ErrClosed)
+
+		_, err = svc.GetLatestMapInfo(ctx)
+		test.That(t, err, test.ShouldBeError, viamcartographer.ErrClosed)
+
+		cmd := map[string]interface{}{}
+		resp, err := svc.DoCommand(ctx, cmd)
+		test.That(t, resp, test.ShouldBeNil)
+		test.That(t, err, test.ShouldBeError, viamcartographer.ErrClosed)
+	})
+
+	t.Run("is idempotent when feature flag enabled", func(t *testing.T) {
+		termFunc := initTestCL(t, logger)
+		defer termFunc()
+
+		dataDirectory, err := os.MkdirTemp("", "*")
+		test.That(t, err, test.ShouldBeNil)
+
+		attrCfg := &vcConfig.Config{
+			ModularizationV2Enabled: &_true,
+			Sensors:                 []string{"replay_sensor"},
+			ConfigParams:            map[string]string{"mode": "2d"},
+			DataDirectory:           dataDirectory,
+			UseLiveData:             &_false,
+			MapRateSec:              &testMapRateSec,
+		}
+
+		svc, err := internaltesthelper.CreateSLAMService(t, attrCfg, logger, false, testExecutableName)
+		test.That(t, err, test.ShouldBeNil)
+
+		test.That(t, svc.Close(context.Background()), test.ShouldBeNil)
+		test.That(t, svc.Close(context.Background()), test.ShouldBeNil)
+
+		pose, componentRef, err := svc.GetPosition(ctx)
+		test.That(t, pose, test.ShouldBeNil)
+		test.That(t, componentRef, test.ShouldBeEmpty)
+		test.That(t, err, test.ShouldBeError, viamcartographer.ErrClosed)
+
+		gpcmF, err := svc.GetPointCloudMap(ctx)
+		test.That(t, gpcmF, test.ShouldBeNil)
+		test.That(t, err, test.ShouldBeError, viamcartographer.ErrClosed)
+
+		gisF, err := svc.GetInternalState(ctx)
+		test.That(t, gisF, test.ShouldBeNil)
+		test.That(t, err, test.ShouldBeError, viamcartographer.ErrClosed)
+
+		_, err = svc.GetLatestMapInfo(ctx)
+		test.That(t, err, test.ShouldBeError, viamcartographer.ErrClosed)
+
+		cmd := map[string]interface{}{}
+		resp, err := svc.DoCommand(ctx, cmd)
+		test.That(t, resp, test.ShouldBeNil)
+		test.That(t, err, test.ShouldBeError, viamcartographer.ErrClosed)
+	})
 }
 
 func TestDoCommand(t *testing.T) {


### PR DESCRIPTION
[Ticket](https://viam.atlassian.net/browse/RSDK-2854)
1. Protect close with a mutex (atomic)
2. Have close return early if already closed (idempotent)
3. Ensure methods which will be called by the slam GRPC server return & log errors if called after the resource is closed