### PR TITLE
RSDK-4122 Fix typo in viam-cartographer github workflows

### DIFF
--- a/.github/workflows/releasecandidate.yml
+++ b/.github/workflows/releasecandidate.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   test:
-    uses: viamrobotics/viam-robotics/.github/workflows/test.yml@main
+    uses: viamrobotics/viam-cartographer/.github/workflows/test.yml@main
 
   appimage:
     uses: viamrobotics/viam-cartographer/.github/workflows/appimage.yml@main

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   test:
-    uses: viamrobotics/viam-robotics/.github/workflows/test.yml@main
+    uses: viamrobotics/viam-cartographer/.github/workflows/test.yml@main
 
   appimage:
   # remove


### PR DESCRIPTION
The github action to create the rc candidate failed because of this typo: https://github.com/viamrobotics/viam-cartographer/actions/runs/5618273249