### PR TITLE
[RSDK-3546] report-slam-mode

### DIFF
--- a/cartofacade/capi_test.go
+++ b/cartofacade/capi_test.go
@@ -142,6 +142,7 @@ func TestCGoAPI(t *testing.T) {
 		// initialize viam_carto correctly
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, vc, test.ShouldNotBeNil)
+		test.That(t, vc.SlamMode, test.ShouldEqual, MappingMode)
 
 		// test start
 		err = vc.start()

--- a/cartofacade/carto_facade_mock.go
+++ b/cartofacade/carto_facade_mock.go
@@ -38,7 +38,7 @@ type Mock struct {
 	InitializeFunc func(
 		ctx context.Context,
 		timeout time.Duration, activeBackgroundWorkers *sync.WaitGroup,
-	) error
+	) (SlamMode, error)
 	StartFunc func(
 		ctx context.Context,
 		timeout time.Duration,
@@ -101,7 +101,7 @@ func (cf *Mock) Initialize(
 	ctx context.Context,
 	timeout time.Duration,
 	activeBackgroundWorkers *sync.WaitGroup,
-) error {
+) (SlamMode, error) {
 	if cf.InitializeFunc == nil {
 		return cf.CartoFacade.Initialize(ctx, timeout, activeBackgroundWorkers)
 	}

--- a/cartofacade/carto_facade_test.go
+++ b/cartofacade/carto_facade_test.go
@@ -152,7 +152,8 @@ func TestInitialize(t *testing.T) {
 	cartoFacade := New(&lib, cfg, algoCfg)
 
 	t.Run("test Initialize - successful case", func(t *testing.T) {
-		err = cartoFacade.Initialize(cancelCtx, 5*time.Second, &activeBackgroundWorkers)
+		slamMode, err := cartoFacade.Initialize(cancelCtx, 5*time.Second, &activeBackgroundWorkers)
+		test.That(t, slamMode, test.ShouldEqual, MappingMode)
 		test.That(t, err, test.ShouldBeNil)
 	})
 

--- a/sensors/lidar/dim-2d/dim-2d_test.go
+++ b/sensors/lidar/dim-2d/dim-2d_test.go
@@ -156,7 +156,7 @@ func TestGetTimedData(t *testing.T) {
 		pcTime, pc, err := dim2d.GetTimedData(ctx, goodLidar)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, pc, test.ShouldNotBeNil)
-		test.That(t, pcTime.After(beforeReading), test.ShouldBeTrue)
+		test.That(t, pcTime.Before(beforeReading), test.ShouldBeFalse)
 		test.That(t, pcTime.Location(), test.ShouldEqual, time.UTC)
 	})
 

--- a/viam-cartographer.go
+++ b/viam-cartographer.go
@@ -375,7 +375,7 @@ func initCartoFacade(ctx context.Context, cartoSvc *cartographerService) error {
 	}
 
 	cf := cartofacade.New(&cartoLib, cartoCfg, cartoAlgoConfig)
-	_, err = cf.Initialize(ctx, cartoSvc.cartoFacadeTimeout, &cartoSvc.cartoFacadeWorkers)
+	slamMode, err := cf.Initialize(ctx, cartoSvc.cartoFacadeTimeout, &cartoSvc.cartoFacadeWorkers)
 	if err != nil {
 		cartoSvc.logger.Errorw("cartofacade initialize failed", "error", err)
 		return err
@@ -392,6 +392,7 @@ func initCartoFacade(ctx context.Context, cartoSvc *cartographerService) error {
 	}
 
 	cartoSvc.cartofacade = &cf
+	cartoSvc.SlamMode = slamMode
 
 	return nil
 }
@@ -443,6 +444,7 @@ type cartographerService struct {
 	resource.Named
 	resource.AlwaysRebuild
 	mu                sync.Mutex
+	SlamMode          cartofacade.SlamMode
 	closed            bool
 	primarySensorName string
 	lidar             lidar.Lidar

--- a/viam-cartographer.go
+++ b/viam-cartographer.go
@@ -375,7 +375,7 @@ func initCartoFacade(ctx context.Context, cartoSvc *cartographerService) error {
 	}
 
 	cf := cartofacade.New(&cartoLib, cartoCfg, cartoAlgoConfig)
-	err = cf.Initialize(ctx, cartoSvc.cartoFacadeTimeout, &cartoSvc.cartoFacadeWorkers)
+	_, err = cf.Initialize(ctx, cartoSvc.cartoFacadeTimeout, &cartoSvc.cartoFacadeWorkers)
 	if err != nil {
 		cartoSvc.logger.Errorw("cartofacade initialize failed", "error", err)
 		return err

--- a/viam-cartographer/src/carto_facade/carto_facade_test.cc
+++ b/viam-cartographer/src/carto_facade/carto_facade_test.cc
@@ -197,6 +197,8 @@ BOOST_AUTO_TEST_CASE(CartoFacade_init_validate) {
     BOOST_TEST(viam_carto_terminate(&invalidvc) == VIAM_CARTO_VC_INVALID);
 
     BOOST_TEST(viam_carto_init(&vc, lib, vcc, ac) == VIAM_CARTO_SUCCESS);
+    BOOST_TEST(vc->slam_mode == VIAM_CARTO_SLAM_MODE_MAPPING);
+
     BOOST_TEST(viam_carto_terminate(&vc) == VIAM_CARTO_SUCCESS);
     // can't terminate a carto instance that has already been terminated
     BOOST_TEST(viam_carto_terminate(&vc) == VIAM_CARTO_VC_INVALID);
@@ -217,7 +219,7 @@ BOOST_AUTO_TEST_CASE(CartoFacade_init_validate) {
     BOOST_TEST(viam_carto_lib_terminate(&lib) == VIAM_CARTO_LIB_INVALID);
 }
 
-BOOST_AUTO_TEST_CASE(CartoFacade_init_derive_action_mode) {
+BOOST_AUTO_TEST_CASE(CartoFacade_init_derive_slam_mode) {
     viam_carto_lib *lib;
     BOOST_TEST(viam_carto_lib_init(&lib, 0, 1) == VIAM_CARTO_SUCCESS);
 
@@ -241,9 +243,10 @@ BOOST_AUTO_TEST_CASE(CartoFacade_init_derive_action_mode) {
             1, VIAM_CARTO_THREE_D, mapping_dir.string(), sensors_vec);
         BOOST_TEST(viam_carto_init(&vc1, lib, vcc_mapping, ac) ==
                    VIAM_CARTO_SUCCESS);
+        BOOST_TEST(vc1->slam_mode == VIAM_CARTO_SLAM_MODE_MAPPING);
         viam::carto_facade::CartoFacade *cf1 =
             static_cast<viam::carto_facade::CartoFacade *>(vc1->carto_obj);
-        BOOST_TEST(cf1->action_mode == ActionMode::MAPPING);
+        BOOST_TEST(cf1->slam_mode == SlamMode::MAPPING);
         BOOST_TEST(cf1->map_builder.GetOptimizeEveryNNodes() ==
                    ac.optimize_every_n_nodes);
         BOOST_TEST(cf1->map_builder.GetNumRangeData() == ac.num_range_data);
@@ -300,9 +303,10 @@ BOOST_AUTO_TEST_CASE(CartoFacade_init_derive_action_mode) {
             1, VIAM_CARTO_THREE_D, updating_dir.string(), sensors_vec);
         BOOST_TEST(viam_carto_init(&vc2, lib, vcc_updating, ac) ==
                    VIAM_CARTO_SUCCESS);
+        BOOST_TEST(vc2->slam_mode == VIAM_CARTO_SLAM_MODE_UPDATING);
         viam::carto_facade::CartoFacade *cf2 =
             static_cast<viam::carto_facade::CartoFacade *>(vc2->carto_obj);
-        BOOST_TEST(cf2->action_mode == ActionMode::UPDATING);
+        BOOST_TEST(cf2->slam_mode == SlamMode::UPDATING);
         BOOST_TEST(cf2->map_builder.GetOptimizeEveryNNodes() ==
                    ac.optimize_every_n_nodes);
         BOOST_TEST(cf2->map_builder.GetNumRangeData() == ac.num_range_data);
@@ -340,9 +344,10 @@ BOOST_AUTO_TEST_CASE(CartoFacade_init_derive_action_mode) {
 
         BOOST_TEST(viam_carto_init(&vc3, lib, vcc_updating,
                                    ac_optimize_on_start) == VIAM_CARTO_SUCCESS);
+        BOOST_TEST(vc3->slam_mode == VIAM_CARTO_SLAM_MODE_UPDATING);
         viam::carto_facade::CartoFacade *cf2 =
             static_cast<viam::carto_facade::CartoFacade *>(vc3->carto_obj);
-        BOOST_TEST(cf2->action_mode == ActionMode::UPDATING);
+        BOOST_TEST(cf2->slam_mode == SlamMode::UPDATING);
         BOOST_TEST(viam_carto_terminate(&vc3) == VIAM_CARTO_SUCCESS);
         viam_carto_config_teardown(vcc_updating);
     }
@@ -354,9 +359,10 @@ BOOST_AUTO_TEST_CASE(CartoFacade_init_derive_action_mode) {
             0, VIAM_CARTO_THREE_D, updating_dir.string(), sensors_vec);
         BOOST_TEST(viam_carto_init(&vc4, lib, vcc_localizing, ac) ==
                    VIAM_CARTO_SUCCESS);
+        BOOST_TEST(vc4->slam_mode == VIAM_CARTO_SLAM_MODE_LOCALIZING);
         viam::carto_facade::CartoFacade *cf3 =
             static_cast<viam::carto_facade::CartoFacade *>(vc4->carto_obj);
-        BOOST_TEST(cf3->action_mode == ActionMode::LOCALIZING);
+        BOOST_TEST(cf3->slam_mode == SlamMode::LOCALIZING);
         BOOST_TEST(cf3->map_builder.GetOptimizeEveryNNodes() ==
                    ac.optimize_every_n_nodes);
         BOOST_TEST(cf3->map_builder.GetNumRangeData() == ac.num_range_data);
@@ -386,9 +392,10 @@ BOOST_AUTO_TEST_CASE(CartoFacade_init_derive_action_mode) {
             0, VIAM_CARTO_THREE_D, updating_dir.string(), sensors_vec);
         BOOST_TEST(viam_carto_init(&vc5, lib, vcc_localizing,
                                    ac_optimize_on_start) == VIAM_CARTO_SUCCESS);
+        BOOST_TEST(vc5->slam_mode == VIAM_CARTO_SLAM_MODE_LOCALIZING);
         viam::carto_facade::CartoFacade *cf3 =
             static_cast<viam::carto_facade::CartoFacade *>(vc5->carto_obj);
-        BOOST_TEST(cf3->action_mode == ActionMode::LOCALIZING);
+        BOOST_TEST(cf3->slam_mode == SlamMode::LOCALIZING);
         BOOST_TEST(viam_carto_terminate(&vc5) == VIAM_CARTO_SUCCESS);
         viam_carto_config_teardown(vcc_localizing);
     }
@@ -429,6 +436,7 @@ BOOST_AUTO_TEST_CASE(CartoFacade_init_terminate) {
         1, VIAM_CARTO_THREE_D, tmp_dir.string(), sensors_vec);
     struct viam_carto_algo_config ac = viam_carto_algo_config_setup();
     BOOST_TEST(viam_carto_init(&vc, lib, vcc, ac) == VIAM_CARTO_SUCCESS);
+    BOOST_TEST(vc->slam_mode == VIAM_CARTO_SLAM_MODE_MAPPING);
     viam::carto_facade::CartoFacade *cf =
         static_cast<viam::carto_facade::CartoFacade *>(vc->carto_obj);
     BOOST_TEST((cf->lib) == lib);
@@ -485,6 +493,7 @@ BOOST_AUTO_TEST_CASE(CartoFacade_demo) {
     struct viam_carto_algo_config ac = viam_carto_algo_config_setup();
 
     BOOST_TEST(viam_carto_init(&vc, lib, vcc, ac) == VIAM_CARTO_SUCCESS);
+    BOOST_TEST(vc->slam_mode == VIAM_CARTO_SLAM_MODE_MAPPING);
 
     // behavior of methods before start
     // AddSensorReading
@@ -971,6 +980,7 @@ BOOST_AUTO_TEST_CASE(CartoFacade_start_stop) {
     struct viam_carto_algo_config ac = viam_carto_algo_config_setup();
 
     BOOST_TEST(viam_carto_init(&vc, lib, vcc, ac) == VIAM_CARTO_SUCCESS);
+    BOOST_TEST(vc->slam_mode == VIAM_CARTO_SLAM_MODE_MAPPING);
     viam::carto_facade::CartoFacade *cf =
         static_cast<viam::carto_facade::CartoFacade *>(vc->carto_obj);
     BOOST_TEST(((cf->state) == CartoFacadeState::IO_INITIALIZED));


### PR DESCRIPTION
[Ticket](https://viam.atlassian.net/browse/RSDK-3546)
[Ticket](https://viam.atlassian.net/browse/RSDK-2897)
[Ticket](https://viam.atlassian.net/browse/RSDK-2124)
[Ticket](https://viam.atlassian.net/browse/RSDK-1787)

1. Renames `ActionMode` to `SlamMode` in C++ code (to more closely reflect its intent of representing whether cartographer is running in Mapping, Updating, or Localizing mode).
2. Returns the SlamMode from viam_cartographer_init all the way back to the cartographer module
3. This information is needed in order to keep integration tests at parity with what they are now (prior to full mod the integration tests watched logs to determine what mode cartographer is in, now we can just have the C++ carto facade the go code what the slam mode is on initialization.

Pre work required for: updating the integration tests: https://github.com/viamrobotics/viam-cartographer/pull/196