### PR TITLE
RSDK-3992 - call into cgo for GetInternalState

### DIFF
--- a/viam-cartographer.go
+++ b/viam-cartographer.go
@@ -560,7 +560,30 @@ func (cartoSvc *cartographerService) GetPointCloudMap(ctx context.Context) (func
 	if !cartoSvc.localizationMode {
 		cartoSvc.mapTimestamp = time.Now().UTC()
 	}
+
+	if cartoSvc.modularizationV2Enabled {
+		return cartoSvc.getPointCloudMapModularizationV2(ctx)
+	}
 	return grpchelper.GetPointCloudMapCallback(ctx, cartoSvc.Name().ShortName(), cartoSvc.clientAlgo)
+}
+
+func (cartoSvc *cartographerService) getPointCloudMapModularizationV2(ctx context.Context) (func() ([]byte, error), error) {
+	chunk := make([]byte, chunkSizeBytes)
+	pc, err := cartoSvc.cartofacade.GetPointCloudMap(ctx, cartoSvc.cartoFacadeTimeout)
+	if err != nil {
+		return nil, err
+	}
+
+	pointcloudReader := bytes.NewReader(pc)
+
+	f := func() ([]byte, error) {
+		bytesRead, err := pointcloudReader.Read(chunk)
+		if err != nil {
+			return nil, err
+		}
+		return chunk[:bytesRead], err
+	}
+	return f, nil
 }
 
 // GetInternalState creates a request, calls the slam algorithms GetInternalState endpoint and returns a callback

--- a/viam-cartographer_internal_test.go
+++ b/viam-cartographer_internal_test.go
@@ -460,14 +460,14 @@ func testApisThatReturnCallbackFuncsSuccess(
 	}
 
 	setMockFunc(mockCartoFacade, bytes)
-
-	getAndCheckCallbackFunc(t, api, false)
+	getAndCheckCallbackFunc(t, api, false, bytes)
 }
 
 func getAndCheckCallbackFunc(
 	t *testing.T,
 	api func(context.Context) (func() ([]byte, error), error),
 	emptyBytes bool,
+	inputBytes []byte,
 ) {
 	callback, err := api(context.Background())
 	test.That(t, err, test.ShouldBeNil)
@@ -478,6 +478,7 @@ func getAndCheckCallbackFunc(
 		test.That(t, bytes, test.ShouldBeNil)
 	} else {
 		test.That(t, bytes, test.ShouldNotBeNil)
+		test.That(t, bytes, test.ShouldResemble, inputBytes)
 	}
 }
 
@@ -519,7 +520,7 @@ func testApisThatReturnCallbackFuncs(
 
 	t.Run("no bytes success", func(t *testing.T) {
 		setMockFunc(mockCartoFacade, []byte{})
-		getAndCheckCallbackFunc(t, api, true)
+		getAndCheckCallbackFunc(t, api, true, []byte{})
 	})
 }
 

--- a/viam-cartographer_internal_test.go
+++ b/viam-cartographer_internal_test.go
@@ -445,47 +445,17 @@ func setMockGetPointCloudFunc(
 func TestGetPointCloudMapEndpointModularizationV2Endpoint(t *testing.T) {
 	svc := &cartographerService{Named: resource.NewName(slam.API, "test").AsNamed()}
 	mockCartoFacade := &cartofacade.Mock{}
-
-	svc.cartofacade = mockCartoFacade
-	svc.modularizationV2Enabled = true
-
-	t.Run("pointcloud smaller than 1 mb limit - success", func(t *testing.T) {
-		file := "viam-cartographer/outputs/viam-office-02-22-3/pointcloud/pointcloud_0.pcd"
-		inputPointCloudMapBytes, err := os.ReadFile(artifact.MustPath(file))
-		test.That(t, err, test.ShouldBeNil)
-		test.That(t, len(inputPointCloudMapBytes), test.ShouldBeLessThan, 1024*1024)
-
-		setMockGetPointCloudFunc(mockCartoFacade, inputPointCloudMapBytes)
-		callback, err := svc.GetPointCloudMap(context.Background())
-		test.That(t, err, test.ShouldBeNil)
-		pointCloudMapBytes, err := slam.HelperConcatenateChunksToFull(callback)
-		test.That(t, err, test.ShouldBeNil)
-		test.That(t, pointCloudMapBytes, test.ShouldResemble, inputPointCloudMapBytes)
-	})
-
-	t.Run("pointcloud larger than 1 mb limit - success", func(t *testing.T) {
-		file := "viam-cartographer/outputs/viam-office-02-22-3/pointcloud/pointcloud_1.pcd"
-		inputPointCloudMapBytes, err := os.ReadFile(artifact.MustPath(file))
-		test.That(t, err, test.ShouldBeNil)
-		test.That(t, len(inputPointCloudMapBytes), test.ShouldBeGreaterThan, 1024*1024)
-
-		setMockGetPointCloudFunc(mockCartoFacade, inputPointCloudMapBytes)
-		callback, err := svc.GetPointCloudMap(context.Background())
-		test.That(t, err, test.ShouldBeNil)
-		pointCloudMapBytes, err := slam.HelperConcatenateChunksToFull(callback)
-		test.That(t, err, test.ShouldBeNil)
-		test.That(t, pointCloudMapBytes, test.ShouldResemble, inputPointCloudMapBytes)
-	})
-
-	t.Run("no bytes success", func(t *testing.T) {
-		setMockGetPointCloudFunc(mockCartoFacade, []byte{})
-
-		callback, err := svc.GetPointCloudMap(context.Background())
-		test.That(t, err, test.ShouldBeNil)
-		pointCloudMapBytes, err := slam.HelperConcatenateChunksToFull(callback)
-		test.That(t, err, test.ShouldBeNil)
-		test.That(t, pointCloudMapBytes, test.ShouldBeNil)
-	})
+	pathToFileLargerThanChunkSize := "viam-cartographer/outputs/viam-office-02-22-3/pointcloud/pointcloud_0.pcd"
+	pathToFileSmallerThanChunkSize := "viam-cartographer/outputs/viam-office-02-22-3/pointcloud/pointcloud_1.pcd"
+	testApisThatReturnCallbackFuncs(
+		t,
+		svc,
+		mockCartoFacade,
+		pathToFileLargerThanChunkSize,
+		pathToFileSmallerThanChunkSize,
+		svc.GetPointCloudMap,
+		setMockGetPointCloudFunc,
+	)
 
 	t.Run("cartofacade error", func(t *testing.T) {
 		setMockGetPointCloudFunc(mockCartoFacade, []byte{})
@@ -594,50 +564,100 @@ func setMockGetInternalStateFunc(
 	}
 }
 
-func TestGetInternalStateModularizationV2Endpoint(t *testing.T) {
-	svc := &cartographerService{Named: resource.NewName(slam.API, "test").AsNamed()}
-	mockCartoFacade := &cartofacade.Mock{}
+func testApisThatReturnCallbackFuncsSuccess(
+	t *testing.T,
+	path string,
+	setMockFunc func(*cartofacade.Mock, []byte),
+	mockCartoFacade *cartofacade.Mock,
+	api func(context.Context) (func() ([]byte, error), error),
+	fileIsLargerThanChunkSize bool,
+) {
+	bytes, err := os.ReadFile(artifact.MustPath(path))
+	test.That(t, err, test.ShouldBeNil)
 
+	if fileIsLargerThanChunkSize {
+		test.That(t, len(bytes), test.ShouldBeGreaterThan, 1024*1024)
+	} else {
+		test.That(t, len(bytes), test.ShouldBeLessThan, 1024*1024)
+	}
+
+	setMockFunc(mockCartoFacade, bytes)
+
+	getAndCheckCallbackFunc(t, api, false)
+}
+
+func getAndCheckCallbackFunc(
+	t *testing.T,
+	api func(context.Context) (func() ([]byte, error), error),
+	emptyBytes bool,
+) {
+	callback, err := api(context.Background())
+	test.That(t, err, test.ShouldBeNil)
+	bytes, err := slam.HelperConcatenateChunksToFull(callback)
+	test.That(t, err, test.ShouldBeNil)
+	if emptyBytes {
+		test.That(t, bytes, test.ShouldBeNil)
+	} else {
+		test.That(t, bytes, test.ShouldNotBeNil)
+	}
+}
+
+func testApisThatReturnCallbackFuncs(
+	t *testing.T,
+	svc *cartographerService,
+	mockCartoFacade *cartofacade.Mock,
+	pathToFileLargerThanChunkSize string,
+	pathToFileSmallerThanChunkSize string,
+	api func(context.Context) (func() ([]byte, error), error),
+	setMockFunc func(*cartofacade.Mock, []byte),
+) {
 	svc.cartofacade = mockCartoFacade
 	svc.modularizationV2Enabled = true
 
-	t.Run("pointcloud smaller than 1 mb limit - success", func(t *testing.T) {
-		file := "viam-cartographer/outputs/viam-office-02-22-3/internal_state/internal_state_0.pbstream"
-		inputInternalStateBytes, err := os.ReadFile(artifact.MustPath(file))
-		test.That(t, err, test.ShouldBeNil)
-		test.That(t, len(inputInternalStateBytes), test.ShouldBeLessThan, 1024*1024)
-
-		setMockGetInternalStateFunc(mockCartoFacade, inputInternalStateBytes)
-		callback, err := svc.GetInternalState(context.Background())
-		test.That(t, err, test.ShouldBeNil)
-		pointCloudMapBytes, err := slam.HelperConcatenateChunksToFull(callback)
-		test.That(t, err, test.ShouldBeNil)
-		test.That(t, pointCloudMapBytes, test.ShouldResemble, inputInternalStateBytes)
+	t.Run("returned value smaller than 1 mb limit - success", func(t *testing.T) {
+		path := pathToFileLargerThanChunkSize
+		testApisThatReturnCallbackFuncsSuccess(
+			t,
+			path,
+			setMockFunc,
+			mockCartoFacade,
+			api,
+			false,
+		)
 	})
 
-	t.Run("pointcloud larger than 1 mb limit - success", func(t *testing.T) {
-		file := "viam-cartographer/outputs/viam-office-02-22-3/internal_state/internal_state_1.pbstream"
-		inputInternalStateBytes, err := os.ReadFile(artifact.MustPath(file))
-		test.That(t, err, test.ShouldBeNil)
-		test.That(t, len(inputInternalStateBytes), test.ShouldBeGreaterThan, 1024*1024)
-
-		setMockGetInternalStateFunc(mockCartoFacade, inputInternalStateBytes)
-		callback, err := svc.GetInternalState(context.Background())
-		test.That(t, err, test.ShouldBeNil)
-		internalStateBytes, err := slam.HelperConcatenateChunksToFull(callback)
-		test.That(t, err, test.ShouldBeNil)
-		test.That(t, internalStateBytes, test.ShouldResemble, inputInternalStateBytes)
+	t.Run("returned value larger than 1 mb limit - success", func(t *testing.T) {
+		path := pathToFileSmallerThanChunkSize
+		testApisThatReturnCallbackFuncsSuccess(
+			t,
+			path,
+			setMockFunc,
+			mockCartoFacade,
+			api,
+			true,
+		)
 	})
 
 	t.Run("no bytes success", func(t *testing.T) {
-		setMockGetInternalStateFunc(mockCartoFacade, []byte{})
-
-		callback, err := svc.GetInternalState(context.Background())
-		test.That(t, err, test.ShouldBeNil)
-		internalStateBytes, err := slam.HelperConcatenateChunksToFull(callback)
-		test.That(t, err, test.ShouldBeNil)
-		test.That(t, internalStateBytes, test.ShouldBeNil)
+		setMockFunc(mockCartoFacade, []byte{})
+		getAndCheckCallbackFunc(t, api, true)
 	})
+}
+
+func TestGetInternalStateModularizationV2Endpoint(t *testing.T) {
+	svc := &cartographerService{Named: resource.NewName(slam.API, "test").AsNamed()}
+	mockCartoFacade := &cartofacade.Mock{}
+	pathToFileLargerThanChunkSize := "viam-cartographer/outputs/viam-office-02-22-3/internal_state/internal_state_0.pbstream"
+	pathToFileSmallerThanChunkSize := "viam-cartographer/outputs/viam-office-02-22-3/internal_state/internal_state_1.pbstream"
+	testApisThatReturnCallbackFuncs(
+		t,
+		svc,
+		mockCartoFacade,
+		pathToFileLargerThanChunkSize,
+		pathToFileSmallerThanChunkSize,
+		svc.GetInternalState,
+		setMockGetInternalStateFunc,
+	)
 
 	t.Run("cartofacade error", func(t *testing.T) {
 		setMockGetInternalStateFunc(mockCartoFacade, []byte{})

--- a/viam-cartographer_test.go
+++ b/viam-cartographer_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/edaniels/golog"
 	"github.com/pkg/errors"
 	viamgrpc "go.viam.com/rdk/grpc"
+	"go.viam.com/rdk/services/slam"
 	"go.viam.com/test"
 	"go.viam.com/utils/artifact"
 	"google.golang.org/grpc"
@@ -349,10 +350,27 @@ func TestNew(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 
 		// TODO: Implement these
+		_, componentReference, err := svc.GetPosition(context.Background())
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, componentReference, test.ShouldEqual, "replay_sensor")
+
 		// timestamp1, err := svc.GetLatestMapInfo(context.Background())
 		// test.That(t, err, test.ShouldBeNil)
-		// _, err = svc.GetPointCloudMap(context.Background())
+
+		// pcmFunc, err := svc.GetPointCloudMap(context.Background())
 		// test.That(t, err, test.ShouldBeNil)
+
+		// pcm, err := slam.HelperConcatenateChunksToFull(pcmFunc)
+		// test.That(t, err, test.ShouldBeNil)
+		// test.That(t, pcm, test.ShouldNotBeNil)
+
+		isFunc, err := svc.GetInternalState(context.Background())
+		test.That(t, err, test.ShouldBeNil)
+
+		is, err := slam.HelperConcatenateChunksToFull(isFunc)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, is, test.ShouldNotBeNil)
+
 		// timestamp2, err := svc.GetLatestMapInfo(context.Background())
 		// test.That(t, err, test.ShouldBeNil)
 		// test.That(t, timestamp1.After(_zeroTime), test.ShouldBeTrue)
@@ -365,26 +383,43 @@ func TestNew(t *testing.T) {
 		termFunc := initTestCL(t, logger)
 		defer termFunc()
 
-		dataDirectory, err := os.MkdirTemp("", "*")
-		test.That(t, err, test.ShouldBeNil)
+		dataDirectory, fsCleanupFunc := initInternalState(t)
+		defer fsCleanupFunc()
 
 		attrCfg := &vcConfig.Config{
 			ModularizationV2Enabled: &_true,
-			Sensors:                 []string{"replay_sensor"},
+			Sensors:                 []string{"good_lidar"},
 			ConfigParams:            map[string]string{"mode": "2d"},
 			DataDirectory:           dataDirectory,
-			UseLiveData:             &_false,
-			MapRateSec:              &testMapRateSec,
+			DataRateMsec:            testDataRateMsec,
+			UseLiveData:             &_true,
 		}
 
 		svc, err := internaltesthelper.CreateSLAMService(t, attrCfg, logger, false, testExecutableName)
 		test.That(t, err, test.ShouldBeNil)
 
 		// TODO: Implement these
+		_, componentReference, err := svc.GetPosition(context.Background())
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, componentReference, test.ShouldEqual, "good_lidar")
+
 		// timestamp1, err := svc.GetLatestMapInfo(context.Background())
 		// test.That(t, err, test.ShouldBeNil)
-		// _, err = svc.GetPointCloudMap(context.Background())
+
+		// pcmFunc, err := svc.GetPointCloudMap(context.Background())
 		// test.That(t, err, test.ShouldBeNil)
+
+		// pcm, err := slam.HelperConcatenateChunksToFull(pcmFunc)
+		// test.That(t, err, test.ShouldBeNil)
+		// test.That(t, pcm, test.ShouldNotBeNil)
+
+		isFunc, err := svc.GetInternalState(context.Background())
+		test.That(t, err, test.ShouldBeNil)
+
+		is, err := slam.HelperConcatenateChunksToFull(isFunc)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, is, test.ShouldNotBeNil)
+
 		// timestamp2, err := svc.GetLatestMapInfo(context.Background())
 		// test.That(t, err, test.ShouldBeNil)
 

--- a/viam-cartographer_test.go
+++ b/viam-cartographer_test.go
@@ -357,12 +357,12 @@ func TestNew(t *testing.T) {
 		// timestamp1, err := svc.GetLatestMapInfo(context.Background())
 		// test.That(t, err, test.ShouldBeNil)
 
-		// pcmFunc, err := svc.GetPointCloudMap(context.Background())
-		// test.That(t, err, test.ShouldBeNil)
+		pcmFunc, err := svc.GetPointCloudMap(context.Background())
+		test.That(t, err, test.ShouldBeNil)
 
-		// pcm, err := slam.HelperConcatenateChunksToFull(pcmFunc)
-		// test.That(t, err, test.ShouldBeNil)
-		// test.That(t, pcm, test.ShouldNotBeNil)
+		pcm, err := slam.HelperConcatenateChunksToFull(pcmFunc)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, pcm, test.ShouldNotBeNil)
 
 		isFunc, err := svc.GetInternalState(context.Background())
 		test.That(t, err, test.ShouldBeNil)
@@ -406,12 +406,12 @@ func TestNew(t *testing.T) {
 		// timestamp1, err := svc.GetLatestMapInfo(context.Background())
 		// test.That(t, err, test.ShouldBeNil)
 
-		// pcmFunc, err := svc.GetPointCloudMap(context.Background())
-		// test.That(t, err, test.ShouldBeNil)
+		pcmFunc, err := svc.GetPointCloudMap(context.Background())
+		test.That(t, err, test.ShouldBeNil)
 
-		// pcm, err := slam.HelperConcatenateChunksToFull(pcmFunc)
-		// test.That(t, err, test.ShouldBeNil)
-		// test.That(t, pcm, test.ShouldNotBeNil)
+		pcm, err := slam.HelperConcatenateChunksToFull(pcmFunc)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, pcm, test.ShouldNotBeNil)
 
 		isFunc, err := svc.GetInternalState(context.Background())
 		test.That(t, err, test.ShouldBeNil)


### PR DESCRIPTION
[Ticket](https://viam.atlassian.net/browse/RSDK-3992)
- If the modularizationV2Enabled feature flag is true, call into the new cartofacade API for GetInternalState
- Write unit tests to make sure cgo is returning the same output that the original code would have