### PR TITLE
RSDK-4074 - quick fix for logging

### DIFF
--- a/sensorprocess/sensorprocess.go
+++ b/sensorprocess/sensorprocess.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"math"
+	"strings"
 	"time"
 
 	"github.com/edaniels/golog"
@@ -51,9 +52,8 @@ func addSensorReading(
 	tsr, err := config.Lidar.TimedSensorReading(ctx)
 	if err != nil {
 		config.Logger.Warn(err)
-		return errors.Is(err, replaypcd.ErrEndOfDataset)
+		return strings.Contains(err.Error(), replaypcd.ErrEndOfDataset.Error())
 	}
-
 	if tsr.Replay {
 		addSensorReadingFromReplaySensor(ctx, tsr.Reading, tsr.ReadingTime, config)
 	} else {

--- a/testhelper/testhelper.go
+++ b/testhelper/testhelper.go
@@ -216,7 +216,7 @@ func getIntegrationLidar() *inject.Camera {
 func getFinishedReplaySensor() *inject.Camera {
 	cam := &inject.Camera{}
 	cam.NextPointCloudFunc = func(ctx context.Context) (pointcloud.PointCloud, error) {
-		return nil, replaypcd.ErrEndOfDataset
+		return nil, errors.Wrap(errors.New("wrapped error"), replaypcd.ErrEndOfDataset.Error())
 	}
 	cam.StreamFunc = func(ctx context.Context, errHandlers ...gostream.ErrorHandler) (gostream.VideoStream, error) {
 		return nil, errors.New("lidar not camera")


### PR DESCRIPTION
errors.Is is not working because the actual error is wrapped with other errors and the old tests still passed because the mock function returns exactly the error the code is checking. Updated to check the if the error message contains the string from rdk and so that the test returns a wrapped error