### PR TITLE
RSDK-3965 - call into cgo for getPointCloudMap

### DIFF
--- a/viam-cartographer.go
+++ b/viam-cartographer.go
@@ -549,13 +549,14 @@ func (cartoSvc *cartographerService) GetPointCloudMap(ctx context.Context) (func
 	ctx, span := trace.StartSpan(ctx, "viamcartographer::cartographerService::GetPointCloudMap")
 	defer span.End()
 
-  if cartoSvc.closed {
+	if cartoSvc.closed {
 		cartoSvc.logger.Warn("GetPointCloudMap called after closed")
 		return nil, ErrClosed
 	}
-  
+
 	if cartoSvc.modularizationV2Enabled {
 		return cartoSvc.getPointCloudMapModularizationV2(ctx)
+	}
 
 	if !cartoSvc.localizationMode {
 		cartoSvc.mapTimestamp = time.Now().UTC()

--- a/viam-cartographer.go
+++ b/viam-cartographer.go
@@ -38,9 +38,8 @@ import (
 
 // Model is the model name of cartographer.
 var (
-	Model          = resource.NewModel("viam", "slam", "cartographer")
-	cartoLib       cartofacade.CartoLib
-	chunkSizeBytes = 1 * 1024 * 1024
+	Model    = resource.NewModel("viam", "slam", "cartographer")
+	cartoLib cartofacade.CartoLib
 	// ErrClosed denotes that the slam service method was called on a closed slam resource.
 	ErrClosed = errors.Errorf("resource (%s) is closed", Model.String())
 )
@@ -56,6 +55,7 @@ const (
 	parsePortMaxTimeoutSec               = 60
 	localhost0                           = "localhost:0"
 	defaultCartoFacadeTimeout            = 5 * time.Second
+	chunkSizeBytes                       = 1 * 1024 * 1024
 )
 
 var defaultCartoAlgoCfg = cartofacade.CartoAlgoConfig{
@@ -557,12 +557,12 @@ func (cartoSvc *cartographerService) GetPointCloudMap(ctx context.Context) (func
 		return nil, ErrClosed
 	}
 
-	if cartoSvc.modularizationV2Enabled {
-		return cartoSvc.getPointCloudMapModularizationV2(ctx)
-	}
-
 	if !cartoSvc.localizationMode {
 		cartoSvc.mapTimestamp = time.Now().UTC()
+	}
+
+	if cartoSvc.modularizationV2Enabled {
+		return cartoSvc.getPointCloudMapModularizationV2(ctx)
 	}
 	return grpchelper.GetPointCloudMapCallback(ctx, cartoSvc.Name().ShortName(), cartoSvc.clientAlgo)
 }

--- a/viam-cartographer_internal_test.go
+++ b/viam-cartographer_internal_test.go
@@ -3,6 +3,7 @@ package viamcartographer
 import (
 	"bytes"
 	"context"
+	"os"
 	"testing"
 	"time"
 
@@ -15,6 +16,7 @@ import (
 	"go.viam.com/rdk/services/slam"
 	"go.viam.com/rdk/spatialmath"
 	"go.viam.com/test"
+	"go.viam.com/utils/artifact"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/structpb"
 
@@ -447,11 +449,15 @@ func TestGetPointCloudMapEndpointModularizationV2Endpoint(t *testing.T) {
 	svc.cartofacade = mockCartoFacade
 	svc.modularizationV2Enabled = true
 
-	inputPointCloudMapBytes := []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
-	setMockGetPointCloudFunc(mockCartoFacade, inputPointCloudMapBytes)
+	var inputPointCloudMapBytes = []byte{}
 
-	t.Run("small chunk size success", func(t *testing.T) {
-		chunkSizeBytes = 1
+	t.Run("pointcloud smaller than 1 mb limit - success", func(t *testing.T) {
+		file := "viam-cartographer/outputs/viam-office-02-22-3/pointcloud/pointcloud_0.pcd"
+		inputPointCloudMapBytes, err := os.ReadFile(artifact.MustPath(file))
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, len(inputPointCloudMapBytes), test.ShouldBeLessThan, 1024*1024)
+
+		setMockGetPointCloudFunc(mockCartoFacade, inputPointCloudMapBytes)
 		callback, err := svc.GetPointCloudMap(context.Background())
 		test.That(t, err, test.ShouldBeNil)
 		pointCloudMapBytes, err := slam.HelperConcatenateChunksToFull(callback)
@@ -459,8 +465,13 @@ func TestGetPointCloudMapEndpointModularizationV2Endpoint(t *testing.T) {
 		test.That(t, pointCloudMapBytes, test.ShouldResemble, inputPointCloudMapBytes)
 	})
 
-	t.Run("large chunk size success", func(t *testing.T) {
-		chunkSizeBytes = 100
+	t.Run("pointcloud larger than 1 mb limit - success", func(t *testing.T) {
+		file := "viam-cartographer/outputs/viam-office-02-22-3/pointcloud/pointcloud_1.pcd"
+		inputPointCloudMapBytes, err := os.ReadFile(artifact.MustPath(file))
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, len(inputPointCloudMapBytes), test.ShouldBeGreaterThan, 1024*1024)
+
+		setMockGetPointCloudFunc(mockCartoFacade, inputPointCloudMapBytes)
 		callback, err := svc.GetPointCloudMap(context.Background())
 		test.That(t, err, test.ShouldBeNil)
 		pointCloudMapBytes, err := slam.HelperConcatenateChunksToFull(callback)
@@ -469,15 +480,8 @@ func TestGetPointCloudMapEndpointModularizationV2Endpoint(t *testing.T) {
 	})
 
 	t.Run("no bytes success", func(t *testing.T) {
-		chunkSizeBytes = 1
 		inputPointCloudMapBytes = []byte{}
-
-		mockCartoFacade.GetPointCloudMapFunc = func(
-			ctx context.Context,
-			timeout time.Duration,
-		) ([]byte, error) {
-			return inputPointCloudMapBytes, nil
-		}
+		setMockGetPointCloudFunc(mockCartoFacade, inputPointCloudMapBytes)
 
 		callback, err := svc.GetPointCloudMap(context.Background())
 		test.That(t, err, test.ShouldBeNil)
@@ -487,8 +491,8 @@ func TestGetPointCloudMapEndpointModularizationV2Endpoint(t *testing.T) {
 	})
 
 	t.Run("cartofacade error", func(t *testing.T) {
-		chunkSizeBytes = 1
 		inputPointCloudMapBytes = []byte{}
+		setMockGetPointCloudFunc(mockCartoFacade, inputPointCloudMapBytes)
 
 		mockCartoFacade.GetPointCloudMapFunc = func(
 			ctx context.Context,

--- a/viam-cartographer_internal_test.go
+++ b/viam-cartographer_internal_test.go
@@ -449,7 +449,7 @@ func TestGetPointCloudMapEndpointModularizationV2Endpoint(t *testing.T) {
 	svc.cartofacade = mockCartoFacade
 	svc.modularizationV2Enabled = true
 
-	var inputPointCloudMapBytes = []byte{}
+	inputPointCloudMapBytes := []byte{}
 
 	t.Run("pointcloud smaller than 1 mb limit - success", func(t *testing.T) {
 		file := "viam-cartographer/outputs/viam-office-02-22-3/pointcloud/pointcloud_0.pcd"

--- a/viam-cartographer_internal_test.go
+++ b/viam-cartographer_internal_test.go
@@ -449,8 +449,6 @@ func TestGetPointCloudMapEndpointModularizationV2Endpoint(t *testing.T) {
 	svc.cartofacade = mockCartoFacade
 	svc.modularizationV2Enabled = true
 
-	inputPointCloudMapBytes := []byte{}
-
 	t.Run("pointcloud smaller than 1 mb limit - success", func(t *testing.T) {
 		file := "viam-cartographer/outputs/viam-office-02-22-3/pointcloud/pointcloud_0.pcd"
 		inputPointCloudMapBytes, err := os.ReadFile(artifact.MustPath(file))
@@ -480,8 +478,7 @@ func TestGetPointCloudMapEndpointModularizationV2Endpoint(t *testing.T) {
 	})
 
 	t.Run("no bytes success", func(t *testing.T) {
-		inputPointCloudMapBytes = []byte{}
-		setMockGetPointCloudFunc(mockCartoFacade, inputPointCloudMapBytes)
+		setMockGetPointCloudFunc(mockCartoFacade, []byte{})
 
 		callback, err := svc.GetPointCloudMap(context.Background())
 		test.That(t, err, test.ShouldBeNil)
@@ -491,8 +488,7 @@ func TestGetPointCloudMapEndpointModularizationV2Endpoint(t *testing.T) {
 	})
 
 	t.Run("cartofacade error", func(t *testing.T) {
-		inputPointCloudMapBytes = []byte{}
-		setMockGetPointCloudFunc(mockCartoFacade, inputPointCloudMapBytes)
+		setMockGetPointCloudFunc(mockCartoFacade, []byte{})
 
 		mockCartoFacade.GetPointCloudMapFunc = func(
 			ctx context.Context,

--- a/viam-cartographer_test.go
+++ b/viam-cartographer_test.go
@@ -390,7 +390,7 @@ func TestNew(t *testing.T) {
 		// timestamp1, err := svc.GetLatestMapInfo(context.Background())
 		// test.That(t, err, test.ShouldBeNil)
 		_, err = svc.GetPointCloudMap(context.Background())
-		test.That(t, err, test.ShouldBeNil)
+		test.That(t, err, test.ShouldBeError, errors.New("VIAM_CARTO_POINTCLOUD_MAP_EMPTY"))
 		// timestamp2, err := svc.GetLatestMapInfo(context.Background())
 		// test.That(t, err, test.ShouldBeNil)
 

--- a/viam-cartographer_test.go
+++ b/viam-cartographer_test.go
@@ -210,15 +210,7 @@ func TestNew(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 
 		timestamp1, err := svc.GetLatestMapInfo(context.Background())
-		logger := golog.NewDebugLogger("testing")
 		logger.Infof("timestamp1 = %v\n", timestamp1)
-		test.That(t, err, test.ShouldBeNil)
-		pcmFunc, err := svc.GetPointCloudMap(context.Background())
-		pcm, err := slam.HelperConcatenateChunksToFull(pcmFunc)
-		test.That(t, err, test.ShouldBeNil)
-
-		logger.Infof("pcm = %v\n", pcm)
-		t.Fatal()
 		test.That(t, err, test.ShouldBeNil)
 		timestamp2, err := svc.GetLatestMapInfo(context.Background())
 		test.That(t, err, test.ShouldBeNil)

--- a/viam-cartographer_test.go
+++ b/viam-cartographer_test.go
@@ -390,7 +390,6 @@ func TestNew(t *testing.T) {
 
 		svc, err := internaltesthelper.CreateSLAMService(t, attrCfg, logger, false, testExecutableName)
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, err, test.ShouldBeNil)
 
 		// TODO: Implement these
 		_, componentReference, err := svc.GetPosition(context.Background())

--- a/viam-cartographer_test.go
+++ b/viam-cartographer_test.go
@@ -360,10 +360,17 @@ func TestNew(t *testing.T) {
 		_, componentReference, err := svc.GetPosition(context.Background())
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, componentReference, test.ShouldEqual, "replay_sensor")
+
 		// timestamp1, err := svc.GetLatestMapInfo(context.Background())
 		// test.That(t, err, test.ShouldBeNil)
-		_, err = svc.GetPointCloudMap(context.Background())
+
+		pcmFunc, err := svc.GetPointCloudMap(context.Background())
 		test.That(t, err, test.ShouldBeNil)
+
+		pcm, err := slam.HelperConcatenateChunksToFull(pcmFunc)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, pcm, test.ShouldNotBeNil)
+
 		// timestamp2, err := svc.GetLatestMapInfo(context.Background())
 		// test.That(t, err, test.ShouldBeNil)
 		// test.That(t, timestamp1.After(_zeroTime), test.ShouldBeTrue)
@@ -396,11 +403,17 @@ func TestNew(t *testing.T) {
 		_, componentReference, err := svc.GetPosition(context.Background())
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, componentReference, test.ShouldEqual, "good_lidar")
+
 		// timestamp1, err := svc.GetLatestMapInfo(context.Background())
 		// test.That(t, err, test.ShouldBeNil)
-		_, err = svc.GetPointCloudMap(context.Background())
+
+		pcmFunc, err := svc.GetPointCloudMap(context.Background())
 		test.That(t, err, test.ShouldBeNil)
-		// test.That(t, err, test.ShouldBeError, errors.New("VIAM_CARTO_POINTCLOUD_MAP_EMPTY"))
+
+		pcm, err := slam.HelperConcatenateChunksToFull(pcmFunc)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, pcm, test.ShouldNotBeNil)
+
 		// timestamp2, err := svc.GetLatestMapInfo(context.Background())
 		// test.That(t, err, test.ShouldBeNil)
 

--- a/viam-cartographer_test.go
+++ b/viam-cartographer_test.go
@@ -349,6 +349,9 @@ func TestNew(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 
 		// TODO: Implement these
+		_, componentReference, err := svc.GetPosition(context.Background())
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, componentReference, test.ShouldEqual, "replay_sensor")
 		// timestamp1, err := svc.GetLatestMapInfo(context.Background())
 		// test.That(t, err, test.ShouldBeNil)
 		_, err = svc.GetPointCloudMap(context.Background())
@@ -381,10 +384,13 @@ func TestNew(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 
 		// TODO: Implement these
+		_, componentReference, err := svc.GetPosition(context.Background())
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, componentReference, test.ShouldEqual, "replay_sensor")
 		// timestamp1, err := svc.GetLatestMapInfo(context.Background())
 		// test.That(t, err, test.ShouldBeNil)
-		// _, err = svc.GetPointCloudMap(context.Background())
-		// test.That(t, err, test.ShouldBeNil)
+		_, err = svc.GetPointCloudMap(context.Background())
+		test.That(t, err, test.ShouldBeNil)
 		// timestamp2, err := svc.GetLatestMapInfo(context.Background())
 		// test.That(t, err, test.ShouldBeNil)
 

--- a/viam-cartographer_test.go
+++ b/viam-cartographer_test.go
@@ -210,7 +210,8 @@ func TestNew(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 
 		timestamp1, err := svc.GetLatestMapInfo(context.Background())
-		logger.Infof("timestamp1 = %v\n", timestamp1)
+		test.That(t, err, test.ShouldBeNil)
+		_, err = svc.GetPointCloudMap(context.Background())
 		test.That(t, err, test.ShouldBeNil)
 		timestamp2, err := svc.GetLatestMapInfo(context.Background())
 		test.That(t, err, test.ShouldBeNil)

--- a/viam-cartographer_test.go
+++ b/viam-cartographer_test.go
@@ -353,8 +353,8 @@ func TestNew(t *testing.T) {
 		// TODO: Implement these
 		// timestamp1, err := svc.GetLatestMapInfo(context.Background())
 		// test.That(t, err, test.ShouldBeNil)
-		// _, err = svc.GetPointCloudMap(context.Background())
-		// test.That(t, err, test.ShouldBeNil)
+		_, err = svc.GetPointCloudMap(context.Background())
+		test.That(t, err, test.ShouldBeNil)
 		// timestamp2, err := svc.GetLatestMapInfo(context.Background())
 		// test.That(t, err, test.ShouldBeNil)
 		// test.That(t, timestamp1.After(_zeroTime), test.ShouldBeTrue)


### PR DESCRIPTION
[RSDK-3695](https://viam.atlassian.net/browse/RSDK-3965)
- If the modularizationV2Enabled feature flag is true, call into the new cartofacade API for GetPointCloudMap
- Write unit tests to make sure cgo is returning the same output that the original code would have

[RSDK-3695]: https://viam.atlassian.net/browse/RSDK-3695?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ