### PR TITLE
RSDK-4345 - add feature flag for cloud story

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -17,13 +17,17 @@ func testValidateTesthelper(
 	testCfgPath string,
 	cloudStoryEnabled bool,
 ) {
-	t.Run("Simplest valid config", func(t *testing.T) {
+	suffix := ""
+	if cloudStoryEnabled {
+		suffix = " with cloudStoryEnabled = true"
+	}
+	t.Run(fmt.Sprintf("Simplest valid config%s", suffix), func(t *testing.T) {
 		cfgService := makeCfgService(false, false)
 		_, err := newConfig(cfgService)
 		test.That(t, err, test.ShouldBeNil)
 	})
 
-	t.Run("Config without required fields", func(t *testing.T) {
+	t.Run(fmt.Sprintf("Config without required fields%s", suffix), func(t *testing.T) {
 		var requiredFields []string
 		if cloudStoryEnabled {
 			requiredFields = []string{"existing_map", "sensors"}
@@ -53,7 +57,7 @@ func testValidateTesthelper(
 		test.That(t, err, test.ShouldBeError, newError(utils.NewConfigValidationFieldRequiredError(testCfgPath, "config_params[mode]").Error()))
 	})
 
-	t.Run("Config with invalid parameter type", func(t *testing.T) {
+	t.Run(fmt.Sprintf("Config with invalid parameter type%s", suffix), func(t *testing.T) {
 		var key string
 		if cloudStoryEnabled {
 			key = "existing_map"
@@ -74,7 +78,7 @@ func testValidateTesthelper(
 		test.That(t, err, test.ShouldBeNil)
 	})
 
-	t.Run("Config with out of range values", func(t *testing.T) {
+	t.Run(fmt.Sprintf("Config with out of range values%s", suffix), func(t *testing.T) {
 		cfgService := makeCfgService(false, cloudStoryEnabled)
 		cfgService.Attributes["data_rate_msec"] = -1
 		_, err := newConfig(cfgService)
@@ -91,7 +95,7 @@ func testValidateTesthelper(
 		}
 	})
 
-	t.Run("All parameters e2e", func(t *testing.T) {
+	t.Run(fmt.Sprintf("All parameters e2e%s", suffix), func(t *testing.T) {
 		cfgService := makeCfgService(false, cloudStoryEnabled)
 		cfgService.Attributes["sensors"] = []string{"a", "b"}
 		cfgService.Attributes["data_rate_msec"] = 1001

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -17,9 +17,9 @@ func configWithoutRequiredFieldsTestHelper(
 	testCfgPath string,
 	logger golog.Logger,
 	cfgFunc func(bool) resource.Config,
+	requiredFields []string,
 ) {
 	t.Helper()
-	requiredFields := []string{"data_dir", "sensors"}
 	dataDirErr := utils.NewConfigValidationFieldRequiredError(testCfgPath, requiredFields[0])
 	cameraErr := utils.NewConfigValidationError(testCfgPath, errSensorsMustNotBeEmpty)
 
@@ -61,7 +61,8 @@ func TestValidate(t *testing.T) {
 	})
 
 	t.Run("Config without required fields", func(t *testing.T) {
-		configWithoutRequiredFieldsTestHelper(t, testCfgPath, logger, makeCfgService)
+		requiredFields := []string{"data_dir", "sensors"}
+		configWithoutRequiredFieldsTestHelper(t, testCfgPath, logger, makeCfgService, requiredFields)
 	})
 
 	t.Run("Config with invalid parameter type", func(t *testing.T) {
@@ -119,7 +120,8 @@ func TestValidateCloudStoryEnabled(t *testing.T) {
 	})
 
 	t.Run("Config without required fields", func(t *testing.T) {
-		configWithoutRequiredFieldsTestHelper(t, testCfgPath, logger, makeCfgServiceCloudStoryEnabled)
+		requiredFields := []string{"existing_map", "sensors"}
+		configWithoutRequiredFieldsTestHelper(t, testCfgPath, logger, makeCfgServiceCloudStoryEnabled, requiredFields)
 	})
 
 	t.Run("Config with invalid parameter type", func(t *testing.T) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -10,6 +10,39 @@ import (
 	"go.viam.com/utils"
 )
 
+const CloudStoryEnabled = "cloud_story_enabled"
+
+func configWithoutRequiredFieldsTestHelper(
+	t *testing.T,
+	testCfgPath string,
+	logger golog.Logger,
+	cfgFunc func(bool) resource.Config,
+) {
+	t.Helper()
+	requiredFields := []string{"data_dir", "sensors"}
+	dataDirErr := utils.NewConfigValidationFieldRequiredError(testCfgPath, requiredFields[0])
+	cameraErr := utils.NewConfigValidationError(testCfgPath, errSensorsMustNotBeEmpty)
+
+	expectedErrors := []error{
+		newError(dataDirErr.Error()),
+		newError(cameraErr.Error()),
+	}
+	for i, requiredField := range requiredFields {
+		logger.Debugf("Testing SLAM config without %s\n", requiredField)
+		cfgService := cfgFunc(false)
+		delete(cfgService.Attributes, requiredField)
+		_, err := newConfig(cfgService)
+
+		test.That(t, err, test.ShouldBeError, expectedErrors[i])
+	}
+	// Test for missing config_params attributes
+	logger.Debug("Testing SLAM config without config_params[mode]")
+	cfgService := cfgFunc(false)
+	delete(cfgService.Attributes["config_params"].(map[string]string), "mode")
+	_, err := newConfig(cfgService)
+	test.That(t, err, test.ShouldBeError, newError(utils.NewConfigValidationFieldRequiredError(testCfgPath, "config_params[mode]").Error()))
+}
+
 func TestValidate(t *testing.T) {
 	testCfgPath := "services.slam.attributes.fake"
 	logger := golog.NewTestLogger(t)
@@ -28,28 +61,7 @@ func TestValidate(t *testing.T) {
 	})
 
 	t.Run("Config without required fields", func(t *testing.T) {
-		requiredFields := []string{"data_dir", "sensors"}
-		dataDirErr := utils.NewConfigValidationFieldRequiredError(testCfgPath, requiredFields[0])
-		cameraErr := utils.NewConfigValidationError(testCfgPath, errSensorsMustNotBeEmpty)
-
-		expectedErrors := []error{
-			newError(dataDirErr.Error()),
-			newError(cameraErr.Error()),
-		}
-		for i, requiredField := range requiredFields {
-			logger.Debugf("Testing SLAM config without %s\n", requiredField)
-			cfgService := makeCfgService(false)
-			delete(cfgService.Attributes, requiredField)
-			_, err := newConfig(cfgService)
-
-			test.That(t, err, test.ShouldBeError, expectedErrors[i])
-		}
-		// Test for missing config_params attributes
-		logger.Debug("Testing SLAM config without config_params[mode]")
-		cfgService := makeCfgService(false)
-		delete(cfgService.Attributes["config_params"].(map[string]string), "mode")
-		_, err := newConfig(cfgService)
-		test.That(t, err, test.ShouldBeError, newError(utils.NewConfigValidationFieldRequiredError(testCfgPath, "config_params[mode]").Error()))
+		configWithoutRequiredFieldsTestHelper(t, testCfgPath, logger, makeCfgService)
 	})
 
 	t.Run("Config with invalid parameter type", func(t *testing.T) {
@@ -87,11 +99,66 @@ func TestValidate(t *testing.T) {
 		}
 		cfg, err := newConfig(cfgService)
 		test.That(t, err, test.ShouldBeNil)
+		test.That(t, cfg.CloudStoryEnabled, test.ShouldBeFalse)
 		test.That(t, cfg.DataDirectory, test.ShouldEqual, cfgService.Attributes["data_dir"])
 		test.That(t, cfg.Sensors, test.ShouldResemble, cfgService.Attributes["sensors"])
 		test.That(t, cfg.DataRateMsec, test.ShouldEqual, cfgService.Attributes["data_rate_msec"])
 		test.That(t, *cfg.MapRateSec, test.ShouldEqual, cfgService.Attributes["map_rate_sec"])
 		test.That(t, cfg.ConfigParams, test.ShouldResemble, cfgService.Attributes["config_params"])
+	})
+}
+
+func TestValidateCloudStoryEnabled(t *testing.T) {
+	testCfgPath := "services.slam.attributes.fake"
+	logger := golog.NewTestLogger(t)
+
+	t.Run("Simplest valid config", func(t *testing.T) {
+		cfgService := makeCfgServiceCloudStoryEnabled(false)
+		_, err := newConfig(cfgService)
+		test.That(t, err, test.ShouldBeNil)
+	})
+
+	t.Run("Config without required fields", func(t *testing.T) {
+		configWithoutRequiredFieldsTestHelper(t, testCfgPath, logger, makeCfgServiceCloudStoryEnabled)
+	})
+
+	t.Run("Config with invalid parameter type", func(t *testing.T) {
+		cfgService := makeCfgServiceCloudStoryEnabled(false)
+		cfgService.Attributes["existing_map"] = true
+		_, err := newConfig(cfgService)
+		expE := newError("1 error(s) decoding:\n\n* 'existing_map' expected type 'string', got unconvertible type 'bool', value: 'true'")
+		test.That(t, err, test.ShouldBeError, expE)
+
+		cfgService.Attributes["existing_map"] = "path"
+		_, err = newConfig(cfgService)
+		test.That(t, err, test.ShouldBeNil)
+	})
+
+	t.Run("Config with out of range values", func(t *testing.T) {
+		cfgService := makeCfgServiceCloudStoryEnabled(false)
+		cfgService.Attributes["data_rate_msec"] = -1
+		_, err := newConfig(cfgService)
+		test.That(t, err, test.ShouldBeError, newError("cannot specify data_rate_msec less than zero"))
+	})
+
+	t.Run("All parameters e2e", func(t *testing.T) {
+		cfgService := makeCfgServiceCloudStoryEnabled(false)
+		cfgService.Attributes["sensors"] = []string{"a", "b"}
+		cfgService.Attributes["data_rate_msec"] = 1001
+
+		cfgService.Attributes["config_params"] = map[string]string{
+			"mode":    "test mode",
+			"value":   "0",
+			"value_2": "test",
+		}
+		cfg, err := newConfig(cfgService)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, cfg.CloudStoryEnabled, test.ShouldBeTrue)
+		test.That(t, cfg.ExistingMap, test.ShouldEqual, cfgService.Attributes["existing_map"])
+		test.That(t, cfg.Sensors, test.ShouldResemble, cfgService.Attributes["sensors"])
+		test.That(t, cfg.DataRateMsec, test.ShouldEqual, cfgService.Attributes["data_rate_msec"])
+		test.That(t, cfg.ConfigParams, test.ShouldResemble, cfgService.Attributes["config_params"])
+		test.That(t, cfg.MapRateSec, test.ShouldBeNil)
 	})
 }
 
@@ -113,6 +180,34 @@ func makeCfgService(IMUIntegrationEnabled bool) resource.Config {
 		cfgService.Attributes["sensors"] = []string{"a"}
 	}
 
+	return cfgService
+}
+
+// makeCfgService creates the simplest possible config that can pass validation.
+func makeCfgServiceCloudStoryEnabled(IMUIntegrationEnabled bool) resource.Config {
+	model := resource.DefaultModelFamily.WithModel("test")
+	cfgService := resource.Config{
+		Name:  "test",
+		API:   slam.API,
+		Model: model,
+	}
+	attributes := make(map[string]interface{})
+	attributes["config_params"] = map[string]string{
+		"mode": "test mode",
+	}
+	attributes["existing_map"] = "path"
+	attributes[CloudStoryEnabled] = true
+
+	if IMUIntegrationEnabled {
+		attributes["imu_integration_enabled"] = true
+		attributes["camera"] = map[string]string{
+			"name": "a",
+		}
+	} else {
+		attributes["sensors"] = []string{"a"}
+	}
+
+	cfgService.Attributes = attributes
 	return cfgService
 }
 

--- a/viam_cartographer.go
+++ b/viam_cartographer.go
@@ -267,6 +267,12 @@ func parseCartoAlgoConfig(configParams map[string]string, logger golog.Logger) (
 				return cartoAlgoCfg, err
 			}
 			cartoAlgoCfg.NumRangeData = iVal
+		case "missing_data_ray_length_meters":
+			fVal, err := strconv.ParseFloat(val, 32)
+			if err != nil {
+				return cartoAlgoCfg, err
+			}
+			cartoAlgoCfg.MissingDataRayLength = float32(fVal)
 		case "missing_data_ray_length":
 			fVal, err := strconv.ParseFloat(val, 32)
 			if err != nil {
@@ -279,7 +285,19 @@ func parseCartoAlgoConfig(configParams map[string]string, logger golog.Logger) (
 				return cartoAlgoCfg, err
 			}
 			cartoAlgoCfg.MaxRange = float32(fVal)
+		case "max_range_meters":
+			fVal, err := strconv.ParseFloat(val, 32)
+			if err != nil {
+				return cartoAlgoCfg, err
+			}
+			cartoAlgoCfg.MaxRange = float32(fVal)
 		case "min_range":
+			fVal, err := strconv.ParseFloat(val, 32)
+			if err != nil {
+				return cartoAlgoCfg, err
+			}
+			cartoAlgoCfg.MinRange = float32(fVal)
+		case "min_range_meters":
 			fVal, err := strconv.ParseFloat(val, 32)
 			if err != nil {
 				return cartoAlgoCfg, err
@@ -298,6 +316,12 @@ func parseCartoAlgoConfig(configParams map[string]string, logger golog.Logger) (
 			}
 			cartoAlgoCfg.FreshSubmapsCount = iVal
 		case "min_covered_area":
+			fVal, err := strconv.ParseFloat(val, 64)
+			if err != nil {
+				return cartoAlgoCfg, err
+			}
+			cartoAlgoCfg.MinCoveredArea = fVal
+		case "min_covered_area_meters_squared":
 			fVal, err := strconv.ParseFloat(val, 64)
 			if err != nil {
 				return cartoAlgoCfg, err

--- a/viam_cartographer_internal_test.go
+++ b/viam_cartographer_internal_test.go
@@ -365,6 +365,44 @@ func TestParseCartoAlgoConfig(t *testing.T) {
 		test.That(t, cartoAlgoConfig, test.ShouldResemble, overRidenCartoAlgoCfg)
 	})
 
+	t.Run("returns overrides when config is non empty for cloud story configs", func(t *testing.T) {
+		configParams := map[string]string{
+			"optimize_on_start":               "true",
+			"optimize_every_n_nodes":          "1",
+			"num_range_data":                  "2",
+			"missing_data_ray_length_meters":  "3.0",
+			"max_range_meters":                "4.0",
+			"min_range_meters":                "5.0",
+			"max_submaps_to_keep":             "6",
+			"fresh_submaps_count":             "7",
+			"min_covered_area_meters_squared": "8.0",
+			"min_added_submaps_count":         "9",
+			"occupied_space_weight":           "10.0",
+			"translation_weight":              "11.0",
+			"rotation_weight":                 "12.0",
+		}
+
+		overRidenCartoAlgoCfg := cartofacade.CartoAlgoConfig{
+			OptimizeOnStart:      true,
+			OptimizeEveryNNodes:  1,
+			NumRangeData:         2,
+			MissingDataRayLength: 3.0,
+			MaxRange:             4.0,
+			MinRange:             5.0,
+			MaxSubmapsToKeep:     6,
+			FreshSubmapsCount:    7,
+			MinCoveredArea:       8.0,
+			MinAddedSubmapsCount: 9,
+			OccupiedSpaceWeight:  10.0,
+			TranslationWeight:    11.0,
+			RotationWeight:       12.0,
+		}
+
+		cartoAlgoConfig, err := parseCartoAlgoConfig(configParams, logger)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, cartoAlgoConfig, test.ShouldResemble, overRidenCartoAlgoCfg)
+	})
+
 	t.Run("returns error when unsupported param provided", func(t *testing.T) {
 		configParams := map[string]string{
 			"optimize_on_start": "true",


### PR DESCRIPTION
# Changes
* adds feature flag to put cloud story changes behind. Feature flag will be provided through the config as `cloud_story_enabled`
* adds config changes for `existing_map`, `enable_mapping`, and `run_slam`
* validates that `existing_map` has been provided
* adds parsing & tests for new config params
* does not create a new getOptionalParameters func
