### PR TITLE
hotfix-add-nlopt

### DIFF
--- a/etc/packaging/appimages/cartographer-module-aarch64.yml
+++ b/etc/packaging/appimages/cartographer-module-aarch64.yml
@@ -77,6 +77,7 @@ AppDir:
     - libglx0:arm64
     - libgl1:arm64
     - libglvnd0:arm64
+    - libnlopt0:arm64
 
   files:
     include: []

--- a/etc/packaging/appimages/cartographer-module-x86_64.yml
+++ b/etc/packaging/appimages/cartographer-module-x86_64.yml
@@ -77,6 +77,7 @@ AppDir:
     - libglx0:amd64
     - libgl1:amd64
     - libglvnd0:amd64
+    - libnlopt0:amd64
 
   files:
     include: []


### PR DESCRIPTION
Adds nlopt to app image as it is now a hard RDK requirement to provide nlopt.

Fixes cartographer-module not booting on linux as the app image doesn't contain the nlopt dynamic lib which RDK requires:
```
robot_server.process.cartographer-module_./cartographer-module.StdErr pexec/managed_process.go:222 \_ /tmp/appimage_extracted_81e530268ca6420dff0edd4f4f8e5ec8/usr/bin/cartographer-module: error while loading shared libraries: libnlopt.so.0: cannot open shared object file: No such file or directory
```

Manual testing:


## Linux aarch64 (fresh raspberry pi raspian lite OS installed using https://docs.viam.com/installation/prepare/rpi-setup/):
```
sudo curl -o /usr/local/bin/rplidar-module https://storage.googleapis.com/packages.viam.com/apps/rplidar/rplidar-module-stable-aarch64.AppImage

sudo curl -o /usr/local/bin/cartographer-module-latest https://storage.googleapis.com/packages.viam.com/apps/slam-servers/cartographer-module-latest-aarch64.AppImage

# cartographer-module-patch copied from being built within canon

nickpi@nickpi:~ $ /usr/local/bin/cartographer-module-stable --version
2023-07-21T11:56:44.703-0400    INFO    cartographerModule      module/main.go:35       viam:slam:cartographer  {"version": "v0.3.19", "git_rev": "d12161af532c247bebc8a1f250c5d957f05f82ee"}
nickpi@nickpi:~ $ /usr/local/bin/cartographer-module-latest --version
/tmp/.mount_cartogYLR9q1/usr/bin/cartographer-module: error while loading shared libraries: libnlopt.so.0: cannot open shared object file: No such file or directory
nickpi@nickpi:~ $ /usr/local/bin/cartographer-module-patch --version
2023-07-21T11:57:13.543-0400    INFO    cartographerModule      module/main.go:35       viam:slam:cartographer  {"git_rev": "796f7d108c0ca00a9c4e4d5f31a1cd414096ac9a"}
```