### PR TITLE
RSDK-4193: New Logic for GetLatestMapInfo

### DIFF
--- a/viam_cartographer.go
+++ b/viam_cartographer.go
@@ -496,7 +496,7 @@ func toChunkedFunc(b []byte) func() ([]byte, error) {
 	return f
 }
 
-// GetLatestMapInfo returns the timestamp  associated with the latest call to GetPointCloudMap,
+// GetLatestMapInfo returns the timestamp associated with the latest call to GetPointCloudMap,
 // unless you are localizing; in which case the timestamp returned is the timestamp of the session.
 func (cartoSvc *CartographerService) GetLatestMapInfo(ctx context.Context) (time.Time, error) {
 	_, span := trace.StartSpan(ctx, "viamcartographer::CartographerService::GetLatestMapInfo")

--- a/viam_cartographer.go
+++ b/viam_cartographer.go
@@ -455,10 +455,6 @@ func (cartoSvc *CartographerService) GetPointCloudMap(ctx context.Context) (func
 		return nil, ErrClosed
 	}
 
-	if cartoSvc.SlamMode != cartofacade.LocalizingMode {
-		cartoSvc.mapTimestamp = time.Now().UTC()
-	}
-
 	pc, err := cartoSvc.cartofacade.GetPointCloudMap(ctx, cartoSvc.cartoFacadeTimeout)
 	if err != nil {
 		return nil, err
@@ -509,6 +505,10 @@ func (cartoSvc *CartographerService) GetLatestMapInfo(ctx context.Context) (time
 	if cartoSvc.closed {
 		cartoSvc.logger.Warn("GetLatestMapInfo called after closed")
 		return time.Time{}, ErrClosed
+	}
+
+	if cartoSvc.SlamMode != cartofacade.LocalizingMode {
+		cartoSvc.mapTimestamp = time.Now().UTC()
 	}
 
 	return cartoSvc.mapTimestamp, nil

--- a/viam_cartographer.go
+++ b/viam_cartographer.go
@@ -443,9 +443,8 @@ func (cartoSvc *CartographerService) GetPosition(ctx context.Context) (spatialma
 	return CheckQuaternionFromClientAlgo(pose, cartoSvc.primarySensorName, returnedExt)
 }
 
-// GetPointCloudMap creates a request, recording the time, calls the slam algorithms GetPointCloudMap endpoint and returns a callback
+// GetPointCloudMap creates a request calls the slam algorithms GetPointCloudMap endpoint and returns a callback
 // function which will return the next chunk of the current pointcloud map.
-// If startup is in localization mode, the timestamp is NOT updated.
 func (cartoSvc *CartographerService) GetPointCloudMap(ctx context.Context) (func() ([]byte, error), error) {
 	ctx, span := trace.StartSpan(ctx, "viamcartographer::CartographerService::GetPointCloudMap")
 	defer span.End()
@@ -496,8 +495,8 @@ func toChunkedFunc(b []byte) func() ([]byte, error) {
 	return f
 }
 
-// GetLatestMapInfo returns the timestamp associated with the latest call to GetPointCloudMap,
-// unless you are localizing; in which case the timestamp returned is the timestamp of the session.
+// GetLatestMapInfo returns a new timestamp every time it is called when in mapping mode, to signal
+// that the map should be updated. In localizing, the timestamp returned is the timestamp of the session.
 func (cartoSvc *CartographerService) GetLatestMapInfo(ctx context.Context) (time.Time, error) {
 	_, span := trace.StartSpan(ctx, "viamcartographer::CartographerService::GetLatestMapInfo")
 	defer span.End()

--- a/viam_cartographer_test.go
+++ b/viam_cartographer_test.go
@@ -144,8 +144,6 @@ func TestNew(t *testing.T) {
 
 		timestamp1, err := svc.GetLatestMapInfo(context.Background())
 		test.That(t, err, test.ShouldBeNil)
-		_, err = svc.GetPointCloudMap(context.Background())
-		test.That(t, err, test.ShouldBeNil)
 		timestamp2, err := svc.GetLatestMapInfo(context.Background())
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, timestamp1.After(_zeroTime), test.ShouldBeTrue)
@@ -176,8 +174,6 @@ func TestNew(t *testing.T) {
 		test.That(t, cs.SlamMode, test.ShouldEqual, cartofacade.UpdatingMode)
 
 		timestamp1, err := svc.GetLatestMapInfo(context.Background())
-		test.That(t, err, test.ShouldBeNil)
-		_, err = svc.GetPointCloudMap(context.Background())
 		test.That(t, err, test.ShouldBeNil)
 		timestamp2, err := svc.GetLatestMapInfo(context.Background())
 		test.That(t, err, test.ShouldBeNil)


### PR DESCRIPTION
Switch from updating timestamp in GetPointCloudMap to updating timestamp every time GetLatestMapInfo is called when not in localizing mode.