### PR TITLE
RSDK-3980 - switch job done file creation to do command

### DIFF
--- a/viam-cartographer.go
+++ b/viam-cartographer.go
@@ -143,8 +143,7 @@ func initSensorProcess(cancelCtx context.Context, cartoSvc *CartographerService)
 	cartoSvc.sensorProcessWorkers.Add(1)
 	go func() {
 		defer cartoSvc.sensorProcessWorkers.Done()
-		jobDone := sensorprocess.Start(cancelCtx, spConfig)
-		if jobDone {
+		if jobDone := sensorprocess.Start(cancelCtx, spConfig); jobDone {
 			cartoSvc.jobDone = true
 			cartoSvc.cancelSensorProcessFunc()
 		}
@@ -751,7 +750,6 @@ func (cartoSvc *CartographerService) getNextDataPoint(ctx context.Context, lidar
 // DoCommand receives arbitrary commands.
 func (cartoSvc *CartographerService) DoCommand(ctx context.Context, req map[string]interface{}) (map[string]interface{}, error) {
 	if cartoSvc.closed {
-		cartoSvc.logger.Warn("DoCommand called after closed")
 		return nil, ErrClosed
 	}
 
@@ -766,9 +764,8 @@ func (cartoSvc *CartographerService) doCommandModularizationV2(
 	ctx context.Context,
 	req map[string]interface{},
 ) (map[string]interface{}, error) {
-	_, ok := req["jobDone"]
-	if ok {
-		return map[string]interface{}{"jobDone": cartoSvc.jobDone}, nil
+	if _, ok := req["job_done"]; ok {
+		return map[string]interface{}{"job_done": cartoSvc.jobDone}, nil
 	}
 
 	return nil, viamgrpc.UnimplementedError


### PR DESCRIPTION
# Changes
- If the error with "reached end of dataset" is seen while reading data from the lidar, stop the sensor process
- If sending job_done command to DoCommand, be able to tell if the job has finished or not

# Testing

Following log only appears once
```
\_ 2023-07-18T15:38:28.571-0400	WARN	cartographerModule	sensorprocess/sensorprocess.go:54	NextPointCloud error: rpc error: code = Unknown desc = reached end of dataset
```

Results from grpcurl to DoCommand:
```
// Before above log
➜  ~ viam --base-url=https://pr-2017-appmain-bplesliplq-uc.a.run.app:443 robot part run --robot kims-robot --location "First Location" --organization "Nils's Org" -part kims-robot-main  -d '{"name": "slam-svc", "command": {"job_done": "true"}}' viam.service.slam.v1.SLAMService.DoCommand
{
  "result": {
      "job_done": false
    }
}
```

```
// After above log
➜  ~ viam --base-url=https://pr-2017-appmain-bplesliplq-uc.a.run.app:443 robot part run --robot kims-robot --location "First Location" --organization "Nils's Org" -part kims-robot-main  -d '{"name": "slam-svc", "command": {"job_done": "true"}}' viam.service.slam.v1.SLAMService.DoCommand
{
  "result": {
      "job_done": true
    }
}
```