### PR TITLE
[RSDK-3546] update-full-mod-integration-tests

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -73,6 +73,7 @@ func testCartographerFullModPosition(t *testing.T, svc slam.Service, expectedCom
 
 	actualPos := position.Point()
 	t.Logf("Position point: (%v, %v, %v)", actualPos.X, actualPos.Y, actualPos.Z)
+	// https://viam.atlassian.net/browse/RSDK-3866
 	// mac
 	if actualPos.X > expectedPosOSX.X-tolerancePos && actualPos.X < expectedPosOSX.X+tolerancePos {
 		test.That(t, actualPos.Y, test.ShouldBeBetween, expectedPosOSX.Y-tolerancePos, expectedPosOSX.Y+tolerancePos)

--- a/integration_test.go
+++ b/integration_test.go
@@ -156,7 +156,6 @@ func testHelperCartographerFullMod(
 	mapRateSec int,
 	expectedMode cartofacade.SlamMode,
 ) []byte {
-	t.Helper()
 	termFunc := internaltesthelper.InitTestCL(t, logger)
 	defer termFunc()
 
@@ -216,7 +215,6 @@ func testHelperCartographerFullMod(
 }
 
 func integrationtestHelperCartographerFullMod(t *testing.T, subAlgo viamcartographer.SubAlgo) {
-	t.Helper()
 	logger := golog.NewTestLogger(t)
 	t.Run("live sensor mapping mode", func(t *testing.T) {
 		dataDirectory, err := os.MkdirTemp("", "*")

--- a/integration_test.go
+++ b/integration_test.go
@@ -349,7 +349,6 @@ func integrationtestHelperCartographer(t *testing.T, subAlgo viamcartographer.Su
 
 	t.Log("\n=== Testing online mode ===\n")
 
-	start := time.Now()
 	mapRateSec := 9999
 	deleteProcessedData := false
 	useLiveData := true
@@ -414,10 +413,6 @@ func integrationtestHelperCartographer(t *testing.T, subAlgo viamcartographer.Su
 
 	// Close out slam service
 	test.That(t, svc.Close(context.Background()), test.ShouldBeNil)
-
-	stop := time.Now()
-	testDuration := stop.Sub(start).Milliseconds()
-	t.Logf("test duration %d", testDuration)
 
 	// Sleep to ensure cartographer stops
 	time.Sleep(time.Millisecond * cartoSleepMsec)

--- a/internal/testhelper/testhelper.go
+++ b/internal/testhelper/testhelper.go
@@ -60,48 +60,6 @@ func ClearDirectory(t *testing.T, path string) {
 	test.That(t, err, test.ShouldBeNil)
 }
 
-// CreateFullModSLAMService creates a slam service for testing.
-func CreateFullModSLAMService(
-	t *testing.T,
-	cfg *vcConfig.Config,
-	deps resource.Dependencies,
-	logger golog.Logger,
-) (slam.Service, error) {
-	t.Helper()
-
-	ctx := context.Background()
-	cfgService := resource.Config{Name: "test", API: slam.API, Model: viamcartographer.Model}
-	cfgService.ConvertedAttributes = cfg
-
-	sensorDeps, err := cfg.Validate("path")
-	if err != nil {
-		return nil, err
-	}
-	test.That(t, sensorDeps, test.ShouldResemble, cfg.Sensors)
-
-	svc, err := viamcartographer.New(
-		ctx,
-		deps,
-		cfgService,
-		logger,
-		true,
-		"true",
-		SensorValidationMaxTimeoutSecForTest,
-		SensorValidationIntervalSecForTest,
-		testDialMaxTimeoutSec,
-		5*time.Second,
-		nil,
-	)
-	if err != nil {
-		test.That(t, svc, test.ShouldBeNil)
-		return nil, err
-	}
-
-	test.That(t, svc, test.ShouldNotBeNil)
-
-	return svc, nil
-}
-
 // CreateFullModSLAMServiceIntegration creates a slam service for testing.
 func CreateFullModSLAMServiceIntegration(
 	t *testing.T,

--- a/internal/testhelper/testhelper.go
+++ b/internal/testhelper/testhelper.go
@@ -67,8 +67,6 @@ func CreateFullModSLAMServiceIntegration(
 	timedSensor s.TimedSensor,
 	logger golog.Logger,
 ) (slam.Service, error) {
-	t.Helper()
-
 	ctx := context.Background()
 	cfgService := resource.Config{Name: "test", API: slam.API, Model: viamcartographer.Model}
 	cfgService.ConvertedAttributes = cfg
@@ -78,7 +76,7 @@ func CreateFullModSLAMServiceIntegration(
 		return nil, err
 	}
 	test.That(t, sensorDeps, test.ShouldResemble, cfg.Sensors)
-	deps := externaltesthelper.SetupDeps(cfg.Sensors)
+	deps := externaltesthelper.SetupStubDeps(cfg.Sensors, t)
 
 	svc, err := viamcartographer.New(
 		ctx,

--- a/sensors/lidar/dim-2d/dim-2d.go
+++ b/sensors/lidar/dim-2d/dim-2d.go
@@ -11,7 +11,6 @@ import (
 	"github.com/edaniels/golog"
 	"github.com/pkg/errors"
 	"go.opencensus.io/trace"
-	"go.viam.com/rdk/pointcloud"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/utils/contextutils"
 	goutils "go.viam.com/utils"
@@ -53,62 +52,6 @@ func NewLidar(
 	}
 
 	return lidar, nil
-}
-
-// GetTimedData returns a 2d lidar reading, the timestamp from when it wask taken
-// (either in live mode or offline mode)
-// and an error if an error occurred getting the lidar data or parsing the offline
-// timestamp.
-func GetTimedData(ctx context.Context, lidar lidar.Lidar) (time.Time, pointcloud.PointCloud, error) {
-	ctx, md := contextutils.ContextWithMetadata(ctx)
-	reqTime := time.Now().UTC()
-	pointcloud, err := lidar.GetData(ctx)
-	if err != nil {
-		return reqTime, nil, err
-	}
-
-	timeRequestedMetadata, ok := md[contextutils.TimeRequestedMetadataKey]
-	if ok {
-		reqTime, err = time.Parse(time.RFC3339Nano, timeRequestedMetadata[0])
-		if err != nil {
-			return reqTime, nil, err
-		}
-	}
-	return reqTime, pointcloud, nil
-}
-
-// ValidateGetData checks every sensorValidationIntervalSec if the provided lidar
-// returned a valid timed lidar readings every sensorValidationIntervalSec
-// until either success or sensorValidationMaxTimeoutSec has elapsed.
-// returns an error if no valid lidar readings were returned.
-func ValidateGetData(
-	ctx context.Context,
-	lidar lidar.Lidar,
-	sensorValidationMaxTimeout time.Duration,
-	sensorValidationInterval time.Duration,
-	logger golog.Logger,
-) error {
-	ctx, span := trace.StartSpan(ctx, "viamcartographer::internal::dim2d::ValidateGetData")
-	defer span.End()
-
-	startTime := time.Now().UTC()
-
-	for {
-		_, _, err := GetTimedData(ctx, lidar)
-		if err == nil {
-			break
-		}
-
-		logger.Debugw("ValidateGetData hit error: ", "error", err)
-		if time.Since(startTime) >= sensorValidationMaxTimeout {
-			return errors.Wrap(err, "ValidateGetData timeout")
-		}
-		if !goutils.SelectContextOrWait(ctx, sensorValidationInterval) {
-			return ctx.Err()
-		}
-	}
-
-	return nil
 }
 
 // ValidateGetAndSaveData makes sure that the provided sensor is actually a lidar and can

--- a/sensors/lidar/lidar.go
+++ b/sensors/lidar/lidar.go
@@ -2,13 +2,17 @@
 package lidar
 
 import (
+	"bytes"
 	"context"
+	"time"
 
 	"github.com/pkg/errors"
 	"go.viam.com/rdk/components/camera"
 	"go.viam.com/rdk/pointcloud"
 	"go.viam.com/rdk/resource"
+	"go.viam.com/rdk/utils/contextutils"
 
+	"github.com/viamrobotics/viam-cartographer/sensors"
 	"github.com/viamrobotics/viam-cartographer/sensors/utils"
 )
 
@@ -37,6 +41,37 @@ func New(deps resource.Dependencies, sensors []string, sensorIndex int) (Lidar, 
 }
 
 // GetData returns data from the lidar sensor.
+// deprecated.
 func (lidar Lidar) GetData(ctx context.Context) (pointcloud.PointCloud, error) {
 	return lidar.lidar.NextPointCloud(ctx)
+}
+
+// TimedSensorReading returns data from the lidar sensor and the time the reading is from & whether it was a replay sensor or not.
+func (lidar Lidar) TimedSensorReading(ctx context.Context) (sensors.TimedSensorReadingResponse, error) {
+	replay := false
+	ctxWithMetadata, md := contextutils.ContextWithMetadata(ctx)
+	readingPc, err := lidar.lidar.NextPointCloud(ctxWithMetadata)
+	if err != nil {
+		msg := "NextPointCloud error"
+		return sensors.TimedSensorReadingResponse{}, errors.Wrap(err, msg)
+	}
+	readingTime := time.Now().UTC()
+
+	buf := new(bytes.Buffer)
+	err = pointcloud.ToPCD(readingPc, buf, pointcloud.PCDBinary)
+	if err != nil {
+		msg := "ToPCD error"
+		return sensors.TimedSensorReadingResponse{}, errors.Wrap(err, msg)
+	}
+
+	timeRequestedMetadata, ok := md[contextutils.TimeRequestedMetadataKey]
+	if ok {
+		replay = true
+		readingTime, err = time.Parse(time.RFC3339Nano, timeRequestedMetadata[0])
+		if err != nil {
+			msg := "replay sensor timestamp parse RFC3339Nano error"
+			return sensors.TimedSensorReadingResponse{}, errors.Wrap(err, msg)
+		}
+	}
+	return sensors.TimedSensorReadingResponse{Reading: buf.Bytes(), ReadingTime: readingTime, Replay: replay}, nil
 }

--- a/sensors/lidar/lidar_test.go
+++ b/sensors/lidar/lidar_test.go
@@ -5,14 +5,19 @@ import (
 	"errors"
 	"image/color"
 	"testing"
+	"time"
 
+	"github.com/edaniels/golog"
 	"go.viam.com/rdk/components/camera"
 	"go.viam.com/rdk/pointcloud"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/testutils/inject"
 	"go.viam.com/test"
 
+	s "github.com/viamrobotics/viam-cartographer/sensors"
 	"github.com/viamrobotics/viam-cartographer/sensors/lidar"
+	dim2d "github.com/viamrobotics/viam-cartographer/sensors/lidar/dim-2d"
+	"github.com/viamrobotics/viam-cartographer/testhelper"
 )
 
 const (
@@ -154,5 +159,60 @@ func TestGetData(t *testing.T) {
 		data, got := pc.At(1, 0, 0)
 		test.That(t, got, test.ShouldBeTrue)
 		test.That(t, data.Color(), test.ShouldResemble, &color.NRGBA{255, 0, 0, 255})
+	})
+}
+
+func TestTimedSensorReading(t *testing.T) {
+	logger := golog.NewTestLogger(t)
+	ctx := context.Background()
+
+	sensors := []string{"invalid_sensor"}
+	invalidLidar, err := dim2d.NewLidar(ctx, testhelper.SetupDeps(sensors), sensors, logger)
+	test.That(t, err, test.ShouldBeNil)
+
+	sensors = []string{"invalid_replay_sensor"}
+	invalidReplayLidar, err := dim2d.NewLidar(ctx, testhelper.SetupDeps(sensors), sensors, logger)
+	test.That(t, err, test.ShouldBeNil)
+
+	sensors = []string{"good_lidar"}
+	goodLidar, err := dim2d.NewLidar(ctx, testhelper.SetupDeps(sensors), sensors, logger)
+	test.That(t, err, test.ShouldBeNil)
+
+	sensors = []string{"replay_sensor"}
+	goodReplayLidar, err := dim2d.NewLidar(ctx, testhelper.SetupDeps(sensors), sensors, logger)
+	test.That(t, err, test.ShouldBeNil)
+
+	t.Run("when the lidar returns an error, returns that error", func(t *testing.T) {
+		tsr, err := invalidLidar.TimedSensorReading(ctx)
+		msg := "invalid sensor"
+		test.That(t, err, test.ShouldBeError)
+		test.That(t, err.Error(), test.ShouldContainSubstring, msg)
+		test.That(t, tsr, test.ShouldResemble, s.TimedSensorReadingResponse{})
+	})
+
+	t.Run("when the replay lidar succeeds but the timestamp is invalid, returns an error", func(t *testing.T) {
+		tsr, err := invalidReplayLidar.TimedSensorReading(ctx)
+		msg := "parsing time \"NOT A TIME\" as \"2006-01-02T15:04:05.999999999Z07:00\": cannot parse \"NOT A TIME\" as \"2006\""
+		test.That(t, err, test.ShouldBeError)
+		test.That(t, err.Error(), test.ShouldContainSubstring, msg)
+		test.That(t, tsr, test.ShouldResemble, s.TimedSensorReadingResponse{})
+	})
+
+	t.Run("when a live lidar succeeds, returns current time in UTC and the reading", func(t *testing.T) {
+		beforeReading := time.Now().UTC()
+		tsr, err := goodLidar.TimedSensorReading(ctx)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, tsr.Reading, test.ShouldNotBeNil)
+		test.That(t, tsr.ReadingTime.After(beforeReading), test.ShouldBeTrue)
+		test.That(t, tsr.ReadingTime.Location(), test.ShouldEqual, time.UTC)
+		test.That(t, tsr.Replay, test.ShouldBeFalse)
+	})
+
+	t.Run("when a replay lidar succeeds, returns the replay sensor time and the reading", func(t *testing.T) {
+		tsr, err := goodReplayLidar.TimedSensorReading(ctx)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, tsr.Reading, test.ShouldNotBeNil)
+		test.That(t, tsr.ReadingTime, test.ShouldEqual, time.Date(2006, 1, 2, 15, 4, 5, 999900000, time.UTC))
+		test.That(t, tsr.Replay, test.ShouldBeTrue)
 	})
 }

--- a/sensors/sensor_mock.go
+++ b/sensors/sensor_mock.go
@@ -1,0 +1,16 @@
+package sensors
+
+import (
+	"context"
+)
+
+// TimedSensorMock represents a fake TimedSensor.
+type TimedSensorMock struct {
+	TimedSensorReadingFunc func(ctx context.Context) (TimedSensorReadingResponse, error)
+}
+
+// TimedSensorReading returns a fake TimedSensorReadingResponse or an error
+// panics if TimedSensorReadingFunc is nil.
+func (tsm *TimedSensorMock) TimedSensorReading(ctx context.Context) (TimedSensorReadingResponse, error) {
+	return tsm.TimedSensorReadingFunc(ctx)
+}

--- a/sensors/sensors.go
+++ b/sensors/sensors.go
@@ -1,0 +1,58 @@
+// Package sensors defines interfaces for sensors used by viam cartographer
+package sensors
+
+import (
+	"context"
+	"time"
+
+	"github.com/edaniels/golog"
+	"github.com/pkg/errors"
+	"go.opencensus.io/trace"
+	goutils "go.viam.com/utils"
+)
+
+// TimedSensorReadingResponse represents a sensor reading with a time & allows the caller to know if the reading is from a replay sensor.
+type TimedSensorReadingResponse struct {
+	Reading     []byte
+	ReadingTime time.Time
+	Replay      bool
+}
+
+// TimedSensor desribes a sensor that reports the time the reading is from & whether or not it is from a replay sensor.
+type TimedSensor interface {
+	TimedSensorReading(ctx context.Context) (TimedSensorReadingResponse, error)
+}
+
+// ValidateGetData checks every sensorValidationIntervalSec if the provided lidar
+// returned a valid timed lidar readings every sensorValidationIntervalSec
+// until either success or sensorValidationMaxTimeoutSec has elapsed.
+// returns an error if no valid lidar readings were returned.
+func ValidateGetData(
+	ctx context.Context,
+	sensor TimedSensor,
+	sensorValidationMaxTimeout time.Duration,
+	sensorValidationInterval time.Duration,
+	logger golog.Logger,
+) error {
+	ctx, span := trace.StartSpan(ctx, "viamcartographer::sensor::ValidateGetData")
+	defer span.End()
+
+	startTime := time.Now().UTC()
+
+	for {
+		_, err := sensor.TimedSensorReading(ctx)
+		if err == nil {
+			break
+		}
+
+		logger.Debugw("ValidateGetData hit error: ", "error", err)
+		if time.Since(startTime) >= sensorValidationMaxTimeout {
+			return errors.Wrap(err, "ValidateGetData timeout")
+		}
+		if !goutils.SelectContextOrWait(ctx, sensorValidationInterval) {
+			return ctx.Err()
+		}
+	}
+
+	return nil
+}

--- a/sensors/sensors_test.go
+++ b/sensors/sensors_test.go
@@ -1,0 +1,63 @@
+// Package s_test implements tests for sensors
+package sensors_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/edaniels/golog"
+	"github.com/pkg/errors"
+	"go.viam.com/test"
+
+	s "github.com/viamrobotics/viam-cartographer/sensors"
+	dim2d "github.com/viamrobotics/viam-cartographer/sensors/lidar/dim-2d"
+	"github.com/viamrobotics/viam-cartographer/testhelper"
+)
+
+func TestValidateGetData(t *testing.T) {
+	logger := golog.NewTestLogger(t)
+	ctx := context.Background()
+
+	sensors := []string{"good_lidar"}
+	goodLidar, err := dim2d.NewLidar(ctx, testhelper.SetupDeps(sensors), sensors, logger)
+	test.That(t, err, test.ShouldBeNil)
+
+	sensors = []string{"invalid_sensor"}
+	invalidLidar, err := dim2d.NewLidar(ctx, testhelper.SetupDeps(sensors), sensors, logger)
+	test.That(t, err, test.ShouldBeNil)
+
+	sensorValidationMaxTimeout := time.Duration(50) * time.Millisecond
+	sensorValidationInterval := time.Duration(10) * time.Millisecond
+
+	t.Run("returns nil if a lidar reading succeeds immediately", func(t *testing.T) {
+		err := s.ValidateGetData(ctx, goodLidar, sensorValidationMaxTimeout, sensorValidationInterval, logger)
+		test.That(t, err, test.ShouldBeNil)
+	})
+
+	t.Run("returns nil if a lidar reading succeeds within the timeout", func(t *testing.T) {
+		sensors = []string{"warming_up_lidar"}
+		warmingUpLidar, err := dim2d.NewLidar(ctx, testhelper.SetupDeps(sensors), sensors, logger)
+		test.That(t, err, test.ShouldBeNil)
+
+		err = s.ValidateGetData(ctx, warmingUpLidar, sensorValidationMaxTimeout, sensorValidationInterval, logger)
+		test.That(t, err, test.ShouldBeNil)
+	})
+
+	t.Run("returns error if no lidar reading succeeds within the timeout", func(t *testing.T) {
+		err := s.ValidateGetData(ctx, invalidLidar, sensorValidationMaxTimeout, sensorValidationInterval, logger)
+		test.That(t, err, test.ShouldBeError, errors.New("ValidateGetData timeout: NextPointCloud error: invalid sensor"))
+	})
+
+	t.Run("returns error if no lidar reading succeeds by the time the context is cancelled", func(t *testing.T) {
+		cancelledCtx, cancelFunc := context.WithCancel(context.Background())
+		cancelFunc()
+
+		sensors = []string{"warming_up_lidar"}
+		warmingUpLidar, err := dim2d.NewLidar(ctx, testhelper.SetupDeps(sensors), sensors, logger)
+		test.That(t, err, test.ShouldBeNil)
+
+		err = s.ValidateGetData(cancelledCtx, warmingUpLidar, sensorValidationMaxTimeout, sensorValidationInterval, logger)
+		test.That(t, err, test.ShouldBeError, context.Canceled)
+	})
+}

--- a/viam-cartographer_internal_test.go
+++ b/viam-cartographer_internal_test.go
@@ -99,7 +99,7 @@ func makeQuaternionFromGenericMap(quat map[string]interface{}) spatialmath.Orien
 }
 
 func TestGetPositionEndpoint(t *testing.T) {
-	svc := &cartographerService{Named: resource.NewName(slam.API, "test").AsNamed()}
+	svc := &CartographerService{Named: resource.NewName(slam.API, "test").AsNamed()}
 	mockSLAMClient := &inject.SLAMServiceClient{}
 	svc.clientAlgo = mockSLAMClient
 
@@ -265,7 +265,7 @@ func checkGetPositionModularizationV2Outputs(
 	inputPose commonv1.Pose,
 	inputQuat map[string]interface{},
 	inputComponentRef string,
-	svc *cartographerService,
+	svc *CartographerService,
 	pos cartofacade.GetPosition,
 ) {
 	setMockGetPositionFunc(mockCartoFacade, pos)
@@ -281,7 +281,7 @@ func checkGetPositionModularizationV2Outputs(
 }
 
 func TestGetPositionModularizationV2Endpoint(t *testing.T) {
-	svc := &cartographerService{Named: resource.NewName(slam.API, "test").AsNamed()}
+	svc := &CartographerService{Named: resource.NewName(slam.API, "test").AsNamed()}
 	mockCartoFacade := &cartofacade.Mock{}
 	svc.cartofacade = mockCartoFacade
 	svc.modularizationV2Enabled = true
@@ -354,7 +354,7 @@ func TestGetPositionModularizationV2Endpoint(t *testing.T) {
 
 //nolint:dupl
 func TestGetPointCloudMapEndpoint(t *testing.T) {
-	svc := &cartographerService{Named: resource.NewName(slam.API, "test").AsNamed()}
+	svc := &CartographerService{Named: resource.NewName(slam.API, "test").AsNamed()}
 	mockSLAMClient := &inject.SLAMServiceClient{}
 	svc.clientAlgo = mockSLAMClient
 
@@ -484,7 +484,7 @@ func getAndCheckCallbackFunc(
 
 func testApisThatReturnCallbackFuncs(
 	t *testing.T,
-	svc *cartographerService,
+	svc *CartographerService,
 	mockCartoFacade *cartofacade.Mock,
 	pathToFileLargerThanChunkSize string,
 	pathToFileSmallerThanChunkSize string,
@@ -525,7 +525,7 @@ func testApisThatReturnCallbackFuncs(
 }
 
 func TestGetPointCloudMapEndpointModularizationV2Endpoint(t *testing.T) {
-	svc := &cartographerService{Named: resource.NewName(slam.API, "test").AsNamed()}
+	svc := &CartographerService{Named: resource.NewName(slam.API, "test").AsNamed()}
 	mockCartoFacade := &cartofacade.Mock{}
 	pathToFileLargerThanChunkSize := "viam-cartographer/outputs/viam-office-02-22-3/pointcloud/pointcloud_0.pcd"
 	pathToFileSmallerThanChunkSize := "viam-cartographer/outputs/viam-office-02-22-3/pointcloud/pointcloud_1.pcd"
@@ -557,7 +557,7 @@ func TestGetPointCloudMapEndpointModularizationV2Endpoint(t *testing.T) {
 
 //nolint:dupl
 func TestGetInternalStateEndpoint(t *testing.T) {
-	svc := &cartographerService{Named: resource.NewName(slam.API, "test").AsNamed()}
+	svc := &CartographerService{Named: resource.NewName(slam.API, "test").AsNamed()}
 	mockSLAMClient := &inject.SLAMServiceClient{}
 	svc.clientAlgo = mockSLAMClient
 
@@ -647,7 +647,7 @@ func setMockGetInternalStateFunc(
 }
 
 func TestGetInternalStateModularizationV2Endpoint(t *testing.T) {
-	svc := &cartographerService{Named: resource.NewName(slam.API, "test").AsNamed()}
+	svc := &CartographerService{Named: resource.NewName(slam.API, "test").AsNamed()}
 	mockCartoFacade := &cartofacade.Mock{}
 	pathToFileLargerThanChunkSize := "viam-cartographer/outputs/viam-office-02-22-3/internal_state/internal_state_0.pbstream"
 	pathToFileSmallerThanChunkSize := "viam-cartographer/outputs/viam-office-02-22-3/internal_state/internal_state_1.pbstream"


### PR DESCRIPTION
[Ticket](https://viam.atlassian.net/browse/RSDK-3546)
[Ticket](https://viam.atlassian.net/browse/RSDK-2897)
[Ticket](https://viam.atlassian.net/browse/RSDK-2124)
[Ticket](https://viam.atlassian.net/browse/RSDK-1787)

1. Add integration tests for the carttesian product of `slam_mode = [mapping,updating,localizing]` and `sensor_type = [live, replay]` 
2. Have integration tests expect position outcomes in integration tests on mac & linux due to https://viam.atlassian.net/browse/RSDK-3866
3. Change viamcartographer.New to take an override TimedSensor, to allow integration tests to control the timestamps of lidar readings, and make integration tests deterministic
4. Add TimedSensor interface which wraps a lidar reading. Change all post full mode code to interact with lidars through that interface to improve test determinism. 
5. Add new integration tests helper `FullModIntegrationLidarTimedSensor` which allows the test to be notified via channel when the end of the mock lidar dataset has been reached, improving the conciseness of tests.
6. Make `CartographerService` public so that the SlamMode can be asserted on in integration tests (which was previously done by tailing carto_grpc_server logs)
