### PR TITLE
fix-pcd-parse-error-log

### DIFF
--- a/viam-cartographer/src/carto_facade/util.cc
+++ b/viam-cartographer/src/carto_facade/util.cc
@@ -177,8 +177,8 @@ carto_sensor_reading(std::string sensor_reading,
         return {false, point_cloud};
     }
     VLOG(1) << "read_pcd succeeded";
-    pcl::PointCloud<pcl::PointXYZRGB>::Ptr cloud(
-        new pcl::PointCloud<pcl::PointXYZRGB>);
+    pcl::PointCloud<pcl::PointXYZ>::Ptr cloud(
+        new pcl::PointCloud<pcl::PointXYZ>);
     pcl::fromPCLPointCloud2(blob, *cloud);
 
     VLOG(1) << "Loaded " << cloud->width * cloud->height << " data points";


### PR DESCRIPTION
This makes it so that the full mod PCD parser for Lidar readings only expects lidar readings to have XYZ rather than XYZRGB. This is needed as PCL will log errors for every lidar reading unless we either:
1. Parse the headers as RPlidar outputs them
2. Change RPlidar to output PCDs in the format this code expects
3. Suppress PCL errors

This code change does 1 for post full mod.
Pre full mod code does 3. 

This is the header that RPlidar outputs currently:
```
VERSION .7
FIELDS x y z
SIZE 4 4 4
TYPE F F F
COUNT 1 1 1
WIDTH 806
HEIGHT 1
VIEWPOINT 0 0 0 1 0 0 0
POINTS 806
DATA binary
```

Without this change the following log is emitted by the PCL library:
`Failed to find match for field 'rgb`
Pre full mod suppressed this error using `pcl::console::setVerbosityLevel(pcl::console::L_ALWAYS);` which disables all logging from the PCL library. 

https://github.com/viamrobotics/slam/commit/88845ca35b58f8190ddf66da841bdf6a32ed8bfb#diff-2cde4539c3c3f4b3aad3a26a1006be0428a2f258d13b2610930e1040f17e17b5R21

This also resolves this ticket: https://viam.atlassian.net/browse/RSDK-3717