### PR TITLE
fix-full-mod-cartographer-time

### DIFF
--- a/cartofacade/capi.go
+++ b/cartofacade/capi.go
@@ -420,7 +420,7 @@ func toSensorReading(sensor string, readings []byte, timestamp time.Time) C.viam
 	readingsCBytes := C.CBytes(readings)
 	defer C.free(readingsCBytes)
 	sr.sensor_reading = C.blk2bstr(readingsCBytes, C.int(len(readings)))
-	sr.sensor_reading_time_unix_micro = C.int64_t(timestamp.UnixMicro())
+	sr.sensor_reading_time_unix_milli = C.int64_t(timestamp.UnixMilli())
 	return sr
 }
 

--- a/cartofacade/capi_test.go
+++ b/cartofacade/capi_test.go
@@ -98,7 +98,7 @@ func TestToSensorReading(t *testing.T) {
 		sr := toSensorReading("mysensor", []byte("he0llo"), timestamp)
 		test.That(t, bstringToGoString(sr.sensor), test.ShouldResemble, "mysensor")
 		test.That(t, bstringToGoString(sr.sensor_reading), test.ShouldResemble, "he0llo")
-		test.That(t, sr.sensor_reading_time_unix_milli, test.ShouldEqual, timestamp.UnixMicro())
+		test.That(t, sr.sensor_reading_time_unix_milli, test.ShouldEqual, timestamp.UnixMilli())
 	})
 }
 

--- a/cartofacade/capi_test.go
+++ b/cartofacade/capi_test.go
@@ -98,7 +98,7 @@ func TestToSensorReading(t *testing.T) {
 		sr := toSensorReading("mysensor", []byte("he0llo"), timestamp)
 		test.That(t, bstringToGoString(sr.sensor), test.ShouldResemble, "mysensor")
 		test.That(t, bstringToGoString(sr.sensor_reading), test.ShouldResemble, "he0llo")
-		test.That(t, sr.sensor_reading_time_unix_micro, test.ShouldEqual, timestamp.UnixMicro())
+		test.That(t, sr.sensor_reading_time_unix_milli, test.ShouldEqual, timestamp.UnixMicro())
 	})
 }
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -60,11 +60,11 @@ func testCartographerMap(t *testing.T, svc slam.Service, localizationMode bool) 
 }
 
 func testCartographerFullModPosition(t *testing.T, svc slam.Service, expectedComponentRef string) {
-	expectedPosOSX := r3.Vector{X: -1.0283431004415964, Y: 1.9804921951032644, Z: 0}
+	expectedPosOSX := r3.Vector{X: -4.534156132500952, Y: 9.800089705182817, Z: 0}
 
 	expectedPosLinux := r3.Vector{X: -0.062249046977189776, Y: 2.97876740701877, Z: 0}
 	tolerancePos := 0.001
-	expectedOri := &spatialmath.R4AA{Theta: 0, RX: 0, RY: 0, RZ: 1}
+	expectedOri := &spatialmath.R4AA{Theta: 0.0018812019022632894, RX: 0, RY: 0, RZ: -1}
 	toleranceOri := 0.001
 
 	position, componentRef, err := svc.GetPosition(context.Background())

--- a/integration_test.go
+++ b/integration_test.go
@@ -61,8 +61,7 @@ func testCartographerMap(t *testing.T, svc slam.Service, localizationMode bool) 
 
 func testCartographerFullModPosition(t *testing.T, svc slam.Service, expectedComponentRef string) {
 	expectedPosOSX := r3.Vector{X: -4.534156132500952, Y: 9.800089705182817, Z: 0}
-
-	expectedPosLinux := r3.Vector{X: -0.062249046977189776, Y: 2.97876740701877, Z: 0}
+	expectedPosLinux := r3.Vector{X: -3.0874594959315647, Y: 4.502970388777862, Z: 0}
 	tolerancePos := 0.001
 	expectedOri := &spatialmath.R4AA{Theta: 0.0018812019022632894, RX: 0, RY: 0, RZ: -1}
 	toleranceOri := 0.001

--- a/viam-cartographer/src/carto_facade/carto_facade.cc
+++ b/viam-cartographer/src/carto_facade/carto_facade.cc
@@ -766,10 +766,10 @@ void CartoFacade::AddSensorReading(const viam_carto_sensor_reading *sr) {
         throw VIAM_CARTO_SENSOR_READING_EMPTY;
     }
 
-    int64_t sensor_reading_time_unix_micro = sr->sensor_reading_time_unix_micro;
+    int64_t sensor_reading_time_unix_milli = sr->sensor_reading_time_unix_milli;
     auto [success, measurement] =
         viam::carto_facade::util::carto_sensor_reading(
-            sensor_reading, sensor_reading_time_unix_micro);
+            sensor_reading, sensor_reading_time_unix_milli);
     if (!success) {
         throw VIAM_CARTO_SENSOR_READING_INVALID;
     }
@@ -778,6 +778,8 @@ void CartoFacade::AddSensorReading(const viam_carto_sensor_reading *sr) {
     bool update_latest_global_pose = false;
 
     if (map_builder_mutex.try_lock()) {
+        VLOG(1) << "AddSensorData timestamp: " << measurement.time
+                << " measurement.ranges.size(): " << measurement.ranges.size();
         map_builder.AddSensorData(measurement);
         auto local_poses = map_builder.GetLocalSlamResultPoses();
         VLOG(1) << "local_poses.size(): " << local_poses.size();

--- a/viam-cartographer/src/carto_facade/carto_facade.h
+++ b/viam-cartographer/src/carto_facade/carto_facade.h
@@ -73,7 +73,7 @@ typedef struct viam_carto_sensor_reading {
     bstring sensor;
     // TODO: change to void* and a size
     bstring sensor_reading;
-    int64_t sensor_reading_time_unix_micro;
+    int64_t sensor_reading_time_unix_milli;
 } viam_carto_sensor_reading;
 
 typedef enum viam_carto_LIDAR_CONFIG {

--- a/viam-cartographer/src/carto_facade/carto_facade_test.cc
+++ b/viam-cartographer/src/carto_facade/carto_facade_test.cc
@@ -57,13 +57,13 @@ void viam_carto_config_teardown(viam_carto_config vcc) {
 }
 viam_carto_sensor_reading new_test_sensor_reading(
     std::string sensor, std::string pcd_path,
-    int64_t sensor_reading_time_unix_micro) {
+    int64_t sensor_reading_time_unix_milli) {
     viam_carto_sensor_reading sr;
     sr.sensor = bfromcstr(sensor.c_str());
     std::string pcd = help::read_file(pcd_path);
     sr.sensor_reading = blk2bstr(pcd.c_str(), pcd.length());
     BOOST_TEST(sr.sensor_reading != nullptr);
-    sr.sensor_reading_time_unix_micro = sensor_reading_time_unix_micro;
+    sr.sensor_reading_time_unix_milli = sensor_reading_time_unix_milli;
     return sr;
 }
 
@@ -589,7 +589,7 @@ BOOST_AUTO_TEST_CASE(CartoFacade_demo) {
         std::string pcd = help::binary_pcd(points);
         sr.sensor_reading = blk2bstr(pcd.c_str(), pcd.length());
         BOOST_TEST(sr.sensor_reading != nullptr);
-        sr.sensor_reading_time_unix_micro = 1687899990420347;
+        sr.sensor_reading_time_unix_milli = 1687899990420347;
         BOOST_TEST(viam_carto_add_sensor_reading(vc, &sr) ==
                    VIAM_CARTO_SENSOR_NOT_IN_SENSOR_LIST);
         BOOST_TEST(viam_carto_add_sensor_reading_destroy(&sr) ==
@@ -604,7 +604,7 @@ BOOST_AUTO_TEST_CASE(CartoFacade_demo) {
         std::string pcd = help::binary_pcd(points);
         sr.sensor_reading = blk2bstr(pcd.c_str(), pcd.length());
         BOOST_TEST(sr.sensor_reading != nullptr);
-        sr.sensor_reading_time_unix_micro = 1687900014152474;
+        sr.sensor_reading_time_unix_milli = 1687900014152474;
         BOOST_TEST(viam_carto_add_sensor_reading(vc, &sr) ==
                    VIAM_CARTO_SENSOR_NOT_IN_SENSOR_LIST);
         BOOST_TEST(viam_carto_add_sensor_reading_destroy(&sr) ==
@@ -620,7 +620,7 @@ BOOST_AUTO_TEST_CASE(CartoFacade_demo) {
         // passing 0 as the second parameter makes the string empty
         sr.sensor_reading = blk2bstr(pcd.c_str(), 0);
         BOOST_TEST(sr.sensor_reading != nullptr);
-        sr.sensor_reading_time_unix_micro = 1687900021820215;
+        sr.sensor_reading_time_unix_milli = 1687900021820215;
         BOOST_TEST(viam_carto_add_sensor_reading(vc, &sr) ==
                    VIAM_CARTO_SENSOR_READING_EMPTY);
         BOOST_TEST(viam_carto_add_sensor_reading_destroy(&sr) ==
@@ -635,7 +635,7 @@ BOOST_AUTO_TEST_CASE(CartoFacade_demo) {
         std::string pcd = "invalid lidar reading";
         sr.sensor_reading = blk2bstr(pcd.c_str(), pcd.length());
         BOOST_TEST(sr.sensor_reading != nullptr);
-        sr.sensor_reading_time_unix_micro = 1687900029557335;
+        sr.sensor_reading_time_unix_milli = 1687900029557335;
         BOOST_TEST(viam_carto_add_sensor_reading(vc, &sr) ==
                    VIAM_CARTO_SENSOR_READING_INVALID);
         BOOST_TEST(viam_carto_add_sensor_reading_destroy(&sr) ==

--- a/viam-cartographer/src/carto_facade/util.cc
+++ b/viam-cartographer/src/carto_facade/util.cc
@@ -161,7 +161,7 @@ int read_pcd(std::string pcd, pcl::PCLPointCloud2 &blob) {
 
 std::tuple<bool, cartographer::sensor::TimedPointCloudData>
 carto_sensor_reading(std::string sensor_reading,
-                     int64_t sensor_reading_time_unix_micro) {
+                     int64_t sensor_reading_time_unix_milli) {
     cartographer::sensor::TimedPointCloudData point_cloud;
     cartographer::sensor::TimedPointCloud ranges;
 
@@ -194,7 +194,8 @@ carto_sensor_reading(std::string sensor_reading,
     }
 
     point_cloud.time =
-        cartographer::common::FromUniversal(sensor_reading_time_unix_micro);
+        cartographer::common::FromUniversal(0) +
+        cartographer::common::FromMilliseconds(sensor_reading_time_unix_milli);
     point_cloud.origin = Eigen::Vector3f::Zero();
     point_cloud.ranges = ranges;
 

--- a/viam-cartographer/src/carto_facade/util.h
+++ b/viam-cartographer/src/carto_facade/util.h
@@ -51,7 +51,7 @@ void write_int_to_buffer_in_bytes(std::string &buffer, int d);
 
 std::tuple<bool, cartographer::sensor::TimedPointCloudData>
 carto_sensor_reading(std::string sensor_reading,
-                     int64_t sensor_reading_time_unix_micro);
+                     int64_t sensor_reading_time_unix_milli);
 int read_pcd(std::string pcd, pcl::PCLPointCloud2 &blob);
 }  // namespace util
 }  // namespace carto_facade

--- a/viam-cartographer/src/slam_service/slam_service.cc
+++ b/viam-cartographer/src/slam_service/slam_service.cc
@@ -731,6 +731,9 @@ void SLAMServiceImpl::ProcessDataAndStartSavingMaps(double data_start_time) {
             std::lock_guard<std::mutex> lk(map_builder_mutex);
             auto measurement = map_builder.GetDataFromFile(file);
             if (measurement.ranges.size() > 0) {
+                VLOG(1) << "AddSensorData timestamp: " << measurement.time
+                        << " measurement.ranges.size(): "
+                        << measurement.ranges.size();
                 trajectory_builder->AddSensorData(kRangeSensorId.id,
                                                   measurement);
                 auto local_poses = map_builder.GetLocalSlamResultPoses();


### PR DESCRIPTION
During the [Full Mod Hardware Test](https://viam.atlassian.net/browse/RSDK-3548) we discovered that full mod wasn't creating maps correctly.

We root caused it & found that it was b/c the way we were describing the time of each lidar reading in full mod (prior to this PR) was:
```
    point_cloud.time =
        cartographer::common::FromUniversal(sensor_reading_time_unix_micro);
```

This PR changes it to:
```
 point_cloud.time =
        cartographer::common::FromUniversal(0) +
        cartographer::common::FromMilliseconds(sensor_reading_time_unix_milli);
```

This bug was due to me misinterpreting `cartographer::common::FromUniversal` to be taking a unix timestamp in microseconds, but instead it appears to be taking `ticks` http://docs.ros.org/en/lunar/api/cartographer/html/namespacecartographer_1_1common.html which appear to not be the same as unix microseconds. 

This approach of adding a unit of time on to universal time also mirrors the approch prior to full mod:
https://github.com/viamrobotics/viam-cartographer/blob/main/viam-cartographer/src/io/file_handler.cc#L62C3-L63C76

```
    double current_time = ReadTimeFromTimestamp(file_path.substr(
        file_path.find(filename_prefix) + filename_prefix.length(),
        file_path.find(".pcd")));
    double time_delta = current_time - start_time;
...
    timed_pcd.time = cartographer::common::FromUniversal(123) +
                     cartographer::common::FromSeconds(double(time_delta));
```

Also required changing the time unit the go code sends to the C++ code from microseconds to milliseconds, as cartographer only has functions for consuming milliseconds, not microseconds.