### PR TITLE
add jobs done file

### DIFF
--- a/viam-cartographer.go
+++ b/viam-cartographer.go
@@ -651,7 +651,6 @@ func (cartoSvc *cartographerService) getNextDataPoint(ctx context.Context, lidar
 		} else {
 			cartoSvc.logger.Warn(err)
 		}
-
 	}
 	if c != nil {
 		c <- 1


### PR DESCRIPTION
adds a jobs done file when the replay camera stops. additionally prevents cartographer from repeating the warning about the job being completed.

Additional issue is this file gets created when all lidar scans are read into the job, but this does not mean that all lidar scans have been processed

unsure of interactions with full mod and interactions with a live replay camera