### PR TITLE
[RSDK-4106] Restructure lidar name and data rate to use map

### DIFF
--- a/cartofacade/capi.go
+++ b/cartofacade/capi.go
@@ -28,7 +28,6 @@ import "C"
 
 import (
 	"errors"
-	"fmt"
 	"time"
 	"unsafe"
 )
@@ -161,29 +160,25 @@ func toSlamMode(cSlamMode C.int) SlamMode {
 
 // NewCarto calls viam_carto_init and returns a pointer to a viam carto object. vcl is only an interface to facilitate testing & that the only type vcl it is actually expected to have is a CartoLib
 func NewCarto(cfg CartoConfig, acfg CartoAlgoConfig, vcl CartoLibInterface) (Carto, error) {
-	fmt.Println("alls not good here")
 	var pVc *C.viam_carto
 
 	vcc, err := getConfig(cfg)
 	if err != nil {
 		return Carto{}, err
 	}
-	fmt.Println("1")
 	vcac := toAlgoConfig(acfg)
-	fmt.Println("2")
 	cl, ok := vcl.(*CartoLib)
 	if !ok {
 		return Carto{}, errors.New("cannot cast provided library to a CartoLib")
 	}
-	fmt.Println("3")
 	status := C.viam_carto_init(&pVc, cl.value, vcc, vcac)
-	fmt.Println("3.5")
+
 	if err := toError(status); err != nil {
 		return Carto{}, err
 	}
-	fmt.Println("4")
+
 	carto := Carto{value: pVc, SlamMode: toSlamMode(pVc.slam_mode)}
-	fmt.Println("alls good here")
+
 	return carto, nil
 }
 

--- a/cartofacade/capi.go
+++ b/cartofacade/capi.go
@@ -10,19 +10,6 @@ package cartofacade
 	#cgo LDFLAGS: -L../viam-cartographer/build -L../viam-cartographer/build/cartographer -lviam-cartographer  -lcartographer -ldl -lm -labsl_hash  -labsl_city -labsl_bad_optional_access -labsl_strerror  -labsl_str_format_internal -labsl_synchronization -labsl_strings -labsl_throw_delegate -lcairo -llua5.3 -lstdc++ -lceres -lprotobuf -lglog -lboost_filesystem -lboost_iostreams -lpcl_io -lpcl_common -labsl_raw_hash_set
 
 	#include "../viam-cartographer/src/carto_facade/carto_facade.h"
-
-	bstring* alloc_bstring_array(size_t len) { return (bstring*) malloc(len * sizeof(bstring)); }
-	int free_bstring_array(bstring* p, size_t len) {
-		int result;
-		for (size_t i = 0; i < len; i++) {
-			result = bdestroy(p[i]);
-			if (result != BSTR_OK) {
-				return result;
-			};
-		}
-		free(p);
-		return BSTR_OK;
-	}
 */
 import "C"
 
@@ -294,17 +281,6 @@ func (vc *Carto) getInternalState() ([]byte, error) {
 }
 
 // this function is only used for testing purposes, but needs to be in this file as CGo is not supported in go test files
-func bStringToGoStringSlice(bstr *C.bstring, length int) []string {
-	bStrings := (*[1 << 28]C.bstring)(unsafe.Pointer(bstr))[:length:length]
-
-	goStrings := []string{}
-	for _, bString := range bStrings {
-		goStrings = append(goStrings, bstringToGoString(bString))
-	}
-	return goStrings
-}
-
-// this function is only used for testing purposes, but needs to be in this file as CGo is not supported in go test files
 func getTestGetPositionResponse() C.viam_carto_get_position_response {
 	gpr := C.viam_carto_get_position_response{}
 
@@ -407,12 +383,6 @@ func toSensorReading(sensor string, readings []byte, timestamp time.Time) C.viam
 
 func bstringToByteSlice(bstr C.bstring) []byte {
 	return C.GoBytes(unsafe.Pointer(bstr.data), bstr.slen)
-}
-
-// freeBstringArray used to cleanup a bstring array (needs to be a go func so it can be used in tests)
-func freeBstringArray(arr *C.bstring, length C.int) {
-	lengthSizeT := C.size_t(length)
-	C.free_bstring_array(arr, lengthSizeT)
 }
 
 func toError(status C.int) error {

--- a/cartofacade/capi_test.go
+++ b/cartofacade/capi_test.go
@@ -62,15 +62,11 @@ func TestGetConfig(t *testing.T) {
 		vcc, err := getConfig(cfg)
 		test.That(t, err, test.ShouldBeNil)
 
-		sensors := bStringToGoStringSlice(vcc.sensors, int(vcc.sensors_len))
-		test.That(t, sensors[0], test.ShouldResemble, "mysensor")
-		test.That(t, sensors[1], test.ShouldResemble, "imu")
-		test.That(t, vcc.sensors_len, test.ShouldEqual, 2)
+		camera := bstringToGoString(vcc.camera)
+		test.That(t, camera, test.ShouldResemble, "mysensor")
 
 		dataDir := bstringToGoString(vcc.data_dir)
 		test.That(t, dataDir, test.ShouldResemble, dir)
-
-		freeBstringArray(vcc.sensors, vcc.sensors_len)
 
 		test.That(t, vcc.lidar_config, test.ShouldEqual, TwoD)
 	})

--- a/cartofacade/carto_facade.go
+++ b/cartofacade/carto_facade.go
@@ -20,17 +20,19 @@ var ErrUnableToAcquireLock = errors.New("VIAM_CARTO_UNABLE_TO_ACQUIRE_LOCK")
 func (cf *CartoFacade) Initialize(ctx context.Context, timeout time.Duration, activeBackgroundWorkers *sync.WaitGroup) (SlamMode, error) {
 	cf.startCGoroutine(ctx, activeBackgroundWorkers)
 	untyped, err := cf.request(ctx, initialize, emptyRequestParams, timeout)
+	fmt.Println("6.5")
 	if err != nil {
+		fmt.Println("6.6")
 		return UnknownMode, err
 	}
-
+	fmt.Println("7")
 	carto, ok := untyped.(Carto)
 	if !ok {
 		return UnknownMode, errors.New("unable to cast response from cartofacade to a carto struct")
 	}
 
 	cf.carto = &carto
-
+	fmt.Println("8")
 	return carto.SlamMode, nil
 }
 
@@ -317,11 +319,14 @@ func (cf *CartoFacade) request(
 
 	// wait until work can call into C (and timeout if needed)
 	select {
+
 	case cf.requestChan <- req:
 		select {
 		case response := <-req.responseChan:
+			fmt.Println("6.3")
 			return response.result, response.err
 		case <-ctx.Done():
+			fmt.Println("6.4")
 			msg := "timeout has occurred while trying to read request from cartofacade"
 			return nil, multierr.Combine(errors.New(msg), ctx.Err())
 		}

--- a/cartofacade/carto_facade.go
+++ b/cartofacade/carto_facade.go
@@ -317,7 +317,6 @@ func (cf *CartoFacade) request(
 
 	// wait until work can call into C (and timeout if needed)
 	select {
-
 	case cf.requestChan <- req:
 		select {
 		case response := <-req.responseChan:

--- a/cartofacade/carto_facade.go
+++ b/cartofacade/carto_facade.go
@@ -20,19 +20,17 @@ var ErrUnableToAcquireLock = errors.New("VIAM_CARTO_UNABLE_TO_ACQUIRE_LOCK")
 func (cf *CartoFacade) Initialize(ctx context.Context, timeout time.Duration, activeBackgroundWorkers *sync.WaitGroup) (SlamMode, error) {
 	cf.startCGoroutine(ctx, activeBackgroundWorkers)
 	untyped, err := cf.request(ctx, initialize, emptyRequestParams, timeout)
-	fmt.Println("6.5")
 	if err != nil {
-		fmt.Println("6.6")
 		return UnknownMode, err
 	}
-	fmt.Println("7")
+
 	carto, ok := untyped.(Carto)
 	if !ok {
 		return UnknownMode, errors.New("unable to cast response from cartofacade to a carto struct")
 	}
 
 	cf.carto = &carto
-	fmt.Println("8")
+
 	return carto.SlamMode, nil
 }
 
@@ -323,10 +321,8 @@ func (cf *CartoFacade) request(
 	case cf.requestChan <- req:
 		select {
 		case response := <-req.responseChan:
-			fmt.Println("6.3")
 			return response.result, response.err
 		case <-ctx.Done():
-			fmt.Println("6.4")
 			msg := "timeout has occurred while trying to read request from cartofacade"
 			return nil, multierr.Combine(errors.New(msg), ctx.Err())
 		}

--- a/cartofacade/testhelpers.go
+++ b/cartofacade/testhelpers.go
@@ -5,14 +5,14 @@ import (
 )
 
 // GetTestConfig gets a sample config for testing purposes.
-func GetTestConfig(sensor string) (CartoConfig, string, error) {
+func GetTestConfig(cameraName string) (CartoConfig, string, error) {
 	dir, err := os.MkdirTemp("", "slam-test")
 	if err != nil {
 		return CartoConfig{}, "", err
 	}
 
 	return CartoConfig{
-		Sensors:            []string{sensor, "imu"},
+		Camera:             cameraName,
 		MapRateSecond:      5,
 		DataDir:            dir,
 		ComponentReference: "component",
@@ -23,7 +23,7 @@ func GetTestConfig(sensor string) (CartoConfig, string, error) {
 // GetBadTestConfig gets a sample config for testing purposes that will cause a failure.
 func GetBadTestConfig() CartoConfig {
 	return CartoConfig{
-		Sensors:     []string{"rplidar", "imu"},
+		Camera:      "rplidar",
 		LidarConfig: TwoD,
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -16,29 +16,42 @@ func newError(configError string) error {
 
 // Config describes how to configure the SLAM service.
 type Config struct {
-	Camera        map[string]string `json:"camera"`
-	ConfigParams  map[string]string `json:"config_params"`
-	DataDirectory string            `json:"data_dir"`
-	MapRateSec    *int              `json:"map_rate_sec"`
+	Camera                map[string]string `json:"camera"`
+	ConfigParams          map[string]string `json:"config_params"`
+	DataDirectory         string            `json:"data_dir"`
+	MapRateSec            *int              `json:"map_rate_sec"`
+	IMUIntegrationEnabled *bool             `json:"imu_integration_enabled"`
+	Sensors               []string          `json:"sensors"`
+	DataRateMsec          int               `json:"data_rate_ms"`
 }
 
 var errCameraMustHaveName = errors.New("\"camera[name]\" is required")
 
+// feature flag
 // Validate creates the list of implicit dependencies.
 func (config *Config) Validate(path string) ([]string, error) {
-	cameraName, ok := config.Camera["name"]
-	if !ok {
-		return nil, utils.NewConfigValidationError(path, errCameraMustHaveName)
-	}
-	dataFreqHz, ok := config.Camera["data_frequency_hz"]
-	if ok {
-		dataFreqHz, err := strconv.Atoi(dataFreqHz)
-		if err != nil {
-			return nil, errors.New("camera[data_frequency_hz] must only contain digits")
+	cameraName := ""
+	if *config.IMUIntegrationEnabled {
+		ok := true
+		cameraName, ok = config.Camera["name"]
+		if !ok {
+			return nil, utils.NewConfigValidationError(path, errCameraMustHaveName)
 		}
-		if dataFreqHz < 0 {
-			return nil, errors.New("cannot specify camera[data_frequency_hz] less than zero")
+		dataFreqHz, ok := config.Camera["data_frequency_hz"]
+		if ok {
+			dataFreqHz, err := strconv.Atoi(dataFreqHz)
+			if err != nil {
+				return nil, errors.New("camera[data_frequency_hz] must only contain digits")
+			}
+			if dataFreqHz < 0 {
+				return nil, errors.New("cannot specify camera[data_frequency_hz] less than zero")
+			}
 		}
+	} else {
+		if config.Sensors == nil || len(config.Sensors) < 1 {
+			return nil, utils.NewConfigValidationError(path, errors.New("\"sensors\" must not be empty"))
+		}
+		cameraName = config.Sensors[0]
 	}
 
 	if config.ConfigParams["mode"] == "" {
@@ -60,18 +73,28 @@ func (config *Config) Validate(path string) ([]string, error) {
 
 // GetOptionalParameters sets any unset optional config parameters to the values passed to this function,
 // and returns them.
-func GetOptionalParameters(config *Config, defaultLidarDataRateMSec, defaultMapRateSec int, logger golog.Logger,
+func GetOptionalParameters(config *Config, defaultLidarDataRateMsec, defaultMapRateSec int, logger golog.Logger,
 ) (int, int, error) {
-	lidarDataRateMSec := defaultLidarDataRateMSec
-	strCameraDataFreqHz, ok := config.Camera["data_frequency_hz"]
-	if !ok {
-		logger.Debugf("problem retrieving lidar data frequency, setting to default value of %d", 1000/defaultLidarDataRateMSec)
-	} else {
-		lidarDataFreqHz, err := strconv.Atoi(strCameraDataFreqHz)
-		if err != nil {
-			return 0, 0, errors.New("camera[data_frequency_hz] must only contain digits")
+	lidarDataRateMsec := defaultLidarDataRateMsec
+
+	// feature flag for new config
+	if *config.IMUIntegrationEnabled {
+		strCameraDataFreqHz, ok := config.Camera["data_frequency_hz"]
+		if !ok {
+			logger.Debugf("problem retrieving lidar data frequency, setting to default value of %d", 1000/defaultLidarDataRateMsec)
+		} else {
+			lidarDataFreqHz, err := strconv.Atoi(strCameraDataFreqHz)
+			if err != nil {
+				return 0, 0, errors.New("camera[data_frequency_hz] must only contain digits")
+			}
+			lidarDataRateMsec = 1000 / lidarDataFreqHz
 		}
-		lidarDataRateMSec = 1000 / lidarDataFreqHz
+	} else {
+		lidarDataRateMsec = config.DataRateMsec
+		if config.DataRateMsec == 0 {
+			lidarDataRateMsec = defaultLidarDataRateMsec
+			logger.Debugf("no data_rate_msec given, setting to default value of %d", defaultLidarDataRateMsec)
+		}
 	}
 
 	mapRateSec := 0
@@ -82,5 +105,5 @@ func GetOptionalParameters(config *Config, defaultLidarDataRateMSec, defaultMapR
 		mapRateSec = *config.MapRateSec
 	}
 
-	return lidarDataRateMSec, mapRateSec, nil
+	return lidarDataRateMsec, mapRateSec, nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -80,19 +80,16 @@ func (config *Config) Validate(path string) ([]string, error) {
 // GetOptionalParameters sets any unset optional config parameters to the values passed to this function,
 // and returns them.
 func GetOptionalParameters(config *Config, defaultLidarDataRateMsec, defaultMapRateSec int, logger golog.Logger,
-) (int, int, error) {
+) (int, int) {
 	lidarDataRateMsec := defaultLidarDataRateMsec
 
 	// feature flag for new config
 	if config.UseNewConfig {
 		strCameraDataFreqHz, ok := config.Camera["data_frequency_hz"]
 		if !ok {
-			logger.Debugf("problem retrieving lidar data frequency, setting to default value of %d", 1000/defaultLidarDataRateMsec)
+			logger.Debugf("config did not provide camera[data_frequency_hz], setting to default value of %d", 1000/defaultLidarDataRateMsec)
 		} else {
-			lidarDataFreqHz, err := strconv.Atoi(strCameraDataFreqHz)
-			if err != nil {
-				return 0, 0, errors.New("camera[data_frequency_hz] must only contain digits")
-			}
+			lidarDataFreqHz, _ := strconv.Atoi(strCameraDataFreqHz)
 			lidarDataRateMsec = 1000 / lidarDataFreqHz
 		}
 	} else {
@@ -111,5 +108,5 @@ func GetOptionalParameters(config *Config, defaultLidarDataRateMsec, defaultMapR
 		mapRateSec = *config.MapRateSec
 	}
 
-	return lidarDataRateMsec, mapRateSec, nil
+	return lidarDataRateMsec, mapRateSec
 }

--- a/config/config.go
+++ b/config/config.go
@@ -2,7 +2,6 @@
 package config
 
 import (
-	"fmt"
 	"strconv"
 
 	"github.com/edaniels/golog"
@@ -34,7 +33,6 @@ var errSensorsMustNotBeEmpty = errors.New("\"sensors\" must not be empty")
 func (config *Config) Validate(path string) ([]string, error) {
 	cameraName := ""
 	if config.UseNewConfig {
-		fmt.Println("using new config")
 		ok := true
 		cameraName, ok = config.Camera["name"]
 		if !ok {
@@ -51,7 +49,6 @@ func (config *Config) Validate(path string) ([]string, error) {
 			}
 		}
 	} else {
-		fmt.Println("using old config")
 		if config.Sensors == nil || len(config.Sensors) < 1 {
 			return nil, utils.NewConfigValidationError(path, errors.New("\"sensors\" must not be empty"))
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -21,7 +21,7 @@ type Config struct {
 	ConfigParams  map[string]string `json:"config_params"`
 	DataDirectory string            `json:"data_dir"`
 	MapRateSec    *int              `json:"map_rate_sec"`
-	UseNewConfig  string            `json:"use_new_config"`
+	UseNewConfig  bool              `json:"use_new_config"`
 	Sensors       []string          `json:"sensors"`
 	DataRateMsec  int               `json:"data_rate_msec"`
 }
@@ -33,7 +33,7 @@ var errSensorsMustNotBeEmpty = errors.New("\"sensors\" must not be empty")
 // Validate creates the list of implicit dependencies.
 func (config *Config) Validate(path string) ([]string, error) {
 	cameraName := ""
-	if config.UseNewConfig == "true" {
+	if config.UseNewConfig {
 		fmt.Println("using new config")
 		ok := true
 		cameraName, ok = config.Camera["name"]
@@ -87,7 +87,7 @@ func GetOptionalParameters(config *Config, defaultLidarDataRateMsec, defaultMapR
 	lidarDataRateMsec := defaultLidarDataRateMsec
 
 	// feature flag for new config
-	if config.UseNewConfig == "true" {
+	if config.UseNewConfig {
 		strCameraDataFreqHz, ok := config.Camera["data_frequency_hz"]
 		if !ok {
 			logger.Debugf("problem retrieving lidar data frequency, setting to default value of %d", 1000/defaultLidarDataRateMsec)

--- a/config/config.go
+++ b/config/config.go
@@ -21,7 +21,7 @@ type Config struct {
 	ConfigParams  map[string]string `json:"config_params"`
 	DataDirectory string            `json:"data_dir"`
 	MapRateSec    *int              `json:"map_rate_sec"`
-	UseNewConfig  bool              `json:"use_new_config"`
+	UseNewConfig  string            `json:"use_new_config"`
 	Sensors       []string          `json:"sensors"`
 	DataRateMsec  int               `json:"data_rate_msec"`
 }
@@ -33,7 +33,7 @@ var errSensorsMustNotBeEmpty = errors.New("\"sensors\" must not be empty")
 // Validate creates the list of implicit dependencies.
 func (config *Config) Validate(path string) ([]string, error) {
 	cameraName := ""
-	if config.UseNewConfig {
+	if config.UseNewConfig == "true" {
 		fmt.Println("using new config")
 		ok := true
 		cameraName, ok = config.Camera["name"]
@@ -87,7 +87,7 @@ func GetOptionalParameters(config *Config, defaultLidarDataRateMsec, defaultMapR
 	lidarDataRateMsec := defaultLidarDataRateMsec
 
 	// feature flag for new config
-	if config.UseNewConfig {
+	if config.UseNewConfig == "true" {
 		strCameraDataFreqHz, ok := config.Camera["data_frequency_hz"]
 		if !ok {
 			logger.Debugf("problem retrieving lidar data frequency, setting to default value of %d", 1000/defaultLidarDataRateMsec)

--- a/config/config.go
+++ b/config/config.go
@@ -80,7 +80,7 @@ func (config *Config) Validate(path string) ([]string, error) {
 // GetOptionalParameters sets any unset optional config parameters to the values passed to this function,
 // and returns them.
 func GetOptionalParameters(config *Config, defaultLidarDataRateMsec, defaultMapRateSec int, logger golog.Logger,
-) (int, int) {
+) (int, int, error) {
 	lidarDataRateMsec := defaultLidarDataRateMsec
 
 	// feature flag for new config
@@ -89,7 +89,10 @@ func GetOptionalParameters(config *Config, defaultLidarDataRateMsec, defaultMapR
 		if !ok {
 			logger.Debugf("config did not provide camera[data_frequency_hz], setting to default value of %d", 1000/defaultLidarDataRateMsec)
 		} else {
-			lidarDataFreqHz, _ := strconv.Atoi(strCameraDataFreqHz)
+			lidarDataFreqHz, err := strconv.Atoi(strCameraDataFreqHz)
+			if err != nil {
+				return 0, 0, newError("camera[data_frequency_hz] must only contain digits")
+			}
 			lidarDataRateMsec = 1000 / lidarDataFreqHz
 		}
 	} else {
@@ -108,5 +111,5 @@ func GetOptionalParameters(config *Config, defaultLidarDataRateMsec, defaultMapR
 		mapRateSec = *config.MapRateSec
 	}
 
-	return lidarDataRateMsec, mapRateSec
+	return lidarDataRateMsec, mapRateSec, nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -16,13 +16,13 @@ func newError(configError string) error {
 
 // Config describes how to configure the SLAM service.
 type Config struct {
-	Camera        map[string]string `json:"camera"`
-	ConfigParams  map[string]string `json:"config_params"`
-	DataDirectory string            `json:"data_dir"`
-	MapRateSec    *int              `json:"map_rate_sec"`
-	UseNewConfig  bool              `json:"use_new_config"`
-	Sensors       []string          `json:"sensors"`
-	DataRateMsec  int               `json:"data_rate_msec"`
+	Camera                map[string]string `json:"camera"`
+	ConfigParams          map[string]string `json:"config_params"`
+	DataDirectory         string            `json:"data_dir"`
+	MapRateSec            *int              `json:"map_rate_sec"`
+	IMUIntegrationEnabled bool              `json:"imu_integration_enabled"`
+	Sensors               []string          `json:"sensors"`
+	DataRateMsec          int               `json:"data_rate_msec"`
 }
 
 var (
@@ -33,7 +33,7 @@ var (
 // Validate creates the list of implicit dependencies.
 func (config *Config) Validate(path string) ([]string, error) {
 	cameraName := ""
-	if config.UseNewConfig {
+	if config.IMUIntegrationEnabled {
 		var ok bool
 		cameraName, ok = config.Camera["name"]
 		if !ok {
@@ -84,7 +84,7 @@ func GetOptionalParameters(config *Config, defaultLidarDataRateMsec, defaultMapR
 	lidarDataRateMsec := defaultLidarDataRateMsec
 
 	// feature flag for new config
-	if config.UseNewConfig {
+	if config.IMUIntegrationEnabled {
 		strCameraDataFreqHz, ok := config.Camera["data_frequency_hz"]
 		if !ok {
 			logger.Debugf("config did not provide camera[data_frequency_hz], setting to default value of %d", 1000/defaultLidarDataRateMsec)

--- a/config/config.go
+++ b/config/config.go
@@ -25,15 +25,16 @@ type Config struct {
 	DataRateMsec  int               `json:"data_rate_msec"`
 }
 
-var errCameraMustHaveName = errors.New("\"camera[name]\" is required")
-var errSensorsMustNotBeEmpty = errors.New("\"sensors\" must not be empty")
+var (
+	errCameraMustHaveName    = errors.New("\"camera[name]\" is required")
+	errSensorsMustNotBeEmpty = errors.New("\"sensors\" must not be empty")
+)
 
-// feature flag
 // Validate creates the list of implicit dependencies.
 func (config *Config) Validate(path string) ([]string, error) {
 	cameraName := ""
 	if config.UseNewConfig {
-		ok := true
+		var ok bool
 		cameraName, ok = config.Camera["name"]
 		if !ok {
 			return nil, utils.NewConfigValidationError(path, errCameraMustHaveName)
@@ -80,7 +81,6 @@ func (config *Config) Validate(path string) ([]string, error) {
 // and returns them.
 func GetOptionalParameters(config *Config, defaultLidarDataRateMsec, defaultMapRateSec int, logger golog.Logger,
 ) (int, int, error) {
-
 	lidarDataRateMsec := defaultLidarDataRateMsec
 
 	// feature flag for new config

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -159,9 +159,7 @@ func TestGetOptionalParameters(t *testing.T) {
 }
 
 func newConfig(conf resource.Config) (*Config, error) {
-	fmt.Println(conf.Attributes["use_new_config"])
 	slamConf, err := resource.TransformAttributeMap[*Config](conf.Attributes)
-	fmt.Println(slamConf.UseNewConfig)
 	if err != nil {
 		return &Config{}, newError(err.Error())
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/edaniels/golog"
@@ -15,19 +16,184 @@ func TestValidate(t *testing.T) {
 	logger := golog.NewTestLogger(t)
 
 	t.Run("Empty config", func(t *testing.T) {
+
 		model := resource.DefaultModelFamily.WithModel("test")
 		cfgService := resource.Config{Name: "test", API: slam.API, Model: model}
 		_, err := newConfig(cfgService)
-		test.That(t, err, test.ShouldBeError, newError("error validating \"services.slam.attributes.fake\": \"camera[name]\" is required"))
+		test.That(t, err, test.ShouldBeError, newError("error validating \"services.slam.attributes.fake\": \"sensors\" must not be empty"))
 	})
 
 	t.Run("Simplest valid config", func(t *testing.T) {
-		cfgService := makeCfgService()
+		cfgService := makeCfgService(false)
 		_, err := newConfig(cfgService)
 		test.That(t, err, test.ShouldBeNil)
 	})
 
 	t.Run("Config without required fields", func(t *testing.T) {
+		requiredFields := []string{"data_dir", "sensors"}
+		dataDirErr := utils.NewConfigValidationFieldRequiredError(testCfgPath, requiredFields[0])
+		cameraErr := utils.NewConfigValidationError(testCfgPath, errSensorsMustNotBeEmpty)
+
+		expectedErrors := []error{
+			newError(dataDirErr.Error()),
+			newError(cameraErr.Error()),
+		}
+		for i, requiredField := range requiredFields {
+			logger.Debugf("Testing SLAM config without %s\n", requiredField)
+			cfgService := makeCfgService(false)
+			delete(cfgService.Attributes, requiredField)
+			_, err := newConfig(cfgService)
+
+			test.That(t, err, test.ShouldBeError, expectedErrors[i])
+		}
+		// Test for missing config_params attributes
+		logger.Debug("Testing SLAM config without config_params[mode]")
+		cfgService := makeCfgService(false)
+		delete(cfgService.Attributes["config_params"].(map[string]string), "mode")
+		_, err := newConfig(cfgService)
+		test.That(t, err, test.ShouldBeError, newError(utils.NewConfigValidationFieldRequiredError(testCfgPath, "config_params[mode]").Error()))
+	})
+
+	t.Run("Config with invalid parameter type", func(t *testing.T) {
+		cfgService := makeCfgService(false)
+		cfgService.Attributes["data_dir"] = true
+		_, err := newConfig(cfgService)
+		expE := newError("1 error(s) decoding:\n\n* 'data_dir' expected type 'string', got unconvertible type 'bool', value: 'true'")
+		test.That(t, err, test.ShouldBeError, expE)
+		cfgService.Attributes["data_dir"] = "true"
+		_, err = newConfig(cfgService)
+		test.That(t, err, test.ShouldBeNil)
+	})
+
+	t.Run("Config with out of range values", func(t *testing.T) {
+		cfgService := makeCfgService(false)
+		cfgService.Attributes["data_rate_msec"] = -1
+		_, err := newConfig(cfgService)
+		test.That(t, err, test.ShouldBeError, newError("cannot specify data_rate_msec less than zero"))
+		cfgService.Attributes["data_rate_msec"] = 1
+		cfgService.Attributes["map_rate_sec"] = -1
+		_, err = newConfig(cfgService)
+		test.That(t, err, test.ShouldBeError, newError("cannot specify map_rate_sec less than zero"))
+	})
+
+	t.Run("All parameters e2e", func(t *testing.T) {
+		cfgService := makeCfgService(false)
+		cfgService.Attributes["sensors"] = []string{"a", "b"}
+		cfgService.Attributes["data_rate_msec"] = 1001
+		cfgService.Attributes["map_rate_sec"] = 1002
+
+		cfgService.Attributes["config_params"] = map[string]string{
+			"mode":    "test mode",
+			"value":   "0",
+			"value_2": "test",
+		}
+		cfg, err := newConfig(cfgService)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, cfg.DataDirectory, test.ShouldEqual, cfgService.Attributes["data_dir"])
+		test.That(t, cfg.Sensors, test.ShouldResemble, cfgService.Attributes["sensors"])
+		test.That(t, cfg.DataRateMsec, test.ShouldEqual, cfgService.Attributes["data_rate_msec"])
+		test.That(t, *cfg.MapRateSec, test.ShouldEqual, cfgService.Attributes["map_rate_sec"])
+		test.That(t, cfg.ConfigParams, test.ShouldResemble, cfgService.Attributes["config_params"])
+	})
+}
+
+// makeCfgService creates the simplest possible config that can pass validation.
+func makeCfgService(useNewConfig bool) resource.Config {
+	model := resource.DefaultModelFamily.WithModel("test")
+	cfgService := resource.Config{Name: "test", API: slam.API, Model: model}
+	cfgService.Attributes = make(map[string]interface{})
+	cfgService.Attributes["config_params"] = map[string]string{
+		"mode": "test mode",
+	}
+	cfgService.Attributes["data_dir"] = "path"
+	if useNewConfig {
+		cfgService.Attributes["use_new_config"] = true
+		cfgService.Attributes["camera"] = map[string]string{
+			"name": "a",
+		}
+	} else {
+		cfgService.Attributes["sensors"] = []string{"a"}
+	}
+
+	return cfgService
+}
+
+func TestGetOptionalParameters(t *testing.T) {
+	logger := golog.NewTestLogger(t)
+
+	t.Run("Pass default parameters", func(t *testing.T) {
+		cfgService := makeCfgService(false)
+		cfgService.Attributes["sensors"] = []string{"a"}
+		cfg, err := newConfig(cfgService)
+		test.That(t, err, test.ShouldBeNil)
+		lidarDataRateMsec, mapRateSec, err := GetOptionalParameters(
+			cfg,
+			1000,
+			1002,
+			logger)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, mapRateSec, test.ShouldEqual, 1002)
+		test.That(t, lidarDataRateMsec, test.ShouldEqual, 1000)
+	})
+
+	t.Run("Return overrides", func(t *testing.T) {
+		cfgService := makeCfgService(false)
+		cfgService.Attributes["camera"] = map[string]string{
+			"name":              "a",
+			"data_frequency_hz": "1",
+		}
+		cfg, err := newConfig(cfgService)
+		two := 2
+		cfg.MapRateSec = &two
+		cfg.DataRateMsec = 50
+		test.That(t, err, test.ShouldBeNil)
+		lidarDataRateMsec, mapRateSec, err := GetOptionalParameters(
+			cfg,
+			1000,
+			1002,
+			logger)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, mapRateSec, test.ShouldEqual, 2)
+		test.That(t, lidarDataRateMsec, test.ShouldEqual, 50)
+	})
+}
+
+func newConfig(conf resource.Config) (*Config, error) {
+	fmt.Println(conf.Attributes["use_new_config"])
+	slamConf, err := resource.TransformAttributeMap[*Config](conf.Attributes)
+	fmt.Println(slamConf.UseNewConfig)
+	if err != nil {
+		return &Config{}, newError(err.Error())
+	}
+
+	if _, err := slamConf.Validate("services.slam.attributes.fake"); err != nil {
+		return &Config{}, newError(err.Error())
+	}
+
+	return slamConf, nil
+}
+
+func TestValidateFeatureFlag(t *testing.T) {
+	testCfgPath := "services.slam.attributes.fake"
+	logger := golog.NewTestLogger(t)
+
+	t.Run("Empty config with feature flag enabled", func(t *testing.T) {
+		model := resource.DefaultModelFamily.WithModel("test")
+		cfgService := resource.Config{Name: "test", API: slam.API, Model: model}
+		cfgService.Attributes = make(map[string]interface{})
+		cfgService.Attributes["use_new_config"] = true
+		fmt.Println("get to here")
+		_, err := newConfig(cfgService)
+		test.That(t, err, test.ShouldBeError, newError("error validating \"services.slam.attributes.fake\": \"camera[name]\" is required"))
+	})
+
+	t.Run("Simplest valid config with feature flag enabled", func(t *testing.T) {
+		cfgService := makeCfgService(true)
+		_, err := newConfig(cfgService)
+		test.That(t, err, test.ShouldBeNil)
+	})
+
+	t.Run("Config without required fields with feature flag enabled", func(t *testing.T) {
 		requiredFields := []string{"data_dir", "camera"}
 		dataDirErr := utils.NewConfigValidationFieldRequiredError(testCfgPath, requiredFields[0])
 		cameraErr := utils.NewConfigValidationError(testCfgPath, errCameraMustHaveName)
@@ -38,7 +204,7 @@ func TestValidate(t *testing.T) {
 		}
 		for i, requiredField := range requiredFields {
 			logger.Debugf("Testing SLAM config without %s\n", requiredField)
-			cfgService := makeCfgService()
+			cfgService := makeCfgService(true)
 			delete(cfgService.Attributes, requiredField)
 			_, err := newConfig(cfgService)
 
@@ -46,23 +212,23 @@ func TestValidate(t *testing.T) {
 		}
 		// Test for missing config_params attributes
 		logger.Debug("Testing SLAM config without config_params[mode]")
-		cfgService := makeCfgService()
+		cfgService := makeCfgService(true)
 		delete(cfgService.Attributes["config_params"].(map[string]string), "mode")
 		_, err := newConfig(cfgService)
 		test.That(t, err, test.ShouldBeError, newError(utils.NewConfigValidationFieldRequiredError(testCfgPath, "config_params[mode]").Error()))
 	})
 
-	t.Run("Config without camera name", func(t *testing.T) {
+	t.Run("Config without camera name with feature flag enabled", func(t *testing.T) {
 		// Test for missing camera name attribute
 		logger.Debug("Testing SLAM config without camera[name]")
-		cfgService := makeCfgService()
+		cfgService := makeCfgService(true)
 		delete(cfgService.Attributes["camera"].(map[string]string), "name")
 		_, err := newConfig(cfgService)
 		test.That(t, err, test.ShouldBeError, newError(utils.NewConfigValidationFieldRequiredError(testCfgPath, "camera[name]").Error()))
 	})
 
-	t.Run("Config with invalid parameter type", func(t *testing.T) {
-		cfgService := makeCfgService()
+	t.Run("Config with invalid parameter type with feature flag enabled", func(t *testing.T) {
+		cfgService := makeCfgService(true)
 		cfgService.Attributes["data_dir"] = true
 		_, err := newConfig(cfgService)
 		expE := newError("1 error(s) decoding:\n\n* 'data_dir' expected type 'string', got unconvertible type 'bool', value: 'true'")
@@ -72,8 +238,8 @@ func TestValidate(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 	})
 
-	t.Run("Config with invalid camera data_frequency_hz", func(t *testing.T) {
-		cfgService := makeCfgService()
+	t.Run("Config with invalid camera data_frequency_hz with feature flag enabled", func(t *testing.T) {
+		cfgService := makeCfgService(true)
 		cfgService.Attributes["camera"] = map[string]string{
 			"name":              "a",
 			"data_frequency_hz": "twenty",
@@ -82,8 +248,8 @@ func TestValidate(t *testing.T) {
 		test.That(t, err, test.ShouldBeError, newError("camera[data_frequency_hz] must only contain digits"))
 	})
 
-	t.Run("Config with out of range values", func(t *testing.T) {
-		cfgService := makeCfgService()
+	t.Run("Config with out of range values with feature flag enabled", func(t *testing.T) {
+		cfgService := makeCfgService(true)
 		cfgService.Attributes["camera"] = map[string]string{
 			"name":              "a",
 			"data_frequency_hz": "-1",
@@ -99,8 +265,8 @@ func TestValidate(t *testing.T) {
 		test.That(t, err, test.ShouldBeError, newError("cannot specify map_rate_sec less than zero"))
 	})
 
-	t.Run("All parameters e2e", func(t *testing.T) {
-		cfgService := makeCfgService()
+	t.Run("All parameters e2e with feature flag enabled", func(t *testing.T) {
+		cfgService := makeCfgService(true)
 		cfgService.Attributes["camera"] = map[string]string{
 			"name":              "a",
 			"data_frequency_hz": "20",
@@ -121,27 +287,11 @@ func TestValidate(t *testing.T) {
 	})
 }
 
-// makeCfgService creates the simplest possible config that can pass validation.
-func makeCfgService() resource.Config {
-	model := resource.DefaultModelFamily.WithModel("test")
-	cfgService := resource.Config{Name: "test", API: slam.API, Model: model}
-	cfgService.Attributes = make(map[string]interface{})
-	cfgService.Attributes["config_params"] = map[string]string{
-		"mode": "test mode",
-	}
-	cfgService.Attributes["data_dir"] = "path"
-	cfgService.Attributes["camera"] = map[string]string{
-		"name":              "a",
-		"data_frequency_hz": "20",
-	}
-	return cfgService
-}
-
-func TestGetOptionalParameters(t *testing.T) {
+func TestGetOptionalParametersFeatureFlag(t *testing.T) {
 	logger := golog.NewTestLogger(t)
 
-	t.Run("Pass default parameters", func(t *testing.T) {
-		cfgService := makeCfgService()
+	t.Run("Pass default parameters with feature flag enabled", func(t *testing.T) {
+		cfgService := makeCfgService(true)
 		cfgService.Attributes["camera"] = map[string]string{"name": "a"}
 		cfg, err := newConfig(cfgService)
 		test.That(t, err, test.ShouldBeNil)
@@ -155,8 +305,8 @@ func TestGetOptionalParameters(t *testing.T) {
 		test.That(t, lidarDataRateMsec, test.ShouldEqual, 1000)
 	})
 
-	t.Run("Return overrides", func(t *testing.T) {
-		cfgService := makeCfgService()
+	t.Run("Return overrides with feature flag enabled", func(t *testing.T) {
+		cfgService := makeCfgService(true)
 		cfgService.Attributes["camera"] = map[string]string{
 			"name":              "a",
 			"data_frequency_hz": "1",
@@ -175,17 +325,4 @@ func TestGetOptionalParameters(t *testing.T) {
 		test.That(t, mapRateSec, test.ShouldEqual, 2)
 		test.That(t, lidarDataRateMsec, test.ShouldEqual, 50)
 	})
-}
-
-func newConfig(conf resource.Config) (*Config, error) {
-	slamConf, err := resource.TransformAttributeMap[*Config](conf.Attributes)
-	if err != nil {
-		return &Config{}, newError(err.Error())
-	}
-
-	if _, err := slamConf.Validate("services.slam.attributes.fake"); err != nil {
-		return &Config{}, newError(err.Error())
-	}
-
-	return slamConf, nil
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -96,7 +96,7 @@ func TestValidate(t *testing.T) {
 }
 
 // makeCfgService creates the simplest possible config that can pass validation.
-func makeCfgService(useNewConfig bool) resource.Config {
+func makeCfgService(IMUIntegrationEnabled bool) resource.Config {
 	model := resource.DefaultModelFamily.WithModel("test")
 	cfgService := resource.Config{Name: "test", API: slam.API, Model: model}
 	cfgService.Attributes = make(map[string]interface{})
@@ -104,8 +104,8 @@ func makeCfgService(useNewConfig bool) resource.Config {
 		"mode": "test mode",
 	}
 	cfgService.Attributes["data_dir"] = "path"
-	if useNewConfig {
-		cfgService.Attributes["use_new_config"] = true
+	if IMUIntegrationEnabled {
+		cfgService.Attributes["imu_integration_enabled"] = true
 		cfgService.Attributes["camera"] = map[string]string{
 			"name": "a",
 		}
@@ -177,7 +177,7 @@ func TestValidateFeatureFlag(t *testing.T) {
 		model := resource.DefaultModelFamily.WithModel("test")
 		cfgService := resource.Config{Name: "test", API: slam.API, Model: model}
 		cfgService.Attributes = make(map[string]interface{})
-		cfgService.Attributes["use_new_config"] = true
+		cfgService.Attributes["imu_integration_enabled"] = true
 		_, err := newConfig(cfgService)
 		test.That(t, err, test.ShouldBeError, newError("error validating \"services.slam.attributes.fake\": \"camera[name]\" is required"))
 	})

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -124,7 +124,7 @@ func TestGetOptionalParameters(t *testing.T) {
 		cfgService.Attributes["sensors"] = []string{"a"}
 		cfg, err := newConfig(cfgService)
 		test.That(t, err, test.ShouldBeNil)
-		lidarDataRateMsec, mapRateSec, err := GetOptionalParameters(
+		lidarDataRateMsec, mapRateSec := GetOptionalParameters(
 			cfg,
 			1000,
 			1002,
@@ -145,7 +145,7 @@ func TestGetOptionalParameters(t *testing.T) {
 		cfg.MapRateSec = &two
 		cfg.DataRateMsec = 50
 		test.That(t, err, test.ShouldBeNil)
-		lidarDataRateMsec, mapRateSec, err := GetOptionalParameters(
+		lidarDataRateMsec, mapRateSec := GetOptionalParameters(
 			cfg,
 			1000,
 			1002,
@@ -265,7 +265,7 @@ func TestGetOptionalParametersFeatureFlag(t *testing.T) {
 		cfgService.Attributes["camera"] = map[string]string{"name": "a"}
 		cfg, err := newConfig(cfgService)
 		test.That(t, err, test.ShouldBeNil)
-		lidarDataRateMsec, mapRateSec, err := GetOptionalParameters(
+		lidarDataRateMsec, mapRateSec := GetOptionalParameters(
 			cfg,
 			1000,
 			1002,
@@ -286,7 +286,7 @@ func TestGetOptionalParametersFeatureFlag(t *testing.T) {
 		cfg.MapRateSec = &two
 		cfg.Camera["data_frequency_hz"] = "20"
 		test.That(t, err, test.ShouldBeNil)
-		lidarDataRateMsec, mapRateSec, err := GetOptionalParameters(
+		lidarDataRateMsec, mapRateSec := GetOptionalParameters(
 			cfg,
 			1000,
 			1002,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/edaniels/golog"
@@ -16,7 +15,6 @@ func TestValidate(t *testing.T) {
 	logger := golog.NewTestLogger(t)
 
 	t.Run("Empty config", func(t *testing.T) {
-
 		model := resource.DefaultModelFamily.WithModel("test")
 		cfgService := resource.Config{Name: "test", API: slam.API, Model: model}
 		_, err := newConfig(cfgService)
@@ -180,7 +178,6 @@ func TestValidateFeatureFlag(t *testing.T) {
 		cfgService := resource.Config{Name: "test", API: slam.API, Model: model}
 		cfgService.Attributes = make(map[string]interface{})
 		cfgService.Attributes["use_new_config"] = true
-		fmt.Println("get to here")
 		_, err := newConfig(cfgService)
 		test.That(t, err, test.ShouldBeError, newError("error validating \"services.slam.attributes.fake\": \"camera[name]\" is required"))
 	})
@@ -189,31 +186,6 @@ func TestValidateFeatureFlag(t *testing.T) {
 		cfgService := makeCfgService(true)
 		_, err := newConfig(cfgService)
 		test.That(t, err, test.ShouldBeNil)
-	})
-
-	t.Run("Config without required fields with feature flag enabled", func(t *testing.T) {
-		requiredFields := []string{"data_dir", "camera"}
-		dataDirErr := utils.NewConfigValidationFieldRequiredError(testCfgPath, requiredFields[0])
-		cameraErr := utils.NewConfigValidationError(testCfgPath, errCameraMustHaveName)
-
-		expectedErrors := []error{
-			newError(dataDirErr.Error()),
-			newError(cameraErr.Error()),
-		}
-		for i, requiredField := range requiredFields {
-			logger.Debugf("Testing SLAM config without %s\n", requiredField)
-			cfgService := makeCfgService(true)
-			delete(cfgService.Attributes, requiredField)
-			_, err := newConfig(cfgService)
-
-			test.That(t, err, test.ShouldBeError, expectedErrors[i])
-		}
-		// Test for missing config_params attributes
-		logger.Debug("Testing SLAM config without config_params[mode]")
-		cfgService := makeCfgService(true)
-		delete(cfgService.Attributes["config_params"].(map[string]string), "mode")
-		_, err := newConfig(cfgService)
-		test.That(t, err, test.ShouldBeError, newError(utils.NewConfigValidationFieldRequiredError(testCfgPath, "config_params[mode]").Error()))
 	})
 
 	t.Run("Config without camera name with feature flag enabled", func(t *testing.T) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -18,7 +18,7 @@ func TestValidate(t *testing.T) {
 		model := resource.DefaultModelFamily.WithModel("test")
 		cfgService := resource.Config{Name: "test", API: slam.API, Model: model}
 		_, err := newConfig(cfgService)
-		test.That(t, err, test.ShouldBeError, newError("error validating \"services.slam.attributes.fake\": \"sensors\" must not be empty"))
+		test.That(t, err, test.ShouldBeError, newError("error validating \"services.slam.attributes.fake\": \"camera[name]\" is required"))
 	})
 
 	t.Run("Simplest valid config", func(t *testing.T) {
@@ -28,13 +28,13 @@ func TestValidate(t *testing.T) {
 	})
 
 	t.Run("Config without required fields", func(t *testing.T) {
-		requiredFields := []string{"data_dir", "sensors"}
+		requiredFields := []string{"data_dir", "camera"}
 		dataDirErr := utils.NewConfigValidationFieldRequiredError(testCfgPath, requiredFields[0])
-		sensorsErr := utils.NewConfigValidationError(testCfgPath, errSensorsMustNotBeEmpty)
+		cameraErr := utils.NewConfigValidationError(testCfgPath, errCameraMustHaveName)
 
 		expectedErrors := []error{
 			newError(dataDirErr.Error()),
-			newError(sensorsErr.Error()),
+			newError(cameraErr.Error()),
 		}
 		for i, requiredField := range requiredFields {
 			logger.Debugf("Testing SLAM config without %s\n", requiredField)
@@ -52,6 +52,15 @@ func TestValidate(t *testing.T) {
 		test.That(t, err, test.ShouldBeError, newError(utils.NewConfigValidationFieldRequiredError(testCfgPath, "config_params[mode]").Error()))
 	})
 
+	t.Run("Config without camera name", func(t *testing.T) {
+		// Test for missing camera name attribute
+		logger.Debug("Testing SLAM config without camera[name]")
+		cfgService := makeCfgService()
+		delete(cfgService.Attributes["camera"].(map[string]string), "name")
+		_, err := newConfig(cfgService)
+		test.That(t, err, test.ShouldBeError, newError(utils.NewConfigValidationFieldRequiredError(testCfgPath, "camera[name]").Error()))
+	})
+
 	t.Run("Config with invalid parameter type", func(t *testing.T) {
 		cfgService := makeCfgService()
 		cfgService.Attributes["data_dir"] = true
@@ -63,12 +72,28 @@ func TestValidate(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 	})
 
+	t.Run("Config with invalid camera data_frequency_hz", func(t *testing.T) {
+		cfgService := makeCfgService()
+		cfgService.Attributes["camera"] = map[string]string{
+			"name":              "a",
+			"data_frequency_hz": "twenty",
+		}
+		_, err := newConfig(cfgService)
+		test.That(t, err, test.ShouldBeError, newError("camera[data_frequency_hz] must only contain digits"))
+	})
+
 	t.Run("Config with out of range values", func(t *testing.T) {
 		cfgService := makeCfgService()
-		cfgService.Attributes["data_rate_msec"] = -1
+		cfgService.Attributes["camera"] = map[string]string{
+			"name":              "a",
+			"data_frequency_hz": "-1",
+		}
 		_, err := newConfig(cfgService)
-		test.That(t, err, test.ShouldBeError, newError("cannot specify data_rate_msec less than zero"))
-		cfgService.Attributes["data_rate_msec"] = 1
+		test.That(t, err, test.ShouldBeError, newError("cannot specify camera[data_frequency_hz] less than zero"))
+		cfgService.Attributes["camera"] = map[string]string{
+			"name":              "a",
+			"data_frequency_hz": "1",
+		}
 		cfgService.Attributes["map_rate_sec"] = -1
 		_, err = newConfig(cfgService)
 		test.That(t, err, test.ShouldBeError, newError("cannot specify map_rate_sec less than zero"))
@@ -76,8 +101,10 @@ func TestValidate(t *testing.T) {
 
 	t.Run("All parameters e2e", func(t *testing.T) {
 		cfgService := makeCfgService()
-		cfgService.Attributes["sensors"] = []string{"a", "b"}
-		cfgService.Attributes["data_rate_msec"] = 1001
+		cfgService.Attributes["camera"] = map[string]string{
+			"name":              "a",
+			"data_frequency_hz": "20",
+		}
 		cfgService.Attributes["map_rate_sec"] = 1002
 
 		cfgService.Attributes["config_params"] = map[string]string{
@@ -88,8 +115,7 @@ func TestValidate(t *testing.T) {
 		cfg, err := newConfig(cfgService)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, cfg.DataDirectory, test.ShouldEqual, cfgService.Attributes["data_dir"])
-		test.That(t, cfg.Sensors, test.ShouldResemble, cfgService.Attributes["sensors"])
-		test.That(t, cfg.DataRateMsec, test.ShouldEqual, cfgService.Attributes["data_rate_msec"])
+		test.That(t, cfg.Camera, test.ShouldResemble, cfgService.Attributes["camera"])
 		test.That(t, *cfg.MapRateSec, test.ShouldEqual, cfgService.Attributes["map_rate_sec"])
 		test.That(t, cfg.ConfigParams, test.ShouldResemble, cfgService.Attributes["config_params"])
 	})
@@ -104,7 +130,10 @@ func makeCfgService() resource.Config {
 		"mode": "test mode",
 	}
 	cfgService.Attributes["data_dir"] = "path"
-	cfgService.Attributes["sensors"] = []string{"a"}
+	cfgService.Attributes["camera"] = map[string]string{
+		"name":              "a",
+		"data_frequency_hz": "20",
+	}
 	return cfgService
 }
 
@@ -113,33 +142,38 @@ func TestGetOptionalParameters(t *testing.T) {
 
 	t.Run("Pass default parameters", func(t *testing.T) {
 		cfgService := makeCfgService()
-		cfgService.Attributes["sensors"] = []string{"a"}
+		cfgService.Attributes["camera"] = map[string]string{"name": "a"}
 		cfg, err := newConfig(cfgService)
 		test.That(t, err, test.ShouldBeNil)
-		dataRateMsec, mapRateSec := GetOptionalParameters(
+		lidarDataRateMSec, mapRateSec, err := GetOptionalParameters(
 			cfg,
-			1001,
+			1000,
 			1002,
 			logger)
-		test.That(t, dataRateMsec, test.ShouldEqual, 1001)
+		test.That(t, err, test.ShouldBeNil)
 		test.That(t, mapRateSec, test.ShouldEqual, 1002)
+		test.That(t, lidarDataRateMSec, test.ShouldEqual, 1000)
 	})
 
 	t.Run("Return overrides", func(t *testing.T) {
 		cfgService := makeCfgService()
-		cfgService.Attributes["sensors"] = []string{"a"}
+		cfgService.Attributes["camera"] = map[string]string{
+			"name":              "a",
+			"data_frequency_hz": "1",
+		}
 		cfg, err := newConfig(cfgService)
 		two := 2
-		cfg.DataRateMsec = 1
 		cfg.MapRateSec = &two
+		cfg.Camera["data_frequency_hz"] = "20"
 		test.That(t, err, test.ShouldBeNil)
-		dataRateMsec, mapRateSec := GetOptionalParameters(
+		lidarDataRateMSec, mapRateSec, err := GetOptionalParameters(
 			cfg,
-			1001,
+			1000,
 			1002,
 			logger)
-		test.That(t, dataRateMsec, test.ShouldEqual, 1)
+		test.That(t, err, test.ShouldBeNil)
 		test.That(t, mapRateSec, test.ShouldEqual, 2)
+		test.That(t, lidarDataRateMSec, test.ShouldEqual, 50)
 	})
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -145,14 +145,14 @@ func TestGetOptionalParameters(t *testing.T) {
 		cfgService.Attributes["camera"] = map[string]string{"name": "a"}
 		cfg, err := newConfig(cfgService)
 		test.That(t, err, test.ShouldBeNil)
-		lidarDataRateMSec, mapRateSec, err := GetOptionalParameters(
+		lidarDataRateMsec, mapRateSec, err := GetOptionalParameters(
 			cfg,
 			1000,
 			1002,
 			logger)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, mapRateSec, test.ShouldEqual, 1002)
-		test.That(t, lidarDataRateMSec, test.ShouldEqual, 1000)
+		test.That(t, lidarDataRateMsec, test.ShouldEqual, 1000)
 	})
 
 	t.Run("Return overrides", func(t *testing.T) {
@@ -166,14 +166,14 @@ func TestGetOptionalParameters(t *testing.T) {
 		cfg.MapRateSec = &two
 		cfg.Camera["data_frequency_hz"] = "20"
 		test.That(t, err, test.ShouldBeNil)
-		lidarDataRateMSec, mapRateSec, err := GetOptionalParameters(
+		lidarDataRateMsec, mapRateSec, err := GetOptionalParameters(
 			cfg,
 			1000,
 			1002,
 			logger)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, mapRateSec, test.ShouldEqual, 2)
-		test.That(t, lidarDataRateMSec, test.ShouldEqual, 50)
+		test.That(t, lidarDataRateMsec, test.ShouldEqual, 50)
 	})
 }
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -124,9 +124,9 @@ func testHelperCartographer(
 		ConfigParams: map[string]string{
 			"mode": reflect.ValueOf(subAlgo).String(),
 		},
-		MapRateSec:    &mapRateSec,
-		DataDirectory: dataDirectory,
-		UseNewConfig:  true,
+		MapRateSec:            &mapRateSec,
+		DataDirectory:         dataDirectory,
+		IMUIntegrationEnabled: true,
 	}
 
 	done := make(chan struct{})

--- a/integration_test.go
+++ b/integration_test.go
@@ -120,7 +120,7 @@ func testHelperCartographer(
 	defer termFunc()
 
 	attrCfg := &vcConfig.Config{
-		Sensors: []string{"stub_lidar"},
+		Camera: map[string]string{"name": "stub_lidar"},
 		ConfigParams: map[string]string{
 			"mode": reflect.ValueOf(subAlgo).String(),
 		},
@@ -130,17 +130,14 @@ func testHelperCartographer(
 
 	done := make(chan struct{})
 	sensorReadingInterval := time.Millisecond * 200
-	timedSensor, err := testhelper.IntegrationLidarTimedSensor(t, attrCfg.Sensors[0], replaySensor, sensorReadingInterval, done)
+	timedSensor, err := testhelper.IntegrationLidarTimedSensor(t, attrCfg.Camera["name"], replaySensor, sensorReadingInterval, done)
 	test.That(t, err, test.ShouldBeNil)
-
 	svc, err := testhelper.CreateIntegrationSLAMService(t, attrCfg, timedSensor, logger)
 	test.That(t, err, test.ShouldBeNil)
 	start := time.Now()
-
 	cSvc, ok := svc.(*viamcartographer.CartographerService)
 	test.That(t, ok, test.ShouldBeTrue)
 	test.That(t, cSvc.SlamMode, test.ShouldEqual, expectedMode)
-
 	ctx, cancelFunc := context.WithTimeout(context.Background(), time.Second*5)
 
 	defer cancelFunc()
@@ -150,7 +147,7 @@ func testHelperCartographer(
 		test.That(t, errors.New("test timeout"), test.ShouldBeNil)
 	}
 
-	testCartographerPosition(t, svc, attrCfg.Sensors[0])
+	testCartographerPosition(t, svc, attrCfg.Camera["name"])
 	testCartographerMap(t, svc, cSvc.SlamMode == cartofacade.LocalizingMode)
 
 	internalState, err := slam.GetInternalStateFull(context.Background(), svc)

--- a/integration_test.go
+++ b/integration_test.go
@@ -126,6 +126,7 @@ func testHelperCartographer(
 		},
 		MapRateSec:    &mapRateSec,
 		DataDirectory: dataDirectory,
+		UseNewConfig:  true,
 	}
 
 	done := make(chan struct{})

--- a/integration_test.go
+++ b/integration_test.go
@@ -134,6 +134,7 @@ func testHelperCartographer(
 	test.That(t, err, test.ShouldBeNil)
 	svc, err := testhelper.CreateIntegrationSLAMService(t, attrCfg, timedSensor, logger)
 	test.That(t, err, test.ShouldBeNil)
+
 	start := time.Now()
 	cSvc, ok := svc.(*viamcartographer.CartographerService)
 	test.That(t, ok, test.ShouldBeTrue)

--- a/integration_test.go
+++ b/integration_test.go
@@ -126,7 +126,7 @@ func testHelperCartographer(
 		},
 		MapRateSec:    &mapRateSec,
 		DataDirectory: dataDirectory,
-		UseNewConfig:  "true",
+		UseNewConfig:  true,
 	}
 
 	done := make(chan struct{})

--- a/integration_test.go
+++ b/integration_test.go
@@ -126,7 +126,7 @@ func testHelperCartographer(
 		},
 		MapRateSec:    &mapRateSec,
 		DataDirectory: dataDirectory,
-		UseNewConfig:  true,
+		UseNewConfig:  "true",
 	}
 
 	done := make(chan struct{})

--- a/integration_test.go
+++ b/integration_test.go
@@ -76,7 +76,7 @@ func testCartographerPosition(t *testing.T, svc slam.Service, expectedComponentR
 		test.That(t, actualPos.Y, test.ShouldBeBetween, expectedPosLinux.Y-tolerancePos, expectedPosLinux.Y+tolerancePos)
 		test.That(t, actualPos.Z, test.ShouldBeBetween, expectedPosLinux.Z-tolerancePos, expectedPosLinux.Z+tolerancePos)
 	} else {
-		t.Error("Position is outside of expected platform range")
+		t.Error("TEST FAILED Position is outside of expected platform range")
 	}
 
 	actualOri := position.Orientation().AxisAngles()
@@ -91,7 +91,7 @@ func testCartographerPosition(t *testing.T, svc slam.Service, expectedComponentR
 		test.That(t, actualOri.RY, test.ShouldBeBetween, expectedOriLinux.RY-toleranceOri, expectedOriLinux.RY+toleranceOri)
 		test.That(t, actualOri.RZ, test.ShouldBeBetween, expectedOriLinux.RZ-toleranceOri, expectedOriLinux.RZ+toleranceOri)
 	} else {
-		t.Error("Orientation is outside of expected platform range")
+		t.Error("TEST FAILED Orientation is outside of expected platform range")
 	}
 }
 
@@ -99,11 +99,11 @@ func saveInternalState(t *testing.T, internalState []byte, dataDir string) {
 	timeStamp := time.Now()
 	internalStateDir := filepath.Join(dataDir, "internal_state")
 	if err := os.Mkdir(internalStateDir, 0o755); err != nil {
-		t.Error("failed to create test internal state directory")
+		t.Error("TEST FAILED failed to create test internal state directory")
 	}
 	filename := filepath.Join(internalStateDir, "map_data_"+timeStamp.UTC().Format(testhelper.SlamTimeFormat)+".pbstream")
 	if err := os.WriteFile(filename, internalState, 0o644); err != nil {
-		t.Error("failed to write test internal state")
+		t.Error("TEST FAILED failed to write test internal state")
 	}
 }
 

--- a/sensorprocess/sensorprocess.go
+++ b/sensorprocess/sensorprocess.go
@@ -20,7 +20,7 @@ type Config struct {
 	CartoFacade       cartofacade.Interface
 	Lidar             sensors.TimedSensor
 	LidarName         string
-	LidarDataRateMSec int
+	LidarDataRateMsec int
 	Timeout           time.Duration
 	Logger            golog.Logger
 }
@@ -98,5 +98,5 @@ func addSensorReadingFromLiveReadings(ctx context.Context, reading []byte, readi
 		}
 	}
 	timeElapsedMs := int(time.Since(startTime).Milliseconds())
-	return int(math.Max(0, float64(config.LidarDataRateMSec-timeElapsedMs)))
+	return int(math.Max(0, float64(config.LidarDataRateMsec-timeElapsedMs)))
 }

--- a/sensorprocess/sensorprocess.go
+++ b/sensorprocess/sensorprocess.go
@@ -17,12 +17,12 @@ import (
 
 // Config holds config needed throughout the process of adding a sensor reading to the cartofacade.
 type Config struct {
-	CartoFacade cartofacade.Interface
-	Lidar       sensors.TimedSensor
-	LidarName   string
-	DataRateMs  int
-	Timeout     time.Duration
-	Logger      golog.Logger
+	CartoFacade       cartofacade.Interface
+	Lidar             sensors.TimedSensor
+	LidarName         string
+	LidarDataRateMSec int
+	Timeout           time.Duration
+	Logger            golog.Logger
 }
 
 // Start polls the lidar to get the next sensor reading and adds it to the cartofacade.
@@ -98,5 +98,5 @@ func addSensorReadingFromLiveReadings(ctx context.Context, reading []byte, readi
 		}
 	}
 	timeElapsedMs := int(time.Since(startTime).Milliseconds())
-	return int(math.Max(0, float64(config.DataRateMs-timeElapsedMs)))
+	return int(math.Max(0, float64(config.LidarDataRateMSec-timeElapsedMs)))
 }

--- a/sensorprocess/sensorprocess_test.go
+++ b/sensorprocess/sensorprocess_test.go
@@ -41,11 +41,11 @@ func TestAddSensorReadingReplaySensor(t *testing.T) {
 	readingTimestamp := time.Now().UTC()
 	cf := cartofacade.Mock{}
 	config := Config{
-		Logger:      logger,
-		CartoFacade: &cf,
-		LidarName:   "good_lidar",
-		DataRateMs:  200,
-		Timeout:     10 * time.Second,
+		Logger:            logger,
+		CartoFacade:       &cf,
+		LidarName:         "good_lidar",
+		LidarDataRateMSec: 200,
+		Timeout:           10 * time.Second,
 	}
 	t.Run("When addSensorReading returns successfully, no infinite loop", func(t *testing.T) {
 		cf.AddSensorReadingFunc = func(
@@ -138,14 +138,14 @@ func TestAddSensorReadingLiveReadings(t *testing.T) {
 	reading := []byte("12345")
 	readingTimestamp := time.Now().UTC()
 	config := Config{
-		Logger:      logger,
-		CartoFacade: &cf,
-		LidarName:   "good_lidar",
-		DataRateMs:  200,
-		Timeout:     10 * time.Second,
+		Logger:            logger,
+		CartoFacade:       &cf,
+		LidarName:         "good_lidar",
+		LidarDataRateMSec: 200,
+		Timeout:           10 * time.Second,
 	}
 
-	t.Run("When AddSensorReading blocks for more than the DataRateMs and succeeds, time to sleep is 0", func(t *testing.T) {
+	t.Run("When AddSensorReading blocks for more than the DataFreqHz and succeeds, time to sleep is 0", func(t *testing.T) {
 		cf.AddSensorReadingFunc = func(
 			ctx context.Context,
 			timeout time.Duration,
@@ -161,7 +161,7 @@ func TestAddSensorReadingLiveReadings(t *testing.T) {
 		test.That(t, timeToSleep, test.ShouldEqual, 0)
 	})
 
-	t.Run("AddSensorReading slower than DataRateMs and returns lock error, time to sleep is 0", func(t *testing.T) {
+	t.Run("AddSensorReading slower than DataFreqHz and returns lock error, time to sleep is 0", func(t *testing.T) {
 		cf.AddSensorReadingFunc = func(
 			ctx context.Context,
 			timeout time.Duration,
@@ -177,7 +177,7 @@ func TestAddSensorReadingLiveReadings(t *testing.T) {
 		test.That(t, timeToSleep, test.ShouldEqual, 0)
 	})
 
-	t.Run("When AddSensorReading blocks for more than the DataRateMs and returns an unexpected error, time to sleep is 0", func(t *testing.T) {
+	t.Run("When AddSensorReading blocks for more than the DataFreqHz and returns an unexpected error, time to sleep is 0", func(t *testing.T) {
 		cf.AddSensorReadingFunc = func(
 			ctx context.Context,
 			timeout time.Duration,
@@ -193,7 +193,7 @@ func TestAddSensorReadingLiveReadings(t *testing.T) {
 		test.That(t, timeToSleep, test.ShouldEqual, 0)
 	})
 
-	t.Run("AddSensorReading faster than the DataRateMs and succeeds, time to sleep is <= DataRateMs", func(t *testing.T) {
+	t.Run("AddSensorReading faster than the DataFreqHz and succeeds, time to sleep is <= DataFreqHz", func(t *testing.T) {
 		cf.AddSensorReadingFunc = func(
 			ctx context.Context,
 			timeout time.Duration,
@@ -206,10 +206,10 @@ func TestAddSensorReadingLiveReadings(t *testing.T) {
 
 		timeToSleep := addSensorReadingFromLiveReadings(context.Background(), reading, readingTimestamp, config)
 		test.That(t, timeToSleep, test.ShouldBeGreaterThan, 0)
-		test.That(t, timeToSleep, test.ShouldBeLessThanOrEqualTo, config.DataRateMs)
+		test.That(t, timeToSleep, test.ShouldBeLessThanOrEqualTo, config.LidarDataRateMSec)
 	})
 
-	t.Run("AddSensorReading faster than the DataRateMs and returns lock error, time to sleep is <= DataRateMs", func(t *testing.T) {
+	t.Run("AddSensorReading faster than the DataFreqHz and returns lock error, time to sleep is <= DataFreqHz", func(t *testing.T) {
 		cf.AddSensorReadingFunc = func(
 			ctx context.Context,
 			timeout time.Duration,
@@ -222,10 +222,10 @@ func TestAddSensorReadingLiveReadings(t *testing.T) {
 
 		timeToSleep := addSensorReadingFromLiveReadings(context.Background(), reading, readingTimestamp, config)
 		test.That(t, timeToSleep, test.ShouldBeGreaterThan, 0)
-		test.That(t, timeToSleep, test.ShouldBeLessThanOrEqualTo, config.DataRateMs)
+		test.That(t, timeToSleep, test.ShouldBeLessThanOrEqualTo, config.LidarDataRateMSec)
 	})
 
-	t.Run("AddSensorReading faster than DataRateMs and returns unexpected error, time to sleep is <= DataRateMs", func(t *testing.T) {
+	t.Run("AddSensorReading faster than DataFreqHz and returns unexpected error, time to sleep is <= DataFreqHz", func(t *testing.T) {
 		cf.AddSensorReadingFunc = func(
 			ctx context.Context,
 			timeout time.Duration,
@@ -238,7 +238,7 @@ func TestAddSensorReadingLiveReadings(t *testing.T) {
 
 		timeToSleep := addSensorReadingFromLiveReadings(context.Background(), reading, readingTimestamp, config)
 		test.That(t, timeToSleep, test.ShouldBeGreaterThan, 0)
-		test.That(t, timeToSleep, test.ShouldBeLessThanOrEqualTo, config.DataRateMs)
+		test.That(t, timeToSleep, test.ShouldBeLessThanOrEqualTo, config.LidarDataRateMSec)
 	})
 }
 
@@ -247,10 +247,10 @@ func invalidSensorTestHelper(
 	t *testing.T,
 	cartoFacadeMock cartofacade.Mock,
 	config Config,
-	sensors []string,
+	cameraName string,
 ) {
 	logger := golog.NewTestLogger(t)
-	sensor, err := s.NewLidar(context.Background(), s.SetupDeps(sensors), sensors, logger)
+	sensor, err := s.NewLidar(context.Background(), s.SetupDeps(cameraName), cameraName, logger)
 	test.That(t, err, test.ShouldBeNil)
 
 	var calls []addSensorReadingArgs
@@ -283,39 +283,39 @@ func TestAddSensorReading(t *testing.T) {
 	cf := cartofacade.Mock{}
 
 	config := Config{
-		Logger:      logger,
-		CartoFacade: &cf,
-		DataRateMs:  200,
-		Timeout:     10 * time.Second,
+		Logger:            logger,
+		CartoFacade:       &cf,
+		LidarDataRateMSec: 200,
+		Timeout:           10 * time.Second,
 	}
 	ctx := context.Background()
 
 	t.Run("returns error when lidar GetData returns error, doesn't try to add sensor data", func(t *testing.T) {
-		sensors := []string{"invalid_sensor"}
+		cam := map[string]string{"name": "invalid_lidar"}
 		invalidSensorTestHelper(
 			ctx,
 			t,
 			cf,
 			config,
-			sensors,
+			cam["name"],
 		)
 	})
 
 	t.Run("returns error when replay sensor timestamp is invalid, doesn't try to add sensor data", func(t *testing.T) {
-		sensors := []string{"invalid_replay_sensor"}
+		cam := map[string]string{"name": "invalid_replay_lidar"}
 		invalidSensorTestHelper(
 			ctx,
 			t,
 			cf,
 			config,
-			sensors,
+			cam["name"],
 		)
 	})
 
 	t.Run("replay sensor adds sensor data until success", func(t *testing.T) {
-		sensors := []string{"replay_sensor"}
+		cam := map[string]string{"name": "replay_lidar"}
 		logger := golog.NewTestLogger(t)
-		replaySensor, err := s.NewLidar(context.Background(), s.SetupDeps(sensors), sensors, logger)
+		replaySensor, err := s.NewLidar(context.Background(), s.SetupDeps(cam["name"]), cam["name"], logger)
 		test.That(t, err, test.ShouldBeNil)
 
 		var calls []addSensorReadingArgs
@@ -351,7 +351,7 @@ func TestAddSensorReading(t *testing.T) {
 		firstTimestamp := calls[0].readingTimestamp
 		for i, call := range calls {
 			t.Logf("call %d", i)
-			test.That(t, call.sensorName, test.ShouldResemble, "replay_sensor")
+			test.That(t, call.sensorName, test.ShouldResemble, "replay_lidar")
 			test.That(t, call.currentReading, test.ShouldResemble, expectedPCD)
 			test.That(t, call.timeout, test.ShouldEqual, config.Timeout)
 			test.That(t, call.readingTimestamp, test.ShouldEqual, firstTimestamp)
@@ -359,9 +359,9 @@ func TestAddSensorReading(t *testing.T) {
 	})
 
 	t.Run("live sensor adds sensor reading once and ignores errors", func(t *testing.T) {
-		sensors := []string{"good_lidar"}
+		cam := map[string]string{"name": "good_lidar"}
 		logger := golog.NewTestLogger(t)
-		liveSensor, err := s.NewLidar(context.Background(), s.SetupDeps(sensors), sensors, logger)
+		liveSensor, err := s.NewLidar(context.Background(), s.SetupDeps(cam["name"]), cam["name"], logger)
 		test.That(t, err, test.ShouldBeNil)
 
 		var calls []addSensorReadingArgs
@@ -415,9 +415,9 @@ func TestAddSensorReading(t *testing.T) {
 	})
 
 	t.Run("returns true when lidar returns an error that it reached end of dataset", func(t *testing.T) {
-		sensors := []string{"finished_replay_sensor"}
+		cam := map[string]string{"name": "finished_replay_lidar"}
 		logger := golog.NewTestLogger(t)
-		replaySensor, err := s.NewLidar(context.Background(), s.SetupDeps(sensors), sensors, logger)
+		replaySensor, err := s.NewLidar(context.Background(), s.SetupDeps(cam["name"]), cam["name"], logger)
 		test.That(t, err, test.ShouldBeNil)
 
 		config.Lidar = replaySensor
@@ -432,17 +432,17 @@ func TestStart(t *testing.T) {
 	cf := cartofacade.Mock{}
 
 	config := Config{
-		Logger:      logger,
-		CartoFacade: &cf,
-		DataRateMs:  200,
-		Timeout:     10 * time.Second,
+		Logger:            logger,
+		CartoFacade:       &cf,
+		LidarDataRateMSec: 200,
+		Timeout:           10 * time.Second,
 	}
 	cancelCtx, cancelFunc := context.WithCancel(context.Background())
 
 	t.Run("returns true when lidar returns an error that it reached end of dataset but the context is valid", func(t *testing.T) {
-		sensors := []string{"finished_replay_sensor"}
+		cam := map[string]string{"name": "finished_replay_lidar"}
 		logger := golog.NewTestLogger(t)
-		replaySensor, err := s.NewLidar(context.Background(), s.SetupDeps(sensors), sensors, logger)
+		replaySensor, err := s.NewLidar(context.Background(), s.SetupDeps(cam["name"]), cam["name"], logger)
 		test.That(t, err, test.ShouldBeNil)
 
 		config.Lidar = replaySensor
@@ -452,9 +452,9 @@ func TestStart(t *testing.T) {
 	})
 
 	t.Run("returns false when lidar returns an error that it reached end of dataset but the context was cancelled", func(t *testing.T) {
-		sensors := []string{"finished_replay_sensor"}
+		cam := map[string]string{"name": "finished_replay_lidar"}
 		logger := golog.NewTestLogger(t)
-		replaySensor, err := s.NewLidar(context.Background(), s.SetupDeps(sensors), sensors, logger)
+		replaySensor, err := s.NewLidar(context.Background(), s.SetupDeps(cam["name"]), cam["name"], logger)
 		test.That(t, err, test.ShouldBeNil)
 
 		config.Lidar = replaySensor

--- a/sensorprocess/sensorprocess_test.go
+++ b/sensorprocess/sensorprocess_test.go
@@ -291,31 +291,31 @@ func TestAddSensorReading(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("returns error when lidar GetData returns error, doesn't try to add sensor data", func(t *testing.T) {
-		cam := map[string]string{"name": "invalid_lidar"}
+		cam := "invalid_lidar"
 		invalidSensorTestHelper(
 			ctx,
 			t,
 			cf,
 			config,
-			cam["name"],
+			cam,
 		)
 	})
 
 	t.Run("returns error when replay sensor timestamp is invalid, doesn't try to add sensor data", func(t *testing.T) {
-		cam := map[string]string{"name": "invalid_replay_lidar"}
+		cam := "invalid_replay_lidar"
 		invalidSensorTestHelper(
 			ctx,
 			t,
 			cf,
 			config,
-			cam["name"],
+			cam,
 		)
 	})
 
 	t.Run("replay sensor adds sensor data until success", func(t *testing.T) {
-		cam := map[string]string{"name": "replay_lidar"}
+		cam := "replay_lidar"
 		logger := golog.NewTestLogger(t)
-		replaySensor, err := s.NewLidar(context.Background(), s.SetupDeps(cam["name"]), cam["name"], logger)
+		replaySensor, err := s.NewLidar(context.Background(), s.SetupDeps(cam), cam, logger)
 		test.That(t, err, test.ShouldBeNil)
 
 		var calls []addSensorReadingArgs
@@ -359,9 +359,9 @@ func TestAddSensorReading(t *testing.T) {
 	})
 
 	t.Run("live sensor adds sensor reading once and ignores errors", func(t *testing.T) {
-		cam := map[string]string{"name": "good_lidar"}
+		cam := "good_lidar"
 		logger := golog.NewTestLogger(t)
-		liveSensor, err := s.NewLidar(context.Background(), s.SetupDeps(cam["name"]), cam["name"], logger)
+		liveSensor, err := s.NewLidar(context.Background(), s.SetupDeps(cam), cam, logger)
 		test.That(t, err, test.ShouldBeNil)
 
 		var calls []addSensorReadingArgs
@@ -415,9 +415,9 @@ func TestAddSensorReading(t *testing.T) {
 	})
 
 	t.Run("returns true when lidar returns an error that it reached end of dataset", func(t *testing.T) {
-		cam := map[string]string{"name": "finished_replay_lidar"}
+		cam := "finished_replay_lidar"
 		logger := golog.NewTestLogger(t)
-		replaySensor, err := s.NewLidar(context.Background(), s.SetupDeps(cam["name"]), cam["name"], logger)
+		replaySensor, err := s.NewLidar(context.Background(), s.SetupDeps(cam), cam, logger)
 		test.That(t, err, test.ShouldBeNil)
 
 		config.Lidar = replaySensor
@@ -440,9 +440,9 @@ func TestStart(t *testing.T) {
 	cancelCtx, cancelFunc := context.WithCancel(context.Background())
 
 	t.Run("returns true when lidar returns an error that it reached end of dataset but the context is valid", func(t *testing.T) {
-		cam := map[string]string{"name": "finished_replay_lidar"}
+		cam := "finished_replay_lidar"
 		logger := golog.NewTestLogger(t)
-		replaySensor, err := s.NewLidar(context.Background(), s.SetupDeps(cam["name"]), cam["name"], logger)
+		replaySensor, err := s.NewLidar(context.Background(), s.SetupDeps(cam), cam, logger)
 		test.That(t, err, test.ShouldBeNil)
 
 		config.Lidar = replaySensor
@@ -452,9 +452,9 @@ func TestStart(t *testing.T) {
 	})
 
 	t.Run("returns false when lidar returns an error that it reached end of dataset but the context was cancelled", func(t *testing.T) {
-		cam := map[string]string{"name": "finished_replay_lidar"}
+		cam := "finished_replay_lidar"
 		logger := golog.NewTestLogger(t)
-		replaySensor, err := s.NewLidar(context.Background(), s.SetupDeps(cam["name"]), cam["name"], logger)
+		replaySensor, err := s.NewLidar(context.Background(), s.SetupDeps(cam), cam, logger)
 		test.That(t, err, test.ShouldBeNil)
 
 		config.Lidar = replaySensor

--- a/sensorprocess/sensorprocess_test.go
+++ b/sensorprocess/sensorprocess_test.go
@@ -44,7 +44,7 @@ func TestAddSensorReadingReplaySensor(t *testing.T) {
 		Logger:            logger,
 		CartoFacade:       &cf,
 		LidarName:         "good_lidar",
-		LidarDataRateMSec: 200,
+		LidarDataRateMsec: 200,
 		Timeout:           10 * time.Second,
 	}
 	t.Run("When addSensorReading returns successfully, no infinite loop", func(t *testing.T) {
@@ -141,7 +141,7 @@ func TestAddSensorReadingLiveReadings(t *testing.T) {
 		Logger:            logger,
 		CartoFacade:       &cf,
 		LidarName:         "good_lidar",
-		LidarDataRateMSec: 200,
+		LidarDataRateMsec: 200,
 		Timeout:           10 * time.Second,
 	}
 
@@ -206,7 +206,7 @@ func TestAddSensorReadingLiveReadings(t *testing.T) {
 
 		timeToSleep := addSensorReadingFromLiveReadings(context.Background(), reading, readingTimestamp, config)
 		test.That(t, timeToSleep, test.ShouldBeGreaterThan, 0)
-		test.That(t, timeToSleep, test.ShouldBeLessThanOrEqualTo, config.LidarDataRateMSec)
+		test.That(t, timeToSleep, test.ShouldBeLessThanOrEqualTo, config.LidarDataRateMsec)
 	})
 
 	t.Run("AddSensorReading faster than the DataFreqHz and returns lock error, time to sleep is <= DataFreqHz", func(t *testing.T) {
@@ -222,7 +222,7 @@ func TestAddSensorReadingLiveReadings(t *testing.T) {
 
 		timeToSleep := addSensorReadingFromLiveReadings(context.Background(), reading, readingTimestamp, config)
 		test.That(t, timeToSleep, test.ShouldBeGreaterThan, 0)
-		test.That(t, timeToSleep, test.ShouldBeLessThanOrEqualTo, config.LidarDataRateMSec)
+		test.That(t, timeToSleep, test.ShouldBeLessThanOrEqualTo, config.LidarDataRateMsec)
 	})
 
 	t.Run("AddSensorReading faster than DataFreqHz and returns unexpected error, time to sleep is <= DataFreqHz", func(t *testing.T) {
@@ -238,7 +238,7 @@ func TestAddSensorReadingLiveReadings(t *testing.T) {
 
 		timeToSleep := addSensorReadingFromLiveReadings(context.Background(), reading, readingTimestamp, config)
 		test.That(t, timeToSleep, test.ShouldBeGreaterThan, 0)
-		test.That(t, timeToSleep, test.ShouldBeLessThanOrEqualTo, config.LidarDataRateMSec)
+		test.That(t, timeToSleep, test.ShouldBeLessThanOrEqualTo, config.LidarDataRateMsec)
 	})
 }
 
@@ -285,7 +285,7 @@ func TestAddSensorReading(t *testing.T) {
 	config := Config{
 		Logger:            logger,
 		CartoFacade:       &cf,
-		LidarDataRateMSec: 200,
+		LidarDataRateMsec: 200,
 		Timeout:           10 * time.Second,
 	}
 	ctx := context.Background()
@@ -434,7 +434,7 @@ func TestStart(t *testing.T) {
 	config := Config{
 		Logger:            logger,
 		CartoFacade:       &cf,
-		LidarDataRateMSec: 200,
+		LidarDataRateMsec: 200,
 		Timeout:           10 * time.Second,
 	}
 	cancelCtx, cancelFunc := context.WithCancel(context.Background())

--- a/sensors/sensors.go
+++ b/sensors/sensors.go
@@ -48,6 +48,7 @@ func NewLidar(
 		return Lidar{}, errors.Wrapf(err, "error getting lidar camera %v for slam service", cameraName)
 	}
 
+	// https://viam.atlassian.net/browse/RSDK-4306
 	// To be implemented once replay camera supports Properties
 	// // If there is a camera provided in the 'camera' field, we enforce that it supports PCD.
 	// properties, err := newLidar.Properties(ctx)

--- a/sensors/sensors.go
+++ b/sensors/sensors.go
@@ -40,6 +40,7 @@ func NewLidar(
 	deps resource.Dependencies,
 	cameraName string,
 	logger golog.Logger,
+	useNewConfig bool,
 ) (Lidar, error) {
 	_, span := trace.StartSpan(ctx, "viamcartographer::sensors::NewLidar")
 	defer span.End()
@@ -47,15 +48,17 @@ func NewLidar(
 	if err != nil {
 		return Lidar{}, errors.Wrapf(err, "error getting lidar camera %v for slam service", cameraName)
 	}
-	// If there is a camera provided in the 'camera' field, we enforce that it supports PCD.
-	properties, err := newLidar.Properties(ctx)
-	if err != nil {
-		return Lidar{}, errors.Wrapf(err, "error getting lidar camera properties %v for slam service", cameraName)
-	}
+	if useNewConfig {
+		// If there is a camera provided in the 'camera' field, we enforce that it supports PCD.
+		properties, err := newLidar.Properties(ctx)
+		if err != nil {
+			return Lidar{}, errors.Wrapf(err, "error getting lidar camera properties %v for slam service", cameraName)
+		}
 
-	if !properties.SupportsPCD {
-		return Lidar{}, errors.New("configuring lidar camera error: " +
-			"'camera' must support PCD")
+		if !properties.SupportsPCD {
+			return Lidar{}, errors.New("configuring lidar camera error: " +
+				"'camera' must support PCD")
+		}
 	}
 
 	return Lidar{

--- a/sensors/sensors.go
+++ b/sensors/sensors.go
@@ -40,7 +40,6 @@ func NewLidar(
 	deps resource.Dependencies,
 	cameraName string,
 	logger golog.Logger,
-	useNewConfig bool,
 ) (Lidar, error) {
 	_, span := trace.StartSpan(ctx, "viamcartographer::sensors::NewLidar")
 	defer span.End()
@@ -48,18 +47,18 @@ func NewLidar(
 	if err != nil {
 		return Lidar{}, errors.Wrapf(err, "error getting lidar camera %v for slam service", cameraName)
 	}
-	if useNewConfig {
-		// If there is a camera provided in the 'camera' field, we enforce that it supports PCD.
-		properties, err := newLidar.Properties(ctx)
-		if err != nil {
-			return Lidar{}, errors.Wrapf(err, "error getting lidar camera properties %v for slam service", cameraName)
-		}
 
-		if !properties.SupportsPCD {
-			return Lidar{}, errors.New("configuring lidar camera error: " +
-				"'camera' must support PCD")
-		}
-	}
+	// To be implemented once replay camera supports Properties
+	// // If there is a camera provided in the 'camera' field, we enforce that it supports PCD.
+	// properties, err := newLidar.Properties(ctx)
+	// if err != nil {
+	// 	return Lidar{}, errors.Wrapf(err, "error getting lidar camera properties %v for slam service", cameraName)
+	// }
+
+	// if !properties.SupportsPCD {
+	// 	return Lidar{}, errors.New("configuring lidar camera error: " +
+	// 		"'camera' must support PCD")
+	// }
 
 	return Lidar{
 		Name:  cameraName,

--- a/sensors/sensors.go
+++ b/sensors/sensors.go
@@ -4,7 +4,6 @@ package sensors
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/edaniels/golog"
@@ -44,16 +43,12 @@ func NewLidar(
 ) (Lidar, error) {
 	_, span := trace.StartSpan(ctx, "viamcartographer::sensors::NewLidar")
 	defer span.End()
-	fmt.Println(cameraName)
 	newLidar, err := camera.FromDependencies(deps, cameraName)
 	if err != nil {
 		return Lidar{}, errors.Wrapf(err, "error getting lidar camera %v for slam service", cameraName)
 	}
-	fmt.Println("am here")
-	fmt.Println(newLidar)
 	// If there is a camera provided in the 'camera' field, we enforce that it supports PCD.
 	properties, err := newLidar.Properties(ctx)
-	fmt.Println("got here")
 	if err != nil {
 		return Lidar{}, errors.Wrapf(err, "error getting lidar camera properties %v for slam service", cameraName)
 	}

--- a/sensors/sensors_test.go
+++ b/sensors/sensors_test.go
@@ -25,9 +25,10 @@ func TestValidateGetData(t *testing.T) {
 	invalidLidar, err := s.NewLidar(ctx, s.SetupDeps(lidar["name"]), lidar["name"], logger)
 	test.That(t, err, test.ShouldBeNil)
 
-	lidar = map[string]string{"name": "np_pcd_camera"}
-	_, err = s.NewLidar(ctx, s.SetupDeps(lidar["name"]), lidar["name"], logger)
-	test.That(t, err, test.ShouldBeError, errors.New("configuring lidar camera error: 'camera' must support PCD"))
+	// test not relevant until replay camera supports Properties
+	// lidar = map[string]string{"name": "no_pcd_camera"}
+	// _, err = s.NewLidar(ctx, s.SetupDeps(lidar["name"]), lidar["name"], logger)
+	// test.That(t, err, test.ShouldBeError, errors.New("configuring lidar camera error: 'camera' must support PCD"))
 
 	sensorValidationMaxTimeout := time.Duration(50) * time.Millisecond
 	sensorValidationInterval := time.Duration(10) * time.Millisecond

--- a/sensors/sensors_test.go
+++ b/sensors/sensors_test.go
@@ -17,13 +17,17 @@ func TestValidateGetData(t *testing.T) {
 	logger := golog.NewTestLogger(t)
 	ctx := context.Background()
 
-	sensors := []string{"good_lidar"}
-	goodLidar, err := s.NewLidar(ctx, s.SetupDeps(sensors), sensors, logger)
+	lidar := map[string]string{"name": "good_lidar"}
+	goodLidar, err := s.NewLidar(ctx, s.SetupDeps(lidar["name"]), lidar["name"], logger)
 	test.That(t, err, test.ShouldBeNil)
 
-	sensors = []string{"invalid_sensor"}
-	invalidLidar, err := s.NewLidar(ctx, s.SetupDeps(sensors), sensors, logger)
+	lidar = map[string]string{"name": "invalid_lidar"}
+	invalidLidar, err := s.NewLidar(ctx, s.SetupDeps(lidar["name"]), lidar["name"], logger)
 	test.That(t, err, test.ShouldBeNil)
+
+	lidar = map[string]string{"name": "np_pcd_camera"}
+	_, err = s.NewLidar(ctx, s.SetupDeps(lidar["name"]), lidar["name"], logger)
+	test.That(t, err, test.ShouldBeError, errors.New("configuring lidar camera error: 'camera' must support PCD"))
 
 	sensorValidationMaxTimeout := time.Duration(50) * time.Millisecond
 	sensorValidationInterval := time.Duration(10) * time.Millisecond
@@ -34,10 +38,9 @@ func TestValidateGetData(t *testing.T) {
 	})
 
 	t.Run("returns nil if a lidar reading succeeds within the timeout", func(t *testing.T) {
-		sensors = []string{"warming_up_lidar"}
-		warmingUpLidar, err := s.NewLidar(ctx, s.SetupDeps(sensors), sensors, logger)
+		lidar = map[string]string{"name": "warming_up_lidar"}
+		warmingUpLidar, err := s.NewLidar(ctx, s.SetupDeps(lidar["name"]), lidar["name"], logger)
 		test.That(t, err, test.ShouldBeNil)
-
 		err = s.ValidateGetData(ctx, warmingUpLidar, sensorValidationMaxTimeout, sensorValidationInterval, logger)
 		test.That(t, err, test.ShouldBeNil)
 	})
@@ -51,8 +54,8 @@ func TestValidateGetData(t *testing.T) {
 		cancelledCtx, cancelFunc := context.WithCancel(context.Background())
 		cancelFunc()
 
-		sensors = []string{"warming_up_lidar"}
-		warmingUpLidar, err := s.NewLidar(ctx, s.SetupDeps(sensors), sensors, logger)
+		lidar = map[string]string{"name": "warming_up_lidar"}
+		warmingUpLidar, err := s.NewLidar(ctx, s.SetupDeps(lidar["name"]), lidar["name"], logger)
 		test.That(t, err, test.ShouldBeNil)
 
 		err = s.ValidateGetData(cancelledCtx, warmingUpLidar, sensorValidationMaxTimeout, sensorValidationInterval, logger)
@@ -64,28 +67,18 @@ func TestNewLidar(t *testing.T) {
 	logger := golog.NewTestLogger(t)
 
 	t.Run("No sensor provided", func(t *testing.T) {
-		sensors := []string{}
-		deps := s.SetupDeps(sensors)
-		actualLidar, err := s.NewLidar(context.Background(), deps, sensors, logger)
-		expectedLidar := s.Lidar{}
-		test.That(t, actualLidar, test.ShouldResemble, expectedLidar)
-		test.That(t, err, test.ShouldBeNil)
-	})
-
-	t.Run("Failed lidar creation due to more than one sensor provided", func(t *testing.T) {
-		sensors := []string{"lidar", "one-too-many"}
-		deps := s.SetupDeps(sensors)
-		actualLidar, err := s.NewLidar(context.Background(), deps, sensors, logger)
-		expectedLidar := s.Lidar{}
-		test.That(t, actualLidar, test.ShouldResemble, expectedLidar)
+		lidar := map[string]string{}
+		deps := s.SetupDeps(lidar["name"])
+		_, err := s.NewLidar(context.Background(), deps, lidar["name"], logger)
 		test.That(t, err, test.ShouldBeError,
-			errors.New("configuring lidar camera error: 'sensors' must contain only one lidar camera, but is 'sensors: [lidar, one-too-many]'"))
+			errors.New("error getting lidar camera "+
+				" for slam service: \"rdk:component:camera/\" missing from dependencies"))
 	})
 
 	t.Run("Failed lidar creation with non-existing sensor", func(t *testing.T) {
-		sensors := []string{"gibberish"}
-		deps := s.SetupDeps(sensors)
-		actualLidar, err := s.NewLidar(context.Background(), deps, sensors, logger)
+		lidar := map[string]string{"name": "gibberish"}
+		deps := s.SetupDeps(lidar["name"])
+		actualLidar, err := s.NewLidar(context.Background(), deps, lidar["name"], logger)
 		expectedLidar := s.Lidar{}
 		test.That(t, actualLidar, test.ShouldResemble, expectedLidar)
 		test.That(t, err, test.ShouldBeError,
@@ -94,11 +87,11 @@ func TestNewLidar(t *testing.T) {
 	})
 
 	t.Run("Successful lidar creation", func(t *testing.T) {
-		sensors := []string{"good_lidar"}
+		lidar := map[string]string{"name": "good_lidar"}
 		ctx := context.Background()
-		deps := s.SetupDeps(sensors)
-		actualLidar, err := s.NewLidar(ctx, deps, sensors, logger)
-		test.That(t, actualLidar.Name, test.ShouldEqual, sensors[0])
+		deps := s.SetupDeps(lidar["name"])
+		actualLidar, err := s.NewLidar(ctx, deps, lidar["name"], logger)
+		test.That(t, actualLidar.Name, test.ShouldEqual, lidar["name"])
 		test.That(t, err, test.ShouldBeNil)
 
 		tsr, err := actualLidar.TimedSensorReading(ctx)
@@ -111,20 +104,20 @@ func TestTimedSensorReading(t *testing.T) {
 	logger := golog.NewTestLogger(t)
 	ctx := context.Background()
 
-	sensors := []string{"invalid_sensor"}
-	invalidLidar, err := s.NewLidar(ctx, s.SetupDeps(sensors), sensors, logger)
+	lidar := map[string]string{"name": "invalid_lidar"}
+	invalidLidar, err := s.NewLidar(ctx, s.SetupDeps(lidar["name"]), lidar["name"], logger)
 	test.That(t, err, test.ShouldBeNil)
 
-	sensors = []string{"invalid_replay_sensor"}
-	invalidReplayLidar, err := s.NewLidar(ctx, s.SetupDeps(sensors), sensors, logger)
+	lidar = map[string]string{"name": "invalid_replay_lidar"}
+	invalidReplayLidar, err := s.NewLidar(ctx, s.SetupDeps(lidar["name"]), lidar["name"], logger)
 	test.That(t, err, test.ShouldBeNil)
 
-	sensors = []string{"good_lidar"}
-	goodLidar, err := s.NewLidar(ctx, s.SetupDeps(sensors), sensors, logger)
+	lidar = map[string]string{"name": "good_lidar"}
+	goodLidar, err := s.NewLidar(ctx, s.SetupDeps(lidar["name"]), lidar["name"], logger)
 	test.That(t, err, test.ShouldBeNil)
 
-	sensors = []string{"replay_sensor"}
-	goodReplayLidar, err := s.NewLidar(ctx, s.SetupDeps(sensors), sensors, logger)
+	lidar = map[string]string{"name": "replay_lidar"}
+	goodReplayLidar, err := s.NewLidar(ctx, s.SetupDeps(lidar["name"]), lidar["name"], logger)
 	test.That(t, err, test.ShouldBeNil)
 
 	t.Run("when the lidar returns an error, returns that error", func(t *testing.T) {

--- a/sensors/sensors_test.go
+++ b/sensors/sensors_test.go
@@ -17,17 +17,18 @@ func TestValidateGetData(t *testing.T) {
 	logger := golog.NewTestLogger(t)
 	ctx := context.Background()
 
-	lidar := map[string]string{"name": "good_lidar"}
-	goodLidar, err := s.NewLidar(ctx, s.SetupDeps(lidar["name"]), lidar["name"], logger)
+	lidar := "good_lidar"
+	goodLidar, err := s.NewLidar(ctx, s.SetupDeps(lidar), lidar, logger)
 	test.That(t, err, test.ShouldBeNil)
 
-	lidar = map[string]string{"name": "invalid_lidar"}
-	invalidLidar, err := s.NewLidar(ctx, s.SetupDeps(lidar["name"]), lidar["name"], logger)
+	lidar = "invalid_lidar"
+	invalidLidar, err := s.NewLidar(ctx, s.SetupDeps(lidar), lidar, logger)
 	test.That(t, err, test.ShouldBeNil)
 
+	// https://viam.atlassian.net/browse/RSDK-4306
 	// test not relevant until replay camera supports Properties
 	// lidar = map[string]string{"name": "no_pcd_camera"}
-	// _, err = s.NewLidar(ctx, s.SetupDeps(lidar["name"]), lidar["name"], logger)
+	// _, err = s.NewLidar(ctx, s.SetupDeps(lidar), lidar, logger)
 	// test.That(t, err, test.ShouldBeError, errors.New("configuring lidar camera error: 'camera' must support PCD"))
 
 	sensorValidationMaxTimeout := time.Duration(50) * time.Millisecond
@@ -39,8 +40,8 @@ func TestValidateGetData(t *testing.T) {
 	})
 
 	t.Run("returns nil if a lidar reading succeeds within the timeout", func(t *testing.T) {
-		lidar = map[string]string{"name": "warming_up_lidar"}
-		warmingUpLidar, err := s.NewLidar(ctx, s.SetupDeps(lidar["name"]), lidar["name"], logger)
+		lidar = "warming_up_lidar"
+		warmingUpLidar, err := s.NewLidar(ctx, s.SetupDeps(lidar), lidar, logger)
 		test.That(t, err, test.ShouldBeNil)
 		err = s.ValidateGetData(ctx, warmingUpLidar, sensorValidationMaxTimeout, sensorValidationInterval, logger)
 		test.That(t, err, test.ShouldBeNil)
@@ -55,8 +56,8 @@ func TestValidateGetData(t *testing.T) {
 		cancelledCtx, cancelFunc := context.WithCancel(context.Background())
 		cancelFunc()
 
-		lidar = map[string]string{"name": "warming_up_lidar"}
-		warmingUpLidar, err := s.NewLidar(ctx, s.SetupDeps(lidar["name"]), lidar["name"], logger)
+		lidar = "warming_up_lidar"
+		warmingUpLidar, err := s.NewLidar(ctx, s.SetupDeps(lidar), lidar, logger)
 		test.That(t, err, test.ShouldBeNil)
 
 		err = s.ValidateGetData(cancelledCtx, warmingUpLidar, sensorValidationMaxTimeout, sensorValidationInterval, logger)
@@ -68,18 +69,18 @@ func TestNewLidar(t *testing.T) {
 	logger := golog.NewTestLogger(t)
 
 	t.Run("No sensor provided", func(t *testing.T) {
-		lidar := map[string]string{}
-		deps := s.SetupDeps(lidar["name"])
-		_, err := s.NewLidar(context.Background(), deps, lidar["name"], logger)
+		lidar := ""
+		deps := s.SetupDeps(lidar)
+		_, err := s.NewLidar(context.Background(), deps, lidar, logger)
 		test.That(t, err, test.ShouldBeError,
 			errors.New("error getting lidar camera "+
 				" for slam service: \"rdk:component:camera/\" missing from dependencies"))
 	})
 
 	t.Run("Failed lidar creation with non-existing sensor", func(t *testing.T) {
-		lidar := map[string]string{"name": "gibberish"}
-		deps := s.SetupDeps(lidar["name"])
-		actualLidar, err := s.NewLidar(context.Background(), deps, lidar["name"], logger)
+		lidar := "gibberish"
+		deps := s.SetupDeps(lidar)
+		actualLidar, err := s.NewLidar(context.Background(), deps, lidar, logger)
 		expectedLidar := s.Lidar{}
 		test.That(t, actualLidar, test.ShouldResemble, expectedLidar)
 		test.That(t, err, test.ShouldBeError,
@@ -88,11 +89,11 @@ func TestNewLidar(t *testing.T) {
 	})
 
 	t.Run("Successful lidar creation", func(t *testing.T) {
-		lidar := map[string]string{"name": "good_lidar"}
+		lidar := "good_lidar"
 		ctx := context.Background()
-		deps := s.SetupDeps(lidar["name"])
-		actualLidar, err := s.NewLidar(ctx, deps, lidar["name"], logger)
-		test.That(t, actualLidar.Name, test.ShouldEqual, lidar["name"])
+		deps := s.SetupDeps(lidar)
+		actualLidar, err := s.NewLidar(ctx, deps, lidar, logger)
+		test.That(t, actualLidar.Name, test.ShouldEqual, lidar)
 		test.That(t, err, test.ShouldBeNil)
 
 		tsr, err := actualLidar.TimedSensorReading(ctx)
@@ -105,20 +106,20 @@ func TestTimedSensorReading(t *testing.T) {
 	logger := golog.NewTestLogger(t)
 	ctx := context.Background()
 
-	lidar := map[string]string{"name": "invalid_lidar"}
-	invalidLidar, err := s.NewLidar(ctx, s.SetupDeps(lidar["name"]), lidar["name"], logger)
+	lidar := "invalid_lidar"
+	invalidLidar, err := s.NewLidar(ctx, s.SetupDeps(lidar), lidar, logger)
 	test.That(t, err, test.ShouldBeNil)
 
-	lidar = map[string]string{"name": "invalid_replay_lidar"}
-	invalidReplayLidar, err := s.NewLidar(ctx, s.SetupDeps(lidar["name"]), lidar["name"], logger)
+	lidar = "invalid_replay_lidar"
+	invalidReplayLidar, err := s.NewLidar(ctx, s.SetupDeps(lidar), lidar, logger)
 	test.That(t, err, test.ShouldBeNil)
 
-	lidar = map[string]string{"name": "good_lidar"}
-	goodLidar, err := s.NewLidar(ctx, s.SetupDeps(lidar["name"]), lidar["name"], logger)
+	lidar = "good_lidar"
+	goodLidar, err := s.NewLidar(ctx, s.SetupDeps(lidar), lidar, logger)
 	test.That(t, err, test.ShouldBeNil)
 
-	lidar = map[string]string{"name": "replay_lidar"}
-	goodReplayLidar, err := s.NewLidar(ctx, s.SetupDeps(lidar["name"]), lidar["name"], logger)
+	lidar = "replay_lidar"
+	goodReplayLidar, err := s.NewLidar(ctx, s.SetupDeps(lidar), lidar, logger)
 	test.That(t, err, test.ShouldBeNil)
 
 	t.Run("when the lidar returns an error, returns that error", func(t *testing.T) {

--- a/sensors/test_deps.go
+++ b/sensors/test_deps.go
@@ -21,30 +21,28 @@ const (
 	BadTime = "NOT A TIME"
 )
 
-// SetupDeps returns the dependencies based on the sensors passed as arguments.
-func SetupDeps(sensors []string) resource.Dependencies {
+// SetupDeps returns the dependencies based on the lidar passed as argument.
+func SetupDeps(lidarName string) resource.Dependencies {
 	deps := make(resource.Dependencies)
-
-	for _, sensor := range sensors {
-		switch sensor {
-		case "good_lidar":
-			deps[camera.Named(sensor)] = getGoodLidar()
-		case "warming_up_lidar":
-			deps[camera.Named(sensor)] = getWarmingUpLidar()
-		case "replay_sensor":
-			deps[camera.Named(sensor)] = getReplaySensor(TestTime)
-		case "invalid_replay_sensor":
-			deps[camera.Named(sensor)] = getReplaySensor(BadTime)
-		case "invalid_sensor":
-			deps[camera.Named(sensor)] = getInvalidSensor()
-		case "gibberish":
-			return deps
-		case "finished_replay_sensor":
-			deps[camera.Named(sensor)] = getFinishedReplaySensor()
-		default:
-			continue
-		}
+	switch lidarName {
+	case "good_lidar":
+		deps[camera.Named(lidarName)] = getGoodLidar()
+	case "warming_up_lidar":
+		deps[camera.Named(lidarName)] = getWarmingUpLidar()
+	case "replay_lidar":
+		deps[camera.Named(lidarName)] = getReplayLidar(TestTime)
+	case "invalid_replay_lidar":
+		deps[camera.Named(lidarName)] = getReplayLidar(BadTime)
+	case "invalid_lidar":
+		deps[camera.Named(lidarName)] = getInvalidLidar()
+	case "np_pcd_camera":
+		deps[camera.Named(lidarName)] = getNoPCDCamera()
+	case "gibberish_lidar":
+		return deps
+	case "finished_replay_lidar":
+		deps[camera.Named(lidarName)] = getFinishedReplayLidar()
 	}
+
 	return deps
 }
 
@@ -65,7 +63,7 @@ func getWarmingUpLidar() *inject.Camera {
 		return nil, transform.NewNoIntrinsicsError("")
 	}
 	cam.PropertiesFunc = func(ctx context.Context) (camera.Properties, error) {
-		return camera.Properties{}, nil
+		return camera.Properties{SupportsPCD: true}, nil
 	}
 	return cam
 }
@@ -82,12 +80,12 @@ func getGoodLidar() *inject.Camera {
 		return nil, transform.NewNoIntrinsicsError("")
 	}
 	cam.PropertiesFunc = func(ctx context.Context) (camera.Properties, error) {
-		return camera.Properties{}, nil
+		return camera.Properties{SupportsPCD: true}, nil
 	}
 	return cam
 }
 
-func getReplaySensor(testTime string) *inject.Camera {
+func getReplayLidar(testTime string) *inject.Camera {
 	cam := &inject.Camera{}
 	cam.NextPointCloudFunc = func(ctx context.Context) (pointcloud.PointCloud, error) {
 		md := ctx.Value(contextutils.MetadataContextKey)
@@ -103,12 +101,12 @@ func getReplaySensor(testTime string) *inject.Camera {
 		return nil, transform.NewNoIntrinsicsError("")
 	}
 	cam.PropertiesFunc = func(ctx context.Context) (camera.Properties, error) {
-		return camera.Properties{}, nil
+		return camera.Properties{SupportsPCD: true}, nil
 	}
 	return cam
 }
 
-func getInvalidSensor() *inject.Camera {
+func getInvalidLidar() *inject.Camera {
 	cam := &inject.Camera{}
 	cam.NextPointCloudFunc = func(ctx context.Context) (pointcloud.PointCloud, error) {
 		return nil, errors.New("invalid sensor")
@@ -119,10 +117,30 @@ func getInvalidSensor() *inject.Camera {
 	cam.ProjectorFunc = func(ctx context.Context) (transform.Projector, error) {
 		return nil, transform.NewNoIntrinsicsError("")
 	}
+	cam.PropertiesFunc = func(ctx context.Context) (camera.Properties, error) {
+		return camera.Properties{SupportsPCD: true}, nil
+	}
 	return cam
 }
 
-func getFinishedReplaySensor() *inject.Camera {
+func getNoPCDCamera() *inject.Camera {
+	cam := &inject.Camera{}
+	cam.NextPointCloudFunc = func(ctx context.Context) (pointcloud.PointCloud, error) {
+		return nil, errors.New("invalid camera")
+	}
+	cam.StreamFunc = func(ctx context.Context, errHandlers ...gostream.ErrorHandler) (gostream.VideoStream, error) {
+		return nil, errors.New("invalid camera")
+	}
+	cam.ProjectorFunc = func(ctx context.Context) (transform.Projector, error) {
+		return nil, transform.NewNoIntrinsicsError("")
+	}
+	cam.PropertiesFunc = func(ctx context.Context) (camera.Properties, error) {
+		return camera.Properties{SupportsPCD: false}, nil
+	}
+	return cam
+}
+
+func getFinishedReplayLidar() *inject.Camera {
 	cam := &inject.Camera{}
 	cam.NextPointCloudFunc = func(ctx context.Context) (pointcloud.PointCloud, error) {
 		return nil, replaypcd.ErrEndOfDataset
@@ -134,7 +152,7 @@ func getFinishedReplaySensor() *inject.Camera {
 		return nil, transform.NewNoIntrinsicsError("")
 	}
 	cam.PropertiesFunc = func(ctx context.Context) (camera.Properties, error) {
-		return camera.Properties{}, nil
+		return camera.Properties{SupportsPCD: true}, nil
 	}
 	return cam
 }

--- a/sensors/test_deps.go
+++ b/sensors/test_deps.go
@@ -35,8 +35,6 @@ func SetupDeps(lidarName string) resource.Dependencies {
 		deps[camera.Named(lidarName)] = getReplayLidar(BadTime)
 	case "invalid_lidar":
 		deps[camera.Named(lidarName)] = getInvalidLidar()
-	case "no_pcd_camera":
-		deps[camera.Named(lidarName)] = getNoPCDCamera()
 	case "gibberish_lidar":
 		return deps
 	case "finished_replay_lidar":
@@ -104,20 +102,6 @@ func getInvalidLidar() *inject.Camera {
 	}
 	cam.StreamFunc = func(ctx context.Context, errHandlers ...gostream.ErrorHandler) (gostream.VideoStream, error) {
 		return nil, errors.New("invalid sensor")
-	}
-	cam.ProjectorFunc = func(ctx context.Context) (transform.Projector, error) {
-		return nil, transform.NewNoIntrinsicsError("")
-	}
-	return cam
-}
-
-func getNoPCDCamera() *inject.Camera {
-	cam := &inject.Camera{}
-	cam.NextPointCloudFunc = func(ctx context.Context) (pointcloud.PointCloud, error) {
-		return nil, errors.New("invalid camera")
-	}
-	cam.StreamFunc = func(ctx context.Context, errHandlers ...gostream.ErrorHandler) (gostream.VideoStream, error) {
-		return nil, errors.New("invalid camera")
 	}
 	cam.ProjectorFunc = func(ctx context.Context) (transform.Projector, error) {
 		return nil, transform.NewNoIntrinsicsError("")

--- a/sensors/test_deps.go
+++ b/sensors/test_deps.go
@@ -62,9 +62,6 @@ func getWarmingUpLidar() *inject.Camera {
 	cam.ProjectorFunc = func(ctx context.Context) (transform.Projector, error) {
 		return nil, transform.NewNoIntrinsicsError("")
 	}
-	cam.PropertiesFunc = func(ctx context.Context) (camera.Properties, error) {
-		return camera.Properties{SupportsPCD: true}, nil
-	}
 	return cam
 }
 
@@ -78,9 +75,6 @@ func getGoodLidar() *inject.Camera {
 	}
 	cam.ProjectorFunc = func(ctx context.Context) (transform.Projector, error) {
 		return nil, transform.NewNoIntrinsicsError("")
-	}
-	cam.PropertiesFunc = func(ctx context.Context) (camera.Properties, error) {
-		return camera.Properties{SupportsPCD: true}, nil
 	}
 	return cam
 }
@@ -114,9 +108,6 @@ func getInvalidLidar() *inject.Camera {
 	cam.ProjectorFunc = func(ctx context.Context) (transform.Projector, error) {
 		return nil, transform.NewNoIntrinsicsError("")
 	}
-	cam.PropertiesFunc = func(ctx context.Context) (camera.Properties, error) {
-		return camera.Properties{SupportsPCD: true}, nil
-	}
 	return cam
 }
 
@@ -130,9 +121,6 @@ func getNoPCDCamera() *inject.Camera {
 	}
 	cam.ProjectorFunc = func(ctx context.Context) (transform.Projector, error) {
 		return nil, transform.NewNoIntrinsicsError("")
-	}
-	cam.PropertiesFunc = func(ctx context.Context) (camera.Properties, error) {
-		return camera.Properties{SupportsPCD: false}, nil
 	}
 	return cam
 }

--- a/sensors/test_deps.go
+++ b/sensors/test_deps.go
@@ -60,6 +60,9 @@ func getWarmingUpLidar() *inject.Camera {
 	cam.ProjectorFunc = func(ctx context.Context) (transform.Projector, error) {
 		return nil, transform.NewNoIntrinsicsError("")
 	}
+	cam.PropertiesFunc = func(ctx context.Context) (camera.Properties, error) {
+		return camera.Properties{}, nil
+	}
 	return cam
 }
 
@@ -73,6 +76,9 @@ func getGoodLidar() *inject.Camera {
 	}
 	cam.ProjectorFunc = func(ctx context.Context) (transform.Projector, error) {
 		return nil, transform.NewNoIntrinsicsError("")
+	}
+	cam.PropertiesFunc = func(ctx context.Context) (camera.Properties, error) {
+		return camera.Properties{}, nil
 	}
 	return cam
 }
@@ -92,6 +98,9 @@ func getReplayLidar(testTime string) *inject.Camera {
 	cam.ProjectorFunc = func(ctx context.Context) (transform.Projector, error) {
 		return nil, transform.NewNoIntrinsicsError("")
 	}
+	cam.PropertiesFunc = func(ctx context.Context) (camera.Properties, error) {
+		return camera.Properties{}, nil
+	}
 	return cam
 }
 
@@ -106,6 +115,9 @@ func getInvalidLidar() *inject.Camera {
 	cam.ProjectorFunc = func(ctx context.Context) (transform.Projector, error) {
 		return nil, transform.NewNoIntrinsicsError("")
 	}
+	cam.PropertiesFunc = func(ctx context.Context) (camera.Properties, error) {
+		return camera.Properties{}, nil
+	}
 	return cam
 }
 
@@ -119,6 +131,9 @@ func getFinishedReplayLidar() *inject.Camera {
 	}
 	cam.ProjectorFunc = func(ctx context.Context) (transform.Projector, error) {
 		return nil, transform.NewNoIntrinsicsError("")
+	}
+	cam.PropertiesFunc = func(ctx context.Context) (camera.Properties, error) {
+		return camera.Properties{}, nil
 	}
 	return cam
 }

--- a/sensors/test_deps.go
+++ b/sensors/test_deps.go
@@ -35,7 +35,7 @@ func SetupDeps(lidarName string) resource.Dependencies {
 		deps[camera.Named(lidarName)] = getReplayLidar(BadTime)
 	case "invalid_lidar":
 		deps[camera.Named(lidarName)] = getInvalidLidar()
-	case "np_pcd_camera":
+	case "no_pcd_camera":
 		deps[camera.Named(lidarName)] = getNoPCDCamera()
 	case "gibberish_lidar":
 		return deps

--- a/sensors/test_deps.go
+++ b/sensors/test_deps.go
@@ -100,9 +100,6 @@ func getReplayLidar(testTime string) *inject.Camera {
 	cam.ProjectorFunc = func(ctx context.Context) (transform.Projector, error) {
 		return nil, transform.NewNoIntrinsicsError("")
 	}
-	cam.PropertiesFunc = func(ctx context.Context) (camera.Properties, error) {
-		return camera.Properties{SupportsPCD: true}, nil
-	}
 	return cam
 }
 
@@ -150,9 +147,6 @@ func getFinishedReplayLidar() *inject.Camera {
 	}
 	cam.ProjectorFunc = func(ctx context.Context) (transform.Projector, error) {
 		return nil, transform.NewNoIntrinsicsError("")
-	}
-	cam.PropertiesFunc = func(ctx context.Context) (camera.Properties, error) {
-		return camera.Properties{SupportsPCD: true}, nil
 	}
 	return cam
 }

--- a/testhelper/testhelper.go
+++ b/testhelper/testhelper.go
@@ -242,7 +242,7 @@ func CreateSLAMService(
 
 	// feature flag for IMU Integration
 	cameraName := ""
-	if cfg.UseNewConfig == "true" {
+	if cfg.UseNewConfig {
 		cameraName = cfg.Camera["name"]
 	} else {
 		fmt.Println("using old config")

--- a/testhelper/testhelper.go
+++ b/testhelper/testhelper.go
@@ -242,7 +242,7 @@ func CreateSLAMService(
 
 	// feature flag for IMU Integration
 	cameraName := ""
-	if cfg.UseNewConfig {
+	if cfg.UseNewConfig == "true" {
 		cameraName = cfg.Camera["name"]
 	} else {
 		fmt.Println("using old config")

--- a/testhelper/testhelper.go
+++ b/testhelper/testhelper.go
@@ -146,7 +146,7 @@ func IntegrationLidarTimedSensor(
 
 	ts.TimedSensorReadingFunc = func(ctx context.Context) (s.TimedSensorReadingResponse, error) {
 		readingTime = readingTime.Add(sensorReadingInterval)
-		// t.Logf("TimedSensorReading Mock i: %d, closed: %v, readingTime: %s\n", i, closed, readingTime.String())
+		t.Logf("TimedSensorReading Mock i: %d, closed: %v, readingTime: %s\n", i, closed, readingTime.String())
 		if i >= NumPointClouds {
 			// communicate to the test that all lidar readings have been written
 			if !closed {

--- a/testhelper/testhelper.go
+++ b/testhelper/testhelper.go
@@ -245,7 +245,6 @@ func CreateSLAMService(
 	if cfg.UseNewConfig {
 		cameraName = cfg.Camera["name"]
 	} else {
-		fmt.Println("using old config")
 		cameraName = cfg.Sensors[0]
 	}
 

--- a/testhelper/testhelper.go
+++ b/testhelper/testhelper.go
@@ -240,13 +240,22 @@ func CreateSLAMService(
 	cfgService := resource.Config{Name: "test", API: slam.API, Model: viamcartographer.Model}
 	cfgService.ConvertedAttributes = cfg
 
-	deps := s.SetupDeps(cfg.Camera["name"])
+	// feature flag for IMU Integration
+	cameraName := ""
+	if cfg.UseNewConfig {
+		cameraName = cfg.Camera["name"]
+	} else {
+		fmt.Println("using old config")
+		cameraName = cfg.Sensors[0]
+	}
+
+	deps := s.SetupDeps(cameraName)
 
 	sensorDeps, err := cfg.Validate("path")
 	if err != nil {
 		return nil, err
 	}
-	test.That(t, sensorDeps, test.ShouldResemble, []string{cfg.Camera["name"]})
+	test.That(t, sensorDeps, test.ShouldResemble, []string{cameraName})
 
 	svc, err := viamcartographer.New(
 		ctx,

--- a/testhelper/testhelper.go
+++ b/testhelper/testhelper.go
@@ -242,7 +242,7 @@ func CreateSLAMService(
 
 	// feature flag for IMU Integration
 	cameraName := ""
-	if cfg.UseNewConfig {
+	if cfg.IMUIntegrationEnabled {
 		cameraName = cfg.Camera["name"]
 	} else {
 		cameraName = cfg.Sensors[0]

--- a/testhelper/testhelper.go
+++ b/testhelper/testhelper.go
@@ -147,7 +147,7 @@ func IntegrationLidarTimedSensor(
 
 	ts.TimedSensorReadingFunc = func(ctx context.Context) (s.TimedSensorReadingResponse, error) {
 		readingTime = readingTime.Add(sensorReadingInterval)
-		t.Logf("TimedSensorReading Mock i: %d, closed: %v, readingTime: %s\n", i, closed, readingTime.String())
+		//t.Logf("TimedSensorReading Mock i: %d, closed: %v, readingTime: %s\n", i, closed, readingTime.String())
 		if i >= NumPointClouds {
 			// communicate to the test that all lidar readings have been written
 			if !closed {
@@ -247,7 +247,7 @@ func CreateSLAMService(
 	if err != nil {
 		return nil, err
 	}
-	test.That(t, sensorDeps, test.ShouldResemble, cfg.Camera)
+	test.That(t, sensorDeps, test.ShouldResemble, []string{cfg.Camera["name"]})
 
 	svc, err := viamcartographer.New(
 		ctx,

--- a/viam-cartographer/src/carto_facade/carto_facade.cc
+++ b/viam-cartographer/src/carto_facade/carto_facade.cc
@@ -882,21 +882,17 @@ extern int viam_carto_init(viam_carto **ppVC, viam_carto_lib *pVCL,
     if (ppVC == nullptr) {
         return VIAM_CARTO_VC_INVALID;
     }
-    LOG(INFO) << "am here";
     if (pVCL == nullptr) {
         return VIAM_CARTO_LIB_INVALID;
     }
-    LOG(INFO) << "got here";
     // allocate viam_carto struct
     viam_carto *vc = (viam_carto *)malloc(sizeof(viam_carto));
     if (vc == nullptr) {
         return VIAM_CARTO_OUT_OF_MEMORY;
     }
     viam::carto_facade::CartoFacade *cf;
-    LOG(INFO) << "also here";
     try {
         cf = new viam::carto_facade::CartoFacade(pVCL, c, ac);
-        LOG(INFO) << "failed here";
     } catch (int err) {
         free(vc);
         return err;

--- a/viam-cartographer/src/carto_facade/carto_facade.cc
+++ b/viam-cartographer/src/carto_facade/carto_facade.cc
@@ -111,26 +111,21 @@ void validate_lidar_config(viam_carto_LIDAR_CONFIG lidar_config) {
 
 config from_viam_carto_config(viam_carto_config vcc) {
     struct config c;
-    for (int i = 0; i < vcc.sensors_len; i++) {
-        c.sensors.push_back(to_std_string(vcc.sensors[i]));
-    }
+    c.camera = to_std_string(vcc.camera);
     c.data_dir = to_std_string(vcc.data_dir);
     c.map_rate_sec = std::chrono::seconds(vcc.map_rate_sec);
     c.lidar_config = vcc.lidar_config;
-    if (c.sensors.size() == 0) {
-        throw VIAM_CARTO_SENSORS_LIST_EMPTY;
-    }
     if (c.data_dir.size() == 0) {
         throw VIAM_CARTO_DATA_DIR_NOT_PROVIDED;
     }
     if (vcc.map_rate_sec < 0) {
         throw VIAM_CARTO_MAP_RATE_SEC_INVALID;
     }
-    if (c.sensors[0].empty()) {
+    if (c.camera.empty()) {
         throw VIAM_CARTO_COMPONENT_REFERENCE_INVALID;
     }
     validate_lidar_config(c.lidar_config);
-    c.component_reference = bstrcpy(vcc.sensors[0]);
+    c.component_reference = bstrcpy(vcc.camera);
 
     return c;
 };

--- a/viam-cartographer/src/carto_facade/carto_facade.cc
+++ b/viam-cartographer/src/carto_facade/carto_facade.cc
@@ -121,7 +121,6 @@ config from_viam_carto_config(viam_carto_config vcc) {
     if (vcc.map_rate_sec < 0) {
         throw VIAM_CARTO_MAP_RATE_SEC_INVALID;
     }
-    LOG(INFO) << "camera name is " << c.camera;
     if (c.camera.empty()) {
         throw VIAM_CARTO_COMPONENT_REFERENCE_INVALID;
     }

--- a/viam-cartographer/src/carto_facade/carto_facade.cc
+++ b/viam-cartographer/src/carto_facade/carto_facade.cc
@@ -121,6 +121,7 @@ config from_viam_carto_config(viam_carto_config vcc) {
     if (vcc.map_rate_sec < 0) {
         throw VIAM_CARTO_MAP_RATE_SEC_INVALID;
     }
+    LOG(INFO) << "camera name is " << c.camera;
     if (c.camera.empty()) {
         throw VIAM_CARTO_COMPONENT_REFERENCE_INVALID;
     }
@@ -881,20 +882,21 @@ extern int viam_carto_init(viam_carto **ppVC, viam_carto_lib *pVCL,
     if (ppVC == nullptr) {
         return VIAM_CARTO_VC_INVALID;
     }
-
+    LOG(INFO) << "am here";
     if (pVCL == nullptr) {
         return VIAM_CARTO_LIB_INVALID;
     }
-
+    LOG(INFO) << "got here";
     // allocate viam_carto struct
     viam_carto *vc = (viam_carto *)malloc(sizeof(viam_carto));
     if (vc == nullptr) {
         return VIAM_CARTO_OUT_OF_MEMORY;
     }
     viam::carto_facade::CartoFacade *cf;
-
+    LOG(INFO) << "also here";
     try {
         cf = new viam::carto_facade::CartoFacade(pVCL, c, ac);
+        LOG(INFO) << "failed here";
     } catch (int err) {
         free(vc);
         return err;

--- a/viam-cartographer/src/carto_facade/carto_facade.h
+++ b/viam-cartographer/src/carto_facade/carto_facade.h
@@ -87,7 +87,6 @@ typedef enum viam_carto_LIDAR_CONFIG {
 #define VIAM_CARTO_LIB_PLATFORM_INVALID 5
 #define VIAM_CARTO_LIB_INVALID 6
 #define VIAM_CARTO_LIB_NOT_INITIALIZED 7
-#define VIAM_CARTO_SENSORS_LIST_EMPTY 8
 #define VIAM_CARTO_UNKNOWN_ERROR 9
 #define VIAM_CARTO_DATA_DIR_NOT_PROVIDED 10
 #define VIAM_CARTO_SLAM_MODE_INVALID 11
@@ -130,8 +129,7 @@ typedef struct viam_carto_algo_config {
 } viam_carto_algo_config;
 
 typedef struct viam_carto_config {
-    bstring *sensors;
-    int sensors_len;
+    bstring camera;
     int map_rate_sec;
     bstring data_dir;
     viam_carto_LIDAR_CONFIG lidar_config;
@@ -292,7 +290,7 @@ static const int checkForShutdownIntervalMicroseconds = 1e5;
 static const double resolutionMeters = 0.05;
 
 typedef struct config {
-    std::vector<std::string> sensors;
+    std::string camera;
     std::chrono::seconds map_rate_sec;
     std::string data_dir;
     bstring component_reference;

--- a/viam-cartographer/src/carto_facade/carto_facade_test.cc
+++ b/viam-cartographer/src/carto_facade/carto_facade_test.cc
@@ -28,32 +28,21 @@ const auto tol = tt::tolerance(0.001);
 
 namespace viam {
 namespace carto_facade {
-viam_carto_config viam_carto_config_setup(
-    int map_rate_sec, viam_carto_LIDAR_CONFIG lidar_config,
-    std::string data_dir, std::vector<std::string> sensors_vec) {
+viam_carto_config viam_carto_config_setup(int map_rate_sec,
+                                          viam_carto_LIDAR_CONFIG lidar_config,
+                                          std::string data_dir,
+                                          std::string camera) {
     struct viam_carto_config vcc;
     vcc.map_rate_sec = map_rate_sec;
     vcc.lidar_config = lidar_config;
     vcc.data_dir = bfromcstr(data_dir.c_str());
-    bstring *sensors =
-        (bstring *)malloc(sizeof(bstring *) * sensors_vec.size());
-    BOOST_TEST(sensors != nullptr);
-    int i = 0;
-    for (auto &&s : sensors_vec) {
-        sensors[i] = bfromcstr(s.c_str());
-        i++;
-    }
-    vcc.sensors_len = sensors_vec.size();
-    vcc.sensors = sensors;
+    vcc.camera = bfromcstr(camera.c_str());
     return vcc;
 }
 
 void viam_carto_config_teardown(viam_carto_config vcc) {
     BOOST_TEST(bdestroy(vcc.data_dir) == BSTR_OK);
-    for (int i = 0; i < vcc.sensors_len; i++) {
-        BOOST_TEST(bdestroy(vcc.sensors[i]) == BSTR_OK);
-    }
-    free(vcc.sensors);
+    BOOST_TEST(bdestroy(vcc.camera) == BSTR_OK);
 }
 viam_carto_sensor_reading new_test_sensor_reading(
     std::string sensor, std::string pcd_path,
@@ -119,47 +108,34 @@ BOOST_AUTO_TEST_CASE(CartoFacade_init_validate) {
     BOOST_TEST(viam_carto_lib_init(&lib, 0, 1) == VIAM_CARTO_SUCCESS);
 
     viam_carto *vc;
-    std::vector<std::string> empty_sensors_vec;
     fs::path tmp_dir =
         fs::temp_directory_path() / fs::path(bfs::unique_path().string());
 
-    struct viam_carto_config vcc_no_sensors = viam_carto_config_setup(
-        1, VIAM_CARTO_THREE_D, tmp_dir.string(), empty_sensors_vec);
     struct viam_carto_algo_config ac = viam_carto_algo_config_setup();
 
-    BOOST_TEST(viam_carto_init(&vc, lib, vcc_no_sensors, ac) ==
-               VIAM_CARTO_SENSORS_LIST_EMPTY);
-
-    std::vector<std::string> sensors_vec;
-    sensors_vec.push_back("sensor_1");
-    sensors_vec.push_back("sensor_2");
-    sensors_vec.push_back("sensor_3");
-    sensors_vec.push_back("sensor_4");
-    sensors_vec.push_back("sensor_5");
+    std::string camera = "lidar";
     struct viam_carto_config vcc_empty_data_dir =
-        viam_carto_config_setup(1, VIAM_CARTO_THREE_D, "", sensors_vec);
+        viam_carto_config_setup(1, VIAM_CARTO_THREE_D, "", camera);
 
     BOOST_TEST(viam_carto_init(&vc, lib, vcc_empty_data_dir, ac) ==
                VIAM_CARTO_DATA_DIR_NOT_PROVIDED);
 
-    std::vector<std::string> sensors_vec2;
-    sensors_vec2.push_back("");
-    sensors_vec2.push_back("sensor_2");
+    std::string camera2 = "";
+
     struct viam_carto_config vcc_empty_component_ref = viam_carto_config_setup(
-        1, VIAM_CARTO_THREE_D, tmp_dir.string(), sensors_vec2);
+        1, VIAM_CARTO_THREE_D, tmp_dir.string(), camera2);
 
     BOOST_TEST(viam_carto_init(&vc, lib, vcc_empty_component_ref, ac) ==
                VIAM_CARTO_COMPONENT_REFERENCE_INVALID);
 
     struct viam_carto_config vcc_invalid_map_rate_sec = viam_carto_config_setup(
-        -1, VIAM_CARTO_THREE_D, tmp_dir.string(), sensors_vec);
+        -1, VIAM_CARTO_THREE_D, tmp_dir.string(), camera);
 
     BOOST_TEST(viam_carto_init(&vc, lib, vcc_invalid_map_rate_sec, ac) ==
                VIAM_CARTO_MAP_RATE_SEC_INVALID);
 
-    struct viam_carto_config vcc_invalid_lidar_config =
-        viam_carto_config_setup(1, static_cast<viam_carto_LIDAR_CONFIG>(-1),
-                                tmp_dir.string(), sensors_vec);
+    struct viam_carto_config vcc_invalid_lidar_config = viam_carto_config_setup(
+        1, static_cast<viam_carto_LIDAR_CONFIG>(-1), tmp_dir.string(), camera);
 
     BOOST_TEST(viam_carto_init(&vc, lib, vcc_invalid_lidar_config, ac) ==
                VIAM_CARTO_LIDAR_CONFIG_INVALID);
@@ -168,22 +144,20 @@ BOOST_AUTO_TEST_CASE(CartoFacade_init_validate) {
     fs::create_directories(deprecated_path.string() + "/data");
 
     struct viam_carto_config vcc_deprecated_path = viam_carto_config_setup(
-        1, VIAM_CARTO_THREE_D, deprecated_path.string(), sensors_vec);
+        1, VIAM_CARTO_THREE_D, deprecated_path.string(), camera);
     BOOST_TEST(viam_carto_init(&vc, lib, vcc_deprecated_path, ac) ==
                VIAM_CARTO_DATA_DIR_INVALID_DEPRECATED_STRUCTURE);
 
     fs::path invalid_path = tmp_dir / fs::path(bfs::unique_path().string()) /
                             fs::path(bfs::unique_path().string());
 
-    struct viam_carto_config vcc_invalid_path =
-        viam_carto_config_setup(1, VIAM_CARTO_THREE_D, invalid_path.string(),
-
-                                sensors_vec);
+    struct viam_carto_config vcc_invalid_path = viam_carto_config_setup(
+        1, VIAM_CARTO_THREE_D, invalid_path.string(), camera);
     BOOST_TEST(viam_carto_init(&vc, lib, vcc_invalid_path, ac) ==
                VIAM_CARTO_DATA_DIR_FILE_SYSTEM_ERROR);
 
     struct viam_carto_config vcc = viam_carto_config_setup(
-        1, VIAM_CARTO_THREE_D, tmp_dir.string(), sensors_vec);
+        1, VIAM_CARTO_THREE_D, tmp_dir.string(), camera);
 
     BOOST_TEST(viam_carto_init(nullptr, lib, vcc, ac) == VIAM_CARTO_VC_INVALID);
     BOOST_TEST(viam_carto_init(nullptr, nullptr, vcc, ac) ==
@@ -203,7 +177,6 @@ BOOST_AUTO_TEST_CASE(CartoFacade_init_validate) {
     // can't terminate a carto instance that has already been terminated
     BOOST_TEST(viam_carto_terminate(&vc) == VIAM_CARTO_VC_INVALID);
 
-    viam_carto_config_teardown(vcc_no_sensors);
     viam_carto_config_teardown(vcc_empty_data_dir);
     viam_carto_config_teardown(vcc_empty_component_ref);
     viam_carto_config_teardown(vcc_invalid_map_rate_sec);
@@ -223,15 +196,9 @@ BOOST_AUTO_TEST_CASE(CartoFacade_init_derive_slam_mode) {
     viam_carto_lib *lib;
     BOOST_TEST(viam_carto_lib_init(&lib, 0, 1) == VIAM_CARTO_SUCCESS);
 
-    std::vector<std::string> empty_sensors_vec;
+    std::string camera = "lidar";
     fs::path tmp_dir =
         fs::temp_directory_path() / fs::path(bfs::unique_path().string());
-    std::vector<std::string> sensors_vec;
-    sensors_vec.push_back("sensor_1");
-    sensors_vec.push_back("sensor_2");
-    sensors_vec.push_back("sensor_3");
-    sensors_vec.push_back("sensor_4");
-    sensors_vec.push_back("sensor_5");
     struct viam_carto_algo_config ac = viam_carto_algo_config_setup();
 
     fs::create_directory(tmp_dir);
@@ -240,7 +207,7 @@ BOOST_AUTO_TEST_CASE(CartoFacade_init_derive_slam_mode) {
         viam_carto *vc1;
         auto mapping_dir = tmp_dir / fs::path("mapping_dir");
         struct viam_carto_config vcc_mapping = viam_carto_config_setup(
-            1, VIAM_CARTO_THREE_D, mapping_dir.string(), sensors_vec);
+            1, VIAM_CARTO_THREE_D, mapping_dir.string(), camera);
         BOOST_TEST(viam_carto_init(&vc1, lib, vcc_mapping, ac) ==
                    VIAM_CARTO_SUCCESS);
         BOOST_TEST(vc1->slam_mode == VIAM_CARTO_SLAM_MODE_MAPPING);
@@ -300,7 +267,7 @@ BOOST_AUTO_TEST_CASE(CartoFacade_init_derive_slam_mode) {
         viam_carto *vc2;
 
         struct viam_carto_config vcc_updating = viam_carto_config_setup(
-            1, VIAM_CARTO_THREE_D, updating_dir.string(), sensors_vec);
+            1, VIAM_CARTO_THREE_D, updating_dir.string(), camera);
         BOOST_TEST(viam_carto_init(&vc2, lib, vcc_updating, ac) ==
                    VIAM_CARTO_SUCCESS);
         BOOST_TEST(vc2->slam_mode == VIAM_CARTO_SLAM_MODE_UPDATING);
@@ -340,7 +307,7 @@ BOOST_AUTO_TEST_CASE(CartoFacade_init_derive_slam_mode) {
         // updating optimize_on_start
         viam_carto *vc3;
         struct viam_carto_config vcc_updating = viam_carto_config_setup(
-            1, VIAM_CARTO_THREE_D, updating_dir.string(), sensors_vec);
+            1, VIAM_CARTO_THREE_D, updating_dir.string(), camera);
 
         BOOST_TEST(viam_carto_init(&vc3, lib, vcc_updating,
                                    ac_optimize_on_start) == VIAM_CARTO_SUCCESS);
@@ -356,7 +323,7 @@ BOOST_AUTO_TEST_CASE(CartoFacade_init_derive_slam_mode) {
         // localizing
         viam_carto *vc4;
         struct viam_carto_config vcc_localizing = viam_carto_config_setup(
-            0, VIAM_CARTO_THREE_D, updating_dir.string(), sensors_vec);
+            0, VIAM_CARTO_THREE_D, updating_dir.string(), camera);
         BOOST_TEST(viam_carto_init(&vc4, lib, vcc_localizing, ac) ==
                    VIAM_CARTO_SUCCESS);
         BOOST_TEST(vc4->slam_mode == VIAM_CARTO_SLAM_MODE_LOCALIZING);
@@ -389,7 +356,7 @@ BOOST_AUTO_TEST_CASE(CartoFacade_init_derive_slam_mode) {
         // localizing optimize_on_start
         viam_carto *vc5;
         struct viam_carto_config vcc_localizing = viam_carto_config_setup(
-            0, VIAM_CARTO_THREE_D, updating_dir.string(), sensors_vec);
+            0, VIAM_CARTO_THREE_D, updating_dir.string(), camera);
         BOOST_TEST(viam_carto_init(&vc5, lib, vcc_localizing,
                                    ac_optimize_on_start) == VIAM_CARTO_SUCCESS);
         BOOST_TEST(vc5->slam_mode == VIAM_CARTO_SLAM_MODE_LOCALIZING);
@@ -406,7 +373,7 @@ BOOST_AUTO_TEST_CASE(CartoFacade_init_derive_slam_mode) {
         ;
         viam_carto *vc6;
         struct viam_carto_config vcc_invalid = viam_carto_config_setup(
-            0, VIAM_CARTO_THREE_D, empty_dir.string(), sensors_vec);
+            0, VIAM_CARTO_THREE_D, empty_dir.string(), camera);
         BOOST_TEST(viam_carto_init(&vc6, lib, vcc_invalid, ac) ==
                    VIAM_CARTO_SLAM_MODE_INVALID);
         viam_carto_config_teardown(vcc_invalid);
@@ -424,16 +391,11 @@ BOOST_AUTO_TEST_CASE(CartoFacade_init_terminate) {
     BOOST_TEST(viam_carto_lib_init(&lib, 0, 1) == VIAM_CARTO_SUCCESS);
 
     viam_carto *vc;
-    std::vector<std::string> sensors_vec;
-    sensors_vec.push_back("sensor_1");
-    sensors_vec.push_back("sensor_2");
-    sensors_vec.push_back("sensor_3");
-    sensors_vec.push_back("sensor_4");
-    sensors_vec.push_back("sensor_5");
+    std::string camera = "lidar";
     fs::path tmp_dir =
         fs::temp_directory_path() / fs::path(bfs::unique_path().string());
     struct viam_carto_config vcc = viam_carto_config_setup(
-        1, VIAM_CARTO_THREE_D, tmp_dir.string(), sensors_vec);
+        1, VIAM_CARTO_THREE_D, tmp_dir.string(), camera);
     struct viam_carto_algo_config ac = viam_carto_algo_config_setup();
     BOOST_TEST(viam_carto_init(&vc, lib, vcc, ac) == VIAM_CARTO_SUCCESS);
     BOOST_TEST(vc->slam_mode == VIAM_CARTO_SLAM_MODE_MAPPING);
@@ -457,10 +419,10 @@ BOOST_AUTO_TEST_CASE(CartoFacade_init_terminate) {
 
     BOOST_TEST((cf->path_to_internal_state) == path_to_internal_state.string());
     BOOST_TEST(((cf->state) == CartoFacadeState::IO_INITIALIZED));
-    BOOST_TEST((cf->config.sensors) == sensors_vec);
+    BOOST_TEST((cf->config.camera) == camera);
     BOOST_TEST((cf->config.map_rate_sec).count() == 1);
     BOOST_TEST((cf->config.data_dir) == tmp_dir.string());
-    BOOST_TEST(to_std_string(cf->config.component_reference) == "sensor_1");
+    BOOST_TEST(to_std_string(cf->config.component_reference) == "lidar");
     BOOST_TEST((cf->config.lidar_config) == VIAM_CARTO_THREE_D);
 
     BOOST_TEST(viam_carto_terminate(&vc) == VIAM_CARTO_SUCCESS);
@@ -478,18 +440,13 @@ BOOST_AUTO_TEST_CASE(CartoFacade_demo) {
 
     // Setup
     viam_carto *vc;
-    std::vector<std::string> sensors_vec;
-    sensors_vec.push_back("sensor_1");
-    sensors_vec.push_back("sensor_2");
-    sensors_vec.push_back("sensor_3");
-    sensors_vec.push_back("sensor_4");
-    sensors_vec.push_back("sensor_5");
+    std::string camera = "lidar";
     fs::path tmp_dir =
         fs::temp_directory_path() / fs::path(bfs::unique_path().string());
     struct viam_carto_config vcc =
         viam_carto_config_setup(60, VIAM_CARTO_THREE_D, tmp_dir.string(),
 
-                                sensors_vec);
+                                camera);
     struct viam_carto_algo_config ac = viam_carto_algo_config_setup();
 
     BOOST_TEST(viam_carto_init(&vc, lib, vcc, ac) == VIAM_CARTO_SUCCESS);
@@ -499,7 +456,7 @@ BOOST_AUTO_TEST_CASE(CartoFacade_demo) {
     // AddSensorReading
     {
         viam_carto_sensor_reading sr = new_test_sensor_reading(
-            "sensor_1", ".artifact/data/viam-cartographer/mock_lidar/0.pcd",
+            "lidar", ".artifact/data/viam-cartographer/mock_lidar/0.pcd",
             1687900053773475);
         viam::carto_facade::CartoFacade *cf =
             static_cast<viam::carto_facade::CartoFacade *>(vc->carto_obj);
@@ -558,7 +515,7 @@ BOOST_AUTO_TEST_CASE(CartoFacade_demo) {
         BOOST_TEST(pr.jmag == 0);
         BOOST_TEST(pr.kmag == 0);
         BOOST_TEST(pr.real == 1);
-        BOOST_TEST(to_std_string(pr.component_reference) == "sensor_1");
+        BOOST_TEST(to_std_string(pr.component_reference) == "lidar");
 
         BOOST_TEST(viam_carto_get_position_response_destroy(&pr) ==
                    VIAM_CARTO_SUCCESS);
@@ -615,7 +572,7 @@ BOOST_AUTO_TEST_CASE(CartoFacade_demo) {
     {
         viam_carto_sensor_reading sr;
         // must be they first sensor in the sensor list
-        sr.sensor = bfromcstr("sensor_1");
+        sr.sensor = bfromcstr("lidar");
         std::string pcd = "empty lidar reading";
         // passing 0 as the second parameter makes the string empty
         sr.sensor_reading = blk2bstr(pcd.c_str(), 0);
@@ -631,7 +588,7 @@ BOOST_AUTO_TEST_CASE(CartoFacade_demo) {
     {
         viam_carto_sensor_reading sr;
         // must be they first sensor in the sensor list
-        sr.sensor = bfromcstr("sensor_1");
+        sr.sensor = bfromcstr("lidar");
         std::string pcd = "invalid lidar reading";
         sr.sensor_reading = blk2bstr(pcd.c_str(), pcd.length());
         BOOST_TEST(sr.sensor_reading != nullptr);
@@ -645,7 +602,7 @@ BOOST_AUTO_TEST_CASE(CartoFacade_demo) {
     // unable to aquire lock
     {
         viam_carto_sensor_reading sr = new_test_sensor_reading(
-            "sensor_1", ".artifact/data/viam-cartographer/mock_lidar/0.pcd",
+            "lidar", ".artifact/data/viam-cartographer/mock_lidar/0.pcd",
             1687900053773475);
         viam::carto_facade::CartoFacade *cf =
             static_cast<viam::carto_facade::CartoFacade *>(vc->carto_obj);
@@ -703,7 +660,7 @@ BOOST_AUTO_TEST_CASE(CartoFacade_demo) {
         BOOST_TEST(pr.jmag == 0);
         BOOST_TEST(pr.kmag == 0);
         BOOST_TEST(pr.real == 1);
-        BOOST_TEST(to_std_string(pr.component_reference) == "sensor_1");
+        BOOST_TEST(to_std_string(pr.component_reference) == "lidar");
 
         BOOST_TEST(viam_carto_get_position_response_destroy(&pr) ==
                    VIAM_CARTO_SUCCESS);
@@ -722,7 +679,7 @@ BOOST_AUTO_TEST_CASE(CartoFacade_demo) {
     {
         VLOG(1) << "viam_carto_add_sensor_reading 1";
         viam_carto_sensor_reading sr = new_test_sensor_reading(
-            "sensor_1", ".artifact/data/viam-cartographer/mock_lidar/0.pcd",
+            "lidar", ".artifact/data/viam-cartographer/mock_lidar/0.pcd",
             1629037851000000);
         BOOST_TEST(viam_carto_add_sensor_reading(vc, &sr) ==
                    VIAM_CARTO_SUCCESS);
@@ -740,7 +697,7 @@ BOOST_AUTO_TEST_CASE(CartoFacade_demo) {
         BOOST_TEST(pr.jmag == 0);
         BOOST_TEST(pr.kmag == 0);
         BOOST_TEST(pr.real == 1);
-        BOOST_TEST(to_std_string(pr.component_reference) == "sensor_1");
+        BOOST_TEST(to_std_string(pr.component_reference) == "lidar");
 
         BOOST_TEST(viam_carto_get_position_response_destroy(&pr) ==
                    VIAM_CARTO_SUCCESS);
@@ -769,7 +726,7 @@ BOOST_AUTO_TEST_CASE(CartoFacade_demo) {
     {
         VLOG(1) << "viam_carto_add_sensor_reading 2";
         viam_carto_sensor_reading sr = new_test_sensor_reading(
-            "sensor_1", ".artifact/data/viam-cartographer/mock_lidar/1.pcd",
+            "lidar", ".artifact/data/viam-cartographer/mock_lidar/1.pcd",
             1629037853000000);
         BOOST_TEST(viam_carto_add_sensor_reading(vc, &sr) ==
                    VIAM_CARTO_SUCCESS);
@@ -789,7 +746,7 @@ BOOST_AUTO_TEST_CASE(CartoFacade_demo) {
         BOOST_TEST(pr.jmag == 0);
         BOOST_TEST(pr.kmag == 0);
         BOOST_TEST(pr.real == 1);
-        BOOST_TEST(to_std_string(pr.component_reference) == "sensor_1");
+        BOOST_TEST(to_std_string(pr.component_reference) == "lidar");
 
         BOOST_TEST(viam_carto_get_position_response_destroy(&pr) ==
                    VIAM_CARTO_SUCCESS);
@@ -827,7 +784,7 @@ BOOST_AUTO_TEST_CASE(CartoFacade_demo) {
     {
         VLOG(1) << "viam_carto_add_sensor_reading 3";
         viam_carto_sensor_reading sr = new_test_sensor_reading(
-            "sensor_1", ".artifact/data/viam-cartographer/mock_lidar/2.pcd",
+            "lidar", ".artifact/data/viam-cartographer/mock_lidar/2.pcd",
             1629037855000000);
         BOOST_TEST(viam_carto_add_sensor_reading(vc, &sr) ==
                    VIAM_CARTO_SUCCESS);
@@ -846,7 +803,7 @@ BOOST_AUTO_TEST_CASE(CartoFacade_demo) {
         BOOST_TEST(pr.jmag == 0);
         BOOST_TEST(pr.kmag != 0);
         BOOST_TEST(pr.real != 1);
-        BOOST_TEST(to_std_string(pr.component_reference) == "sensor_1");
+        BOOST_TEST(to_std_string(pr.component_reference) == "lidar");
 
         BOOST_TEST(viam_carto_get_position_response_destroy(&pr) ==
                    VIAM_CARTO_SUCCESS);
@@ -875,7 +832,7 @@ BOOST_AUTO_TEST_CASE(CartoFacade_demo) {
     // AddSensorReading
     {
         viam_carto_sensor_reading sr = new_test_sensor_reading(
-            "sensor_1", ".artifact/data/viam-cartographer/mock_lidar/0.pcd",
+            "lidar", ".artifact/data/viam-cartographer/mock_lidar/0.pcd",
             1687900053773475);
         viam::carto_facade::CartoFacade *cf =
             static_cast<viam::carto_facade::CartoFacade *>(vc->carto_obj);
@@ -920,31 +877,21 @@ BOOST_AUTO_TEST_CASE(CartoFacade_config) {
     viam_carto_lib *lib;
     BOOST_TEST(viam_carto_lib_init(&lib, 0, 1) == VIAM_CARTO_SUCCESS);
 
-    std::vector<std::string> sensors_vec;
-    sensors_vec.push_back("sensor_1");
-    sensors_vec.push_back("sensor_2");
-    sensors_vec.push_back("sensor_3");
-    sensors_vec.push_back("sensor_4");
-    sensors_vec.push_back("sensor_5");
+    std::string camera = "lidar";
     fs::path tmp_dir =
         fs::temp_directory_path() / fs::path(bfs::unique_path().string());
     struct viam_carto_config vcc =
         viam_carto_config_setup(1, VIAM_CARTO_THREE_D, tmp_dir.string(),
 
-                                sensors_vec);
+                                camera);
 
     struct config c = viam::carto_facade::from_viam_carto_config(vcc);
 
-    BOOST_TEST(to_std_string(c.component_reference) == "sensor_1");
+    BOOST_TEST(to_std_string(c.component_reference) == "lidar");
     BOOST_TEST(c.data_dir == tmp_dir.string());
     BOOST_TEST(c.lidar_config == VIAM_CARTO_THREE_D);
     BOOST_TEST(c.map_rate_sec.count() == 1);
-    BOOST_TEST(c.sensors.size() == 5);
-    BOOST_TEST(c.sensors[0] == "sensor_1");
-    BOOST_TEST(c.sensors[1] == "sensor_2");
-    BOOST_TEST(c.sensors[2] == "sensor_3");
-    BOOST_TEST(c.sensors[3] == "sensor_4");
-    BOOST_TEST(c.sensors[4] == "sensor_5");
+    BOOST_TEST(c.camera == "lidar");
 
     viam_carto_config_teardown(vcc);
     BOOST_TEST(bdestroy(c.component_reference) == BSTR_OK);
@@ -965,18 +912,13 @@ BOOST_AUTO_TEST_CASE(CartoFacade_start_stop) {
 
     // Setup
     viam_carto *vc;
-    std::vector<std::string> sensors_vec;
-    sensors_vec.push_back("sensor_1");
-    sensors_vec.push_back("sensor_2");
-    sensors_vec.push_back("sensor_3");
-    sensors_vec.push_back("sensor_4");
-    sensors_vec.push_back("sensor_5");
+    std::string camera = "lidar";
     fs::path tmp_dir =
         fs::temp_directory_path() / fs::path(bfs::unique_path().string());
     struct viam_carto_config vcc =
         viam_carto_config_setup(1, VIAM_CARTO_THREE_D, tmp_dir.string(),
 
-                                sensors_vec);
+                                camera);
     struct viam_carto_algo_config ac = viam_carto_algo_config_setup();
 
     BOOST_TEST(viam_carto_init(&vc, lib, vcc, ac) == VIAM_CARTO_SUCCESS);

--- a/viam_cartographer.go
+++ b/viam_cartographer.go
@@ -172,14 +172,14 @@ func New(
 
 	// feature flag for new config
 	name := ""
-	if *svcConfig.IMUIntegrationEnabled {
+	if svcConfig.UseNewConfig {
 		name = svcConfig.Camera["name"]
 	} else {
 		name = svcConfig.Sensors[0]
 	}
 
 	// Get the lidar for the Dim2D cartographer sub algorithm
-	lidar, err := s.NewLidar(ctx, deps, name, logger)
+	lidar, err := s.NewLidar(ctx, deps, name, logger, svcConfig.UseNewConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/viam_cartographer.go
+++ b/viam_cartographer.go
@@ -5,6 +5,7 @@ package viamcartographer
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -37,7 +38,7 @@ var (
 const (
 	// DefaultExecutableName is what this program expects to call to start the cartographer grpc server.
 	DefaultExecutableName                = "carto_grpc_server"
-	defaultDataRateMsec                  = 200
+	defaultLidarDataRateMSec             = 200
 	defaultMapRateSec                    = 60
 	defaultDialMaxTimeoutSec             = 30
 	defaultSensorValidationMaxTimeoutSec = 30
@@ -117,12 +118,12 @@ func TerminateCartoLib() error {
 
 func initSensorProcess(cancelCtx context.Context, cartoSvc *CartographerService) {
 	spConfig := sensorprocess.Config{
-		CartoFacade: cartoSvc.cartofacade,
-		Lidar:       cartoSvc.timedLidar,
-		LidarName:   cartoSvc.primarySensorName,
-		DataRateMs:  cartoSvc.dataRateMs,
-		Timeout:     cartoSvc.cartoFacadeTimeout,
-		Logger:      cartoSvc.logger,
+		CartoFacade:       cartoSvc.cartofacade,
+		Lidar:             cartoSvc.timedLidar,
+		LidarName:         cartoSvc.lidarName,
+		LidarDataRateMSec: cartoSvc.lidarDataRateMSec,
+		Timeout:           cartoSvc.cartoFacadeTimeout,
+		Logger:            cartoSvc.logger,
 	}
 
 	cartoSvc.sensorProcessWorkers.Add(1)
@@ -160,15 +161,18 @@ func New(
 			c.Model.Name, svcConfig.ConfigParams["mode"])
 	}
 
-	dataRateMsec, mapRateSec := vcConfig.GetOptionalParameters(
+	lidarDataRateMSec, mapRateSec, err := vcConfig.GetOptionalParameters(
 		svcConfig,
-		defaultDataRateMsec,
+		defaultLidarDataRateMSec,
 		defaultMapRateSec,
 		logger,
 	)
+	if err != nil {
+		return nil, err
+	}
 
 	// Get the lidar for the Dim2D cartographer sub algorithm
-	lidar, err := s.NewLidar(ctx, deps, svcConfig.Sensors, logger)
+	lidar, err := s.NewLidar(ctx, deps, svcConfig.Camera["name"], logger)
 	if err != nil {
 		return nil, err
 	}
@@ -188,14 +192,13 @@ func New(
 	// Cartographer SLAM Service Object
 	cartoSvc := &CartographerService{
 		Named:                         c.ResourceName().AsNamed(),
-		primarySensorName:             lidar.Name,
+		lidarName:                     lidar.Name,
 		lidar:                         lidar,
+		lidarDataRateMSec:             lidarDataRateMSec,
 		timedLidar:                    timedSensor,
 		subAlgo:                       subAlgo,
 		configParams:                  svcConfig.ConfigParams,
 		dataDirectory:                 svcConfig.DataDirectory,
-		sensors:                       svcConfig.Sensors,
-		dataRateMs:                    dataRateMsec,
 		mapRateSec:                    mapRateSec,
 		cancelSensorProcessFunc:       cancelSensorProcessFunc,
 		cancelCartoFacadeFunc:         cancelCartoFacadeFunc,
@@ -214,7 +217,7 @@ func New(
 			}
 		}
 	}()
-
+	fmt.Println("1")
 	if err = s.ValidateGetData(
 		cancelSensorProcessCtx,
 		timedSensor,
@@ -224,13 +227,15 @@ func New(
 		err = errors.Wrap(err, "failed to get data from lidar")
 		return nil, err
 	}
+	fmt.Println("2")
 
 	err = initCartoFacade(cancelCartoFacadeCtx, cartoSvc)
 	if err != nil {
 		return nil, err
 	}
-
+	fmt.Println("1")
 	initSensorProcess(cancelSensorProcessCtx, cartoSvc)
+	fmt.Println("2")
 	return cartoSvc, nil
 }
 
@@ -332,17 +337,20 @@ func initCartoFacade(ctx context.Context, cartoSvc *CartographerService) error {
 	if err != nil {
 		return err
 	}
-
+	fmt.Println("3")
 	cartoCfg := cartofacade.CartoConfig{
-		Sensors:            cartoSvc.sensors,
+		Camera:             cartoSvc.camera["name"],
 		MapRateSecond:      cartoSvc.mapRateSec,
 		DataDir:            cartoSvc.dataDirectory,
-		ComponentReference: cartoSvc.primarySensorName,
+		ComponentReference: cartoSvc.lidarName,
 		LidarConfig:        cartofacade.TwoD,
 	}
+	fmt.Println("4")
 
 	cf := cartofacade.New(&cartoLib, cartoCfg, cartoAlgoConfig)
+	fmt.Println("4.5")
 	slamMode, err := cf.Initialize(ctx, cartoSvc.cartoFacadeTimeout, &cartoSvc.cartoFacadeWorkers)
+	fmt.Println("5")
 	if err != nil {
 		cartoSvc.logger.Errorw("cartofacade initialize failed", "error", err)
 		return err
@@ -389,19 +397,19 @@ type CartographerService struct {
 	mu                sync.Mutex
 	SlamMode          cartofacade.SlamMode
 	closed            bool
-	primarySensorName string
+	lidarName         string
+	lidarDataRateMSec int
 	lidar             s.Lidar
 	timedLidar        s.TimedSensor
 	subAlgo           SubAlgo
 
 	configParams  map[string]string
 	dataDirectory string
-	sensors       []string
+	camera        map[string]string
 
 	cartofacade        cartofacade.Interface
 	cartoFacadeTimeout time.Duration
 
-	dataRateMs int
 	mapRateSec int
 
 	cancelSensorProcessFunc func()
@@ -440,7 +448,7 @@ func (cartoSvc *CartographerService) GetPosition(ctx context.Context) (spatialma
 			"kmag": pos.Kmag,
 		},
 	}
-	return CheckQuaternionFromClientAlgo(pose, cartoSvc.primarySensorName, returnedExt)
+	return CheckQuaternionFromClientAlgo(pose, cartoSvc.lidarName, returnedExt)
 }
 
 // GetPointCloudMap creates a request calls the slam algorithms GetPointCloudMap endpoint and returns a callback

--- a/viam_cartographer.go
+++ b/viam_cartographer.go
@@ -172,7 +172,7 @@ func New(
 
 	// feature flag for new config
 	name := ""
-	if svcConfig.UseNewConfig == "true" {
+	if svcConfig.UseNewConfig {
 		name = svcConfig.Camera["name"]
 	} else {
 		name = svcConfig.Sensors[0]

--- a/viam_cartographer.go
+++ b/viam_cartographer.go
@@ -5,7 +5,6 @@ package viamcartographer
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -217,7 +216,6 @@ func New(
 			}
 		}
 	}()
-	fmt.Println("1")
 	if err = s.ValidateGetData(
 		cancelSensorProcessCtx,
 		timedSensor,
@@ -227,15 +225,13 @@ func New(
 		err = errors.Wrap(err, "failed to get data from lidar")
 		return nil, err
 	}
-	fmt.Println("2")
 
 	err = initCartoFacade(cancelCartoFacadeCtx, cartoSvc)
 	if err != nil {
 		return nil, err
 	}
-	fmt.Println("1")
 	initSensorProcess(cancelSensorProcessCtx, cartoSvc)
-	fmt.Println("2")
+
 	return cartoSvc, nil
 }
 
@@ -337,20 +333,17 @@ func initCartoFacade(ctx context.Context, cartoSvc *CartographerService) error {
 	if err != nil {
 		return err
 	}
-	fmt.Println("3")
+
 	cartoCfg := cartofacade.CartoConfig{
-		Camera:             cartoSvc.camera["name"],
+		Camera:             cartoSvc.lidarName,
 		MapRateSecond:      cartoSvc.mapRateSec,
 		DataDir:            cartoSvc.dataDirectory,
 		ComponentReference: cartoSvc.lidarName,
 		LidarConfig:        cartofacade.TwoD,
 	}
-	fmt.Println("4")
 
 	cf := cartofacade.New(&cartoLib, cartoCfg, cartoAlgoConfig)
-	fmt.Println("4.5")
 	slamMode, err := cf.Initialize(ctx, cartoSvc.cartoFacadeTimeout, &cartoSvc.cartoFacadeWorkers)
-	fmt.Println("5")
 	if err != nil {
 		cartoSvc.logger.Errorw("cartofacade initialize failed", "error", err)
 		return err

--- a/viam_cartographer.go
+++ b/viam_cartographer.go
@@ -179,7 +179,7 @@ func New(
 	}
 
 	// Get the lidar for the Dim2D cartographer sub algorithm
-	lidar, err := s.NewLidar(ctx, deps, name, logger, svcConfig.UseNewConfig)
+	lidar, err := s.NewLidar(ctx, deps, name, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/viam_cartographer.go
+++ b/viam_cartographer.go
@@ -172,7 +172,7 @@ func New(
 
 	// feature flag for new config
 	name := ""
-	if svcConfig.UseNewConfig {
+	if svcConfig.IMUIntegrationEnabled {
 		name = svcConfig.Camera["name"]
 	} else {
 		name = svcConfig.Sensors[0]

--- a/viam_cartographer.go
+++ b/viam_cartographer.go
@@ -160,7 +160,7 @@ func New(
 			c.Model.Name, svcConfig.ConfigParams["mode"])
 	}
 
-	lidarDataRateMsec, mapRateSec, err := vcConfig.GetOptionalParameters(
+	lidarDataRateMsec, mapRateSec := vcConfig.GetOptionalParameters(
 		svcConfig,
 		defaultLidarDataRateMsec,
 		defaultMapRateSec,

--- a/viam_cartographer.go
+++ b/viam_cartographer.go
@@ -160,7 +160,7 @@ func New(
 			c.Model.Name, svcConfig.ConfigParams["mode"])
 	}
 
-	lidarDataRateMsec, mapRateSec := vcConfig.GetOptionalParameters(
+	lidarDataRateMsec, mapRateSec, err := vcConfig.GetOptionalParameters(
 		svcConfig,
 		defaultLidarDataRateMsec,
 		defaultMapRateSec,

--- a/viam_cartographer.go
+++ b/viam_cartographer.go
@@ -172,7 +172,7 @@ func New(
 
 	// feature flag for new config
 	name := ""
-	if svcConfig.UseNewConfig {
+	if svcConfig.UseNewConfig == "true" {
 		name = svcConfig.Camera["name"]
 	} else {
 		name = svcConfig.Sensors[0]

--- a/viam_cartographer.go
+++ b/viam_cartographer.go
@@ -183,9 +183,9 @@ func New(
 	// use the override in testing if non nil
 	// otherwise use the lidar from deps as the
 	// timed sensor
-	timedSensor := testTimedSensorOverride
-	if timedSensor == nil {
-		timedSensor = lidar
+	timedLidar := testTimedSensorOverride
+	if timedLidar == nil {
+		timedLidar = lidar
 	}
 
 	// Cartographer SLAM Service Object
@@ -194,7 +194,7 @@ func New(
 		lidarName:                     lidar.Name,
 		lidar:                         lidar,
 		lidarDataRateMSec:             lidarDataRateMSec,
-		timedLidar:                    timedSensor,
+		timedLidar:                    timedLidar,
 		subAlgo:                       subAlgo,
 		configParams:                  svcConfig.ConfigParams,
 		dataDirectory:                 svcConfig.DataDirectory,
@@ -218,7 +218,7 @@ func New(
 	}()
 	if err = s.ValidateGetData(
 		cancelSensorProcessCtx,
-		timedSensor,
+		timedLidar,
 		time.Duration(sensorValidationMaxTimeoutSec)*time.Second,
 		time.Duration(cartoSvc.sensorValidationIntervalSec)*time.Second,
 		cartoSvc.logger); err != nil {
@@ -398,7 +398,6 @@ type CartographerService struct {
 
 	configParams  map[string]string
 	dataDirectory string
-	camera        map[string]string
 
 	cartofacade        cartofacade.Interface
 	cartoFacadeTimeout time.Duration

--- a/viam_cartographer.go
+++ b/viam_cartographer.go
@@ -37,7 +37,7 @@ var (
 const (
 	// DefaultExecutableName is what this program expects to call to start the cartographer grpc server.
 	DefaultExecutableName                = "carto_grpc_server"
-	defaultLidarDataRateMSec             = 200
+	defaultLidarDataRateMsec             = 200
 	defaultMapRateSec                    = 60
 	defaultDialMaxTimeoutSec             = 30
 	defaultSensorValidationMaxTimeoutSec = 30
@@ -120,7 +120,7 @@ func initSensorProcess(cancelCtx context.Context, cartoSvc *CartographerService)
 		CartoFacade:       cartoSvc.cartofacade,
 		Lidar:             cartoSvc.timedLidar,
 		LidarName:         cartoSvc.lidarName,
-		LidarDataRateMSec: cartoSvc.lidarDataRateMSec,
+		LidarDataRateMsec: cartoSvc.lidarDataRateMsec,
 		Timeout:           cartoSvc.cartoFacadeTimeout,
 		Logger:            cartoSvc.logger,
 	}
@@ -160,9 +160,9 @@ func New(
 			c.Model.Name, svcConfig.ConfigParams["mode"])
 	}
 
-	lidarDataRateMSec, mapRateSec, err := vcConfig.GetOptionalParameters(
+	lidarDataRateMsec, mapRateSec, err := vcConfig.GetOptionalParameters(
 		svcConfig,
-		defaultLidarDataRateMSec,
+		defaultLidarDataRateMsec,
 		defaultMapRateSec,
 		logger,
 	)
@@ -170,8 +170,16 @@ func New(
 		return nil, err
 	}
 
+	// feature flag for new config
+	name := ""
+	if *svcConfig.IMUIntegrationEnabled {
+		name = svcConfig.Camera["name"]
+	} else {
+		name = svcConfig.Sensors[0]
+	}
+
 	// Get the lidar for the Dim2D cartographer sub algorithm
-	lidar, err := s.NewLidar(ctx, deps, svcConfig.Camera["name"], logger)
+	lidar, err := s.NewLidar(ctx, deps, name, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -193,7 +201,7 @@ func New(
 		Named:                         c.ResourceName().AsNamed(),
 		lidarName:                     lidar.Name,
 		lidar:                         lidar,
-		lidarDataRateMSec:             lidarDataRateMSec,
+		lidarDataRateMsec:             lidarDataRateMsec,
 		timedLidar:                    timedLidar,
 		subAlgo:                       subAlgo,
 		configParams:                  svcConfig.ConfigParams,
@@ -391,7 +399,7 @@ type CartographerService struct {
 	SlamMode          cartofacade.SlamMode
 	closed            bool
 	lidarName         string
-	lidarDataRateMSec int
+	lidarDataRateMsec int
 	lidar             s.Lidar
 	timedLidar        s.TimedSensor
 	subAlgo           SubAlgo

--- a/viam_cartographer_internal_test.go
+++ b/viam_cartographer_internal_test.go
@@ -92,7 +92,7 @@ func TestGetPositionEndpoint(t *testing.T) {
 	var inputQuat map[string]interface{}
 
 	t.Run("empty component reference success", func(t *testing.T) {
-		svc.primarySensorName = ""
+		svc.lidarName = ""
 		inputPose = commonv1.Pose{X: 0, Y: 0, Z: 0, OX: 0, OY: 0, OZ: 1, Theta: 0}
 		inputQuat = map[string]interface{}{"real": 1.0, "imag": 0.0, "jmag": 0.0, "kmag": 0.0}
 
@@ -100,7 +100,7 @@ func TestGetPositionEndpoint(t *testing.T) {
 	})
 
 	t.Run("origin pose success", func(t *testing.T) {
-		svc.primarySensorName = "primarySensor1"
+		svc.lidarName = "primarySensor1"
 		inputPose = commonv1.Pose{X: 0, Y: 0, Z: 0, OX: 0, OY: 0, OZ: 1, Theta: 0}
 		inputQuat = map[string]interface{}{"real": 1.0, "imag": 0.0, "jmag": 0.0, "kmag": 0.0}
 
@@ -108,7 +108,7 @@ func TestGetPositionEndpoint(t *testing.T) {
 	})
 
 	t.Run("non origin pose success", func(t *testing.T) {
-		svc.primarySensorName = "primarySensor2"
+		svc.lidarName = "primarySensor2"
 		inputPose = commonv1.Pose{X: 5, Y: 5, Z: 5, OX: 0, OY: 0, OZ: 1, Theta: 0}
 		inputQuat = map[string]interface{}{"real": 1.0, "imag": 1.0, "jmag": 0.0, "kmag": 0.0}
 
@@ -116,7 +116,7 @@ func TestGetPositionEndpoint(t *testing.T) {
 	})
 
 	t.Run("error case", func(t *testing.T) {
-		svc.primarySensorName = "primarySensor3"
+		svc.lidarName = "primarySensor3"
 		mockCartoFacade.GetPositionFunc = func(
 			ctx context.Context,
 			timeout time.Duration,

--- a/viam_cartographer_test.go
+++ b/viam_cartographer_test.go
@@ -25,7 +25,7 @@ import (
 
 const (
 	testExecutableName = "true" // the program "true", not the boolean value
-	testDataRateMsec   = 200
+	testDataFreqHz     = "5"
 )
 
 var (
@@ -53,7 +53,7 @@ func TestNew(t *testing.T) {
 			test.That(t, err, test.ShouldBeNil)
 		}()
 		attrCfg := &vcConfig.Config{
-			Sensors:       []string{"lidar", "one-too-many"},
+			Camera:        map[string]string{"name": "lidar", "name2": "one-too-many"},
 			ConfigParams:  map[string]string{"mode": "2d"},
 			DataDirectory: dataDirectory,
 		}
@@ -76,10 +76,9 @@ func TestNew(t *testing.T) {
 		}()
 
 		attrCfg := &vcConfig.Config{
-			Sensors:       []string{"gibberish"},
+			Camera:        map[string]string{"name": "gibberish", "data_frequency_hz": testDataFreqHz},
 			ConfigParams:  map[string]string{"mode": "2d"},
 			DataDirectory: dataDirectory,
-			DataRateMsec:  testDataRateMsec,
 		}
 
 		_, err = testhelper.CreateSLAMService(t, attrCfg, logger)
@@ -100,10 +99,9 @@ func TestNew(t *testing.T) {
 		}()
 
 		attrCfg := &vcConfig.Config{
-			Sensors:       []string{"good_lidar"},
+			Camera:        map[string]string{"name": "good_lidar", "data_frequency_hz": testDataFreqHz},
 			ConfigParams:  map[string]string{"mode": "2d"},
 			DataDirectory: dataDirectory,
-			DataRateMsec:  testDataRateMsec,
 		}
 
 		svc, err := testhelper.CreateSLAMService(t, attrCfg, logger)
@@ -125,10 +123,9 @@ func TestNew(t *testing.T) {
 		}()
 
 		attrCfg := &vcConfig.Config{
-			Sensors:       []string{"invalid_sensor"},
+			Camera:        map[string]string{"name": "invalid_sensor", "data_frequency_hz": testDataFreqHz},
 			ConfigParams:  map[string]string{"mode": "2d"},
 			DataDirectory: dataDirectory,
-			DataRateMsec:  testDataRateMsec,
 		}
 
 		_, err = testhelper.CreateSLAMService(t, attrCfg, logger)
@@ -145,7 +142,7 @@ func TestNew(t *testing.T) {
 		defer fsCleanupFunc()
 
 		attrCfg := &vcConfig.Config{
-			Sensors:       []string{"replay_sensor"},
+			Camera:        map[string]string{"name": "good_lidar"},
 			ConfigParams:  map[string]string{"mode": "2d"},
 			DataDirectory: dataDirectory,
 			MapRateSec:    &_zeroInt,
@@ -195,7 +192,7 @@ func TestNew(t *testing.T) {
 		defer fsCleanupFunc()
 
 		attrCfg := &vcConfig.Config{
-			Sensors:       []string{"good_lidar"},
+			Camera:        map[string]string{"name": "good_lidar"},
 			ConfigParams:  map[string]string{"mode": "2d"},
 			DataDirectory: dataDirectory,
 			DataRateMsec:  testDataRateMsec,
@@ -246,16 +243,15 @@ func TestNew(t *testing.T) {
 		defer fsCleanupFunc()
 
 		attrCfg := &vcConfig.Config{
-			Sensors:       []string{},
+			Camera:        map[string]string{},
 			ConfigParams:  map[string]string{"mode": "2d"},
 			DataDirectory: dataDirectory,
 		}
 
 		svc, err := testhelper.CreateSLAMService(t, attrCfg, logger)
-		test.That(t, err, test.ShouldBeError, errors.New("error validating \"path\": \"sensors\" must not be empty"))
+		test.That(t, err, test.ShouldBeError, errors.New("error validating \"path\": \"camera\" must not be empty"))
 		test.That(t, svc, test.ShouldBeNil)
 	})
-}
 
 func TestClose(t *testing.T) {
 	logger := golog.NewTestLogger(t)
@@ -273,7 +269,7 @@ func TestClose(t *testing.T) {
 		}()
 
 		attrCfg := &vcConfig.Config{
-			Sensors:       []string{"replay_sensor"},
+			Camera:        map[string]string{"name": "replay_sensor"},
 			ConfigParams:  map[string]string{"mode": "2d"},
 			DataDirectory: dataDirectory,
 			MapRateSec:    &testMapRateSec,
@@ -325,11 +321,10 @@ func TestDoCommand(t *testing.T) {
 
 	test.That(t, err, test.ShouldBeNil)
 	attrCfg := &vcConfig.Config{
-		Sensors:       []string{"good_lidar"},
+		Camera:        map[string]string{"name": "good_lidar", "data_frequency_hz": testDataFreqHz},
 		ConfigParams:  map[string]string{"mode": "2d", "test_param": "viam"},
 		DataDirectory: dataDirectory,
 		MapRateSec:    &testMapRateSec,
-		DataRateMsec:  testDataRateMsec,
 	}
 	svc, err := testhelper.CreateSLAMService(t, attrCfg, logger)
 	test.That(t, err, test.ShouldBeNil)

--- a/viam_cartographer_test.go
+++ b/viam_cartographer_test.go
@@ -168,7 +168,6 @@ func TestNew(t *testing.T) {
 			Camera:        map[string]string{"name": "good_lidar"},
 			ConfigParams:  map[string]string{"mode": "2d"},
 			DataDirectory: dataDirectory,
-			DataRateMsec:  testDataRateMsec,
 		}
 
 		svc, err := testhelper.CreateSLAMService(t, attrCfg, logger)
@@ -225,6 +224,7 @@ func TestNew(t *testing.T) {
 		test.That(t, err, test.ShouldBeError, errors.New("error validating \"path\": \"camera[name]\" is required"))
 		test.That(t, svc, test.ShouldBeNil)
 	})
+}
 
 func TestClose(t *testing.T) {
 	logger := golog.NewTestLogger(t)

--- a/viam_cartographer_test.go
+++ b/viam_cartographer_test.go
@@ -26,6 +26,7 @@ import (
 const (
 	testExecutableName = "true" // the program "true", not the boolean value
 	testDataFreqHz     = "5"
+	testDataRateMsec   = 200
 )
 
 var (
@@ -49,9 +50,10 @@ func TestNew(t *testing.T) {
 		}()
 
 		attrCfg := &vcConfig.Config{
-			Camera:        map[string]string{"name": "gibberish", "data_frequency_hz": testDataFreqHz},
+			Sensors:       []string{"gibberish"},
 			ConfigParams:  map[string]string{"mode": "2d"},
 			DataDirectory: dataDirectory,
+			DataRateMsec:  testDataRateMsec,
 		}
 
 		_, err = testhelper.CreateSLAMService(t, attrCfg, logger)
@@ -75,6 +77,7 @@ func TestNew(t *testing.T) {
 			Camera:        map[string]string{"name": "good_lidar", "data_frequency_hz": testDataFreqHz},
 			ConfigParams:  map[string]string{"mode": "2d"},
 			DataDirectory: dataDirectory,
+			UseNewConfig:  true,
 		}
 
 		svc, err := testhelper.CreateSLAMService(t, attrCfg, logger)
@@ -99,6 +102,7 @@ func TestNew(t *testing.T) {
 			Camera:        map[string]string{"name": "invalid_lidar", "data_frequency_hz": testDataFreqHz},
 			ConfigParams:  map[string]string{"mode": "2d"},
 			DataDirectory: dataDirectory,
+			UseNewConfig:  true,
 		}
 
 		_, err = testhelper.CreateSLAMService(t, attrCfg, logger)
@@ -119,6 +123,7 @@ func TestNew(t *testing.T) {
 			ConfigParams:  map[string]string{"mode": "2d"},
 			DataDirectory: dataDirectory,
 			MapRateSec:    &_zeroInt,
+			UseNewConfig:  true,
 		}
 
 		svc, err := testhelper.CreateSLAMService(t, attrCfg, logger)
@@ -133,7 +138,7 @@ func TestNew(t *testing.T) {
 
 		_, componentReference, err := svc.GetPosition(context.Background())
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, componentReference, test.ShouldEqual, "replay_sensor")
+		test.That(t, componentReference, test.ShouldEqual, "good_lidar")
 
 		pcmFunc, err := svc.GetPointCloudMap(context.Background())
 		test.That(t, err, test.ShouldBeNil)
@@ -168,6 +173,7 @@ func TestNew(t *testing.T) {
 			Camera:        map[string]string{"name": "good_lidar"},
 			ConfigParams:  map[string]string{"mode": "2d"},
 			DataDirectory: dataDirectory,
+			UseNewConfig:  true,
 		}
 
 		svc, err := testhelper.CreateSLAMService(t, attrCfg, logger)
@@ -218,6 +224,7 @@ func TestNew(t *testing.T) {
 			Camera:        map[string]string{},
 			ConfigParams:  map[string]string{"mode": "2d"},
 			DataDirectory: dataDirectory,
+			UseNewConfig:  true,
 		}
 
 		svc, err := testhelper.CreateSLAMService(t, attrCfg, logger)
@@ -246,6 +253,7 @@ func TestClose(t *testing.T) {
 			ConfigParams:  map[string]string{"mode": "2d"},
 			DataDirectory: dataDirectory,
 			MapRateSec:    &testMapRateSec,
+			UseNewConfig:  true,
 		}
 
 		svc, err := testhelper.CreateSLAMService(t, attrCfg, logger)
@@ -298,6 +306,7 @@ func TestDoCommand(t *testing.T) {
 		ConfigParams:  map[string]string{"mode": "2d", "test_param": "viam"},
 		DataDirectory: dataDirectory,
 		MapRateSec:    &testMapRateSec,
+		UseNewConfig:  true,
 	}
 	svc, err := testhelper.CreateSLAMService(t, attrCfg, logger)
 	test.That(t, err, test.ShouldBeNil)

--- a/viam_cartographer_test.go
+++ b/viam_cartographer_test.go
@@ -74,10 +74,10 @@ func TestNew(t *testing.T) {
 		}()
 
 		attrCfg := &vcConfig.Config{
-			Camera:        map[string]string{"name": "good_lidar", "data_frequency_hz": testDataFreqHz},
-			ConfigParams:  map[string]string{"mode": "2d"},
-			DataDirectory: dataDirectory,
-			UseNewConfig:  true,
+			Camera:                map[string]string{"name": "good_lidar", "data_frequency_hz": testDataFreqHz},
+			ConfigParams:          map[string]string{"mode": "2d"},
+			DataDirectory:         dataDirectory,
+			IMUIntegrationEnabled: true,
 		}
 
 		svc, err := testhelper.CreateSLAMService(t, attrCfg, logger)
@@ -99,10 +99,10 @@ func TestNew(t *testing.T) {
 		}()
 
 		attrCfg := &vcConfig.Config{
-			Camera:        map[string]string{"name": "invalid_lidar", "data_frequency_hz": testDataFreqHz},
-			ConfigParams:  map[string]string{"mode": "2d"},
-			DataDirectory: dataDirectory,
-			UseNewConfig:  true,
+			Camera:                map[string]string{"name": "invalid_lidar", "data_frequency_hz": testDataFreqHz},
+			ConfigParams:          map[string]string{"mode": "2d"},
+			DataDirectory:         dataDirectory,
+			IMUIntegrationEnabled: true,
 		}
 
 		_, err = testhelper.CreateSLAMService(t, attrCfg, logger)
@@ -119,11 +119,11 @@ func TestNew(t *testing.T) {
 		defer fsCleanupFunc()
 
 		attrCfg := &vcConfig.Config{
-			Camera:        map[string]string{"name": "good_lidar"},
-			ConfigParams:  map[string]string{"mode": "2d"},
-			DataDirectory: dataDirectory,
-			MapRateSec:    &_zeroInt,
-			UseNewConfig:  true,
+			Camera:                map[string]string{"name": "good_lidar"},
+			ConfigParams:          map[string]string{"mode": "2d"},
+			DataDirectory:         dataDirectory,
+			MapRateSec:            &_zeroInt,
+			IMUIntegrationEnabled: true,
 		}
 
 		svc, err := testhelper.CreateSLAMService(t, attrCfg, logger)
@@ -170,10 +170,10 @@ func TestNew(t *testing.T) {
 		defer fsCleanupFunc()
 
 		attrCfg := &vcConfig.Config{
-			Camera:        map[string]string{"name": "good_lidar"},
-			ConfigParams:  map[string]string{"mode": "2d"},
-			DataDirectory: dataDirectory,
-			UseNewConfig:  true,
+			Camera:                map[string]string{"name": "good_lidar"},
+			ConfigParams:          map[string]string{"mode": "2d"},
+			DataDirectory:         dataDirectory,
+			IMUIntegrationEnabled: true,
 		}
 
 		svc, err := testhelper.CreateSLAMService(t, attrCfg, logger)
@@ -221,10 +221,10 @@ func TestNew(t *testing.T) {
 		defer fsCleanupFunc()
 
 		attrCfg := &vcConfig.Config{
-			Camera:        map[string]string{},
-			ConfigParams:  map[string]string{"mode": "2d"},
-			DataDirectory: dataDirectory,
-			UseNewConfig:  true,
+			Camera:                map[string]string{},
+			ConfigParams:          map[string]string{"mode": "2d"},
+			DataDirectory:         dataDirectory,
+			IMUIntegrationEnabled: true,
 		}
 
 		svc, err := testhelper.CreateSLAMService(t, attrCfg, logger)
@@ -249,11 +249,11 @@ func TestClose(t *testing.T) {
 		}()
 
 		attrCfg := &vcConfig.Config{
-			Camera:        map[string]string{"name": "replay_lidar"},
-			ConfigParams:  map[string]string{"mode": "2d"},
-			DataDirectory: dataDirectory,
-			MapRateSec:    &testMapRateSec,
-			UseNewConfig:  true,
+			Camera:                map[string]string{"name": "replay_lidar"},
+			ConfigParams:          map[string]string{"mode": "2d"},
+			DataDirectory:         dataDirectory,
+			MapRateSec:            &testMapRateSec,
+			IMUIntegrationEnabled: true,
 		}
 
 		svc, err := testhelper.CreateSLAMService(t, attrCfg, logger)
@@ -302,11 +302,11 @@ func TestDoCommand(t *testing.T) {
 
 	test.That(t, err, test.ShouldBeNil)
 	attrCfg := &vcConfig.Config{
-		Camera:        map[string]string{"name": "good_lidar", "data_frequency_hz": testDataFreqHz},
-		ConfigParams:  map[string]string{"mode": "2d", "test_param": "viam"},
-		DataDirectory: dataDirectory,
-		MapRateSec:    &testMapRateSec,
-		UseNewConfig:  true,
+		Camera:                map[string]string{"name": "good_lidar", "data_frequency_hz": testDataFreqHz},
+		ConfigParams:          map[string]string{"mode": "2d", "test_param": "viam"},
+		DataDirectory:         dataDirectory,
+		MapRateSec:            &testMapRateSec,
+		IMUIntegrationEnabled: true,
 	}
 	svc, err := testhelper.CreateSLAMService(t, attrCfg, logger)
 	test.That(t, err, test.ShouldBeNil)

--- a/viam_cartographer_test.go
+++ b/viam_cartographer_test.go
@@ -37,33 +37,6 @@ var (
 func TestNew(t *testing.T) {
 	logger := golog.NewTestLogger(t)
 
-	t.Run("Failed creation of cartographer slam service with more than one sensor", func(t *testing.T) {
-		termFunc := testhelper.InitTestCL(t, logger)
-		defer termFunc()
-
-		dataDirectory, err := os.MkdirTemp("", "*")
-		test.That(t, err, test.ShouldBeNil)
-		defer func() {
-			err := os.RemoveAll(dataDirectory)
-			test.That(t, err, test.ShouldBeNil)
-		}()
-
-		defer func() {
-			err := os.RemoveAll(dataDirectory)
-			test.That(t, err, test.ShouldBeNil)
-		}()
-		attrCfg := &vcConfig.Config{
-			Camera:        map[string]string{"name": "lidar", "name2": "one-too-many"},
-			ConfigParams:  map[string]string{"mode": "2d"},
-			DataDirectory: dataDirectory,
-		}
-
-		_, err = testhelper.CreateSLAMService(t, attrCfg, logger)
-		test.That(t, err, test.ShouldBeError,
-			errors.New("configuring lidar camera error: 'sensors' must contain only one "+
-				"lidar camera, but is 'sensors: [lidar, one-too-many]'"))
-	})
-
 	t.Run("Failed creation of cartographer slam service with non-existing sensor", func(t *testing.T) {
 		termFunc := testhelper.InitTestCL(t, logger)
 		defer termFunc()
@@ -123,7 +96,7 @@ func TestNew(t *testing.T) {
 		}()
 
 		attrCfg := &vcConfig.Config{
-			Camera:        map[string]string{"name": "invalid_sensor", "data_frequency_hz": testDataFreqHz},
+			Camera:        map[string]string{"name": "invalid_lidar", "data_frequency_hz": testDataFreqHz},
 			ConfigParams:  map[string]string{"mode": "2d"},
 			DataDirectory: dataDirectory,
 		}
@@ -249,7 +222,7 @@ func TestNew(t *testing.T) {
 		}
 
 		svc, err := testhelper.CreateSLAMService(t, attrCfg, logger)
-		test.That(t, err, test.ShouldBeError, errors.New("error validating \"path\": \"camera\" must not be empty"))
+		test.That(t, err, test.ShouldBeError, errors.New("error validating \"path\": \"camera[name]\" is required"))
 		test.That(t, svc, test.ShouldBeNil)
 	})
 
@@ -269,7 +242,7 @@ func TestClose(t *testing.T) {
 		}()
 
 		attrCfg := &vcConfig.Config{
-			Camera:        map[string]string{"name": "replay_sensor"},
+			Camera:        map[string]string{"name": "replay_lidar"},
 			ConfigParams:  map[string]string{"mode": "2d"},
 			DataDirectory: dataDirectory,
 			MapRateSec:    &testMapRateSec,

--- a/viam_cartographer_test.go
+++ b/viam_cartographer_test.go
@@ -85,7 +85,7 @@ func TestNew(t *testing.T) {
 
 		_, err = testhelper.CreateSLAMService(t, attrCfg, logger)
 		test.That(t, err, test.ShouldBeError,
-			errors.New("error getting camera "+
+			errors.New("error getting lidar camera "+
 				"gibberish for slam service: \"rdk:component:camera/gibberish\" missing from dependencies"))
 	})
 
@@ -135,7 +135,7 @@ func TestNew(t *testing.T) {
 		_, err = testhelper.CreateSLAMService(t, attrCfg, logger)
 		test.That(t, err, test.ShouldBeError,
 
-			errors.New("failed to get data from lidar: ValidateGetData timeout: NextPointCloud error: invalid lidar"))
+			errors.New("failed to get data from lidar: ValidateGetData timeout: NextPointCloud error: invalid sensor"))
 	})
 
 	t.Run("Successful creation of cartographer slam service in localization mode", func(t *testing.T) {
@@ -307,7 +307,7 @@ func TestNewFeatureFlag(t *testing.T) {
 		_, err = testhelper.CreateSLAMService(t, attrCfg, logger)
 		test.That(t, err, test.ShouldBeError,
 
-			errors.New("failed to get data from lidar: ValidateGetData timeout: NextPointCloud error: invalid lidar"))
+			errors.New("failed to get data from lidar: ValidateGetData timeout: NextPointCloud error: invalid sensor"))
 	})
 
 	t.Run("Successful creation of cartographer slam service in localization mode with feature flag enabled", func(t *testing.T) {


### PR DESCRIPTION
- Edit lidar naming and config
- Build data frequency into lidar map rather than separate variable
- Add feature flag

Testing new config structure with replay sensor: 
```javascript
{
  "components": [
    {
      "type": "camera",
      "model": "replay_pcd",
      "attributes": {
        "time_interval": {
          "end": "2023-07-31T18:31:30.597920Z",
          "start": "2023-07-31T18:31:17.597920Z"
        },
        "batch_size": 50,
        "robot_id": "d1f2018b-6de0-449f-8d7a-7e6fd8ace7b3",
        "source": "MULAN"
      },
      "depends_on": [],
      "name": "replay-camera"
    }
  ],
  "services": [
    {
      "type": "slam",
      "model": "viam:slam:cartographer",
      "attributes": {
        "camera": {
          "name": "replay-camera"
        },
        "config_params": {
          "mode": "2d"
        },
        "data_dir": "/Users/patriciastrutz/Development/Data/new_new_data",
        "imu_integration_enabled": true
      },
      "name": "slam"
    }
  ],
  "modules": [
    {
      "name": "cartographer",
      "executable_path": "/usr/local/bin/cartographer-module",
      "debug": true
    },
    {
      "name": "rplidar",
      "executable_path": "/opt/homebrew/bin/rplidar-module"
    }
  ]
}
``` 

Testing feature flag implementation to use old config structure with replay sensor: 
```javascript
{
  "components": [
    {
      "type": "camera",
      "model": "replay_pcd",
      "attributes": {
        "time_interval": {
          "end": "2023-07-31T18:31:30.597920Z",
          "start": "2023-07-31T18:31:17.597920Z"
        },
        "batch_size": 50,
        "robot_id": "d1f2018b-6de0-449f-8d7a-7e6fd8ace7b3",
        "source": "MULAN"
      },
      "depends_on": [],
      "name": "replay-camera"
    }
  ],
  "services": [
    {
      "type": "slam",
      "model": "viam:slam:cartographer",
      "attributes": {
        "sensors": ["replay-camera"]
        "config_params": {
          "mode": "2d"
        },
        "data_dir": "/Users/patriciastrutz/Development/Data/new_new_data",
        "imu_integration_enabled": false
      },
      "name": "slam"
    }
  ],
  "modules": [
    {
      "name": "cartographer",
      "executable_path": "/usr/local/bin/cartographer-module",
      "debug": true
    },
    {
      "name": "rplidar",
      "executable_path": "/opt/homebrew/bin/rplidar-module"
    }
  ]
}
``` 