### PR TITLE
[RSDK-4039] fix-makefile-not-rebuilding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,12 +95,13 @@ else
 	$(error "Unsupported system. Only apt and brew currently supported.")
 endif
 
-build: bin/cartographer-module
+build: cartographer-module
 
 viam-cartographer/build/carto_grpc_server: ensure-submodule-initialized grpc/buf
 	cd viam-cartographer && cmake -Bbuild -G Ninja ${EXTRA_CMAKE_FLAGS} && cmake --build build
 
-bin/cartographer-module: viam-cartographer/build/carto_grpc_server
+cartographer-module: viam-cartographer/build/carto_grpc_server
+	rm -f bin/cartographer-module
 	mkdir -p bin && go build $(GO_BUILD_LDFLAGS) -o bin/cartographer-module module/main.go
 
 # Ideally build-asan would be added to build-debug, but can't yet 


### PR DESCRIPTION
[Ticket](https://viam.atlassian.net/browse/RSDK-4039)

Fixes `make build` not rebuilding cartographer-module if it has been built before. 
Now `make build` always rebuilds the cartographer-module go binary.
Follows the same pattern as: viam-server's `make server` make target: https://github.com/viamrobotics/rdk/blob/main/Makefile#L81
I accidentally introduced this bug in the build system in https://github.com/viamrobotics/viam-cartographer/pull/186