### PR TITLE
RSDK-4361 - add enable mapping flag for cloud story

### DIFF
--- a/cartofacade/capi.go
+++ b/cartofacade/capi.go
@@ -92,6 +92,9 @@ type CartoConfig struct {
 	DataDir            string
 	ComponentReference string
 	LidarConfig        LidarConfig
+
+	CloudStoryEnabled bool
+	EnableMapping     bool
 }
 
 // CartoAlgoConfig contains config values from app
@@ -334,6 +337,9 @@ func getConfig(cfg CartoConfig) (C.viam_carto_config, error) {
 	vcc.map_rate_sec = C.int(cfg.MapRateSecond)
 	vcc.data_dir = goStringToBstring(cfg.DataDir)
 	vcc.lidar_config = lidarCfg
+
+	vcc.cloud_story_enabled = C.bool(cfg.CloudStoryEnabled)
+	vcc.enable_mapping = C.bool(cfg.EnableMapping)
 
 	return vcc, nil
 }

--- a/cartofacade/capi.go
+++ b/cartofacade/capi.go
@@ -303,13 +303,6 @@ func getTestGetPositionResponse() C.viam_carto_get_position_response {
 	return gpr
 }
 
-func cBoolToGoBool(val C.bool) bool {
-	if val {
-		return true
-	}
-	return false
-}
-
 func bstringToGoString(bstr C.bstring) string {
 	return C.GoStringN(C.bstr2cstr(bstr, 0), bstr.slen)
 }

--- a/cartofacade/capi.go
+++ b/cartofacade/capi.go
@@ -303,6 +303,13 @@ func getTestGetPositionResponse() C.viam_carto_get_position_response {
 	return gpr
 }
 
+func cBoolToGoBool(val C.bool) bool {
+	if val {
+		return true
+	}
+	return false
+}
+
 func bstringToGoString(bstr C.bstring) string {
 	return C.GoStringN(C.bstr2cstr(bstr, 0), bstr.slen)
 }

--- a/cartofacade/capi_test.go
+++ b/cartofacade/capi_test.go
@@ -68,10 +68,10 @@ func TestGetConfig(t *testing.T) {
 		dataDir := bstringToGoString(vcc.data_dir)
 		test.That(t, dataDir, test.ShouldResemble, dir)
 
-		cloudStoryEnabled := cBoolToGoBool(vcc.cloud_story_enabled)
+		cloudStoryEnabled := bool(vcc.cloud_story_enabled)
 		test.That(t, cloudStoryEnabled, test.ShouldBeFalse)
 
-		enableMapping := cBoolToGoBool(vcc.enable_mapping)
+		enableMapping := bool(vcc.enable_mapping)
 		test.That(t, enableMapping, test.ShouldBeFalse)
 
 		test.That(t, vcc.lidar_config, test.ShouldEqual, TwoD)
@@ -94,10 +94,10 @@ func TestGetConfig(t *testing.T) {
 		dataDir := bstringToGoString(vcc.data_dir)
 		test.That(t, dataDir, test.ShouldResemble, dir)
 
-		cloudStoryEnabled := cBoolToGoBool(vcc.cloud_story_enabled)
+		cloudStoryEnabled := bool(vcc.cloud_story_enabled)
 		test.That(t, cloudStoryEnabled, test.ShouldBeFalse)
 
-		enableMapping := cBoolToGoBool(vcc.enable_mapping)
+		enableMapping := bool(vcc.enable_mapping)
 		test.That(t, enableMapping, test.ShouldBeFalse)
 
 		test.That(t, vcc.lidar_config, test.ShouldEqual, TwoD)

--- a/cartofacade/capi_test.go
+++ b/cartofacade/capi_test.go
@@ -68,8 +68,13 @@ func TestGetConfig(t *testing.T) {
 		dataDir := bstringToGoString(vcc.data_dir)
 		test.That(t, dataDir, test.ShouldResemble, dir)
 
+		cloudStoryEnabled := cBoolToGoBool(vcc.cloud_story_enabled)
+		test.That(t, cloudStoryEnabled, test.ShouldBeFalse)
+
+		enableMapping := cBoolToGoBool(vcc.enable_mapping)
+		test.That(t, enableMapping, test.ShouldBeFalse)
+
 		test.That(t, vcc.lidar_config, test.ShouldEqual, TwoD)
-		test.That(t, vcc.cloud_story_enabled, test.ShouldBeFalse)
 	})
 
 	t.Run("config properly converted between C and go with an IMU specified", func(t *testing.T) {
@@ -89,8 +94,13 @@ func TestGetConfig(t *testing.T) {
 		dataDir := bstringToGoString(vcc.data_dir)
 		test.That(t, dataDir, test.ShouldResemble, dir)
 
+		cloudStoryEnabled := cBoolToGoBool(vcc.cloud_story_enabled)
+		test.That(t, cloudStoryEnabled, test.ShouldBeFalse)
+
+		enableMapping := cBoolToGoBool(vcc.enable_mapping)
+		test.That(t, enableMapping, test.ShouldBeFalse)
+
 		test.That(t, vcc.lidar_config, test.ShouldEqual, TwoD)
-		test.That(t, vcc.cloud_story_enabled, test.ShouldBeFalse)
 	})
 }
 

--- a/cartofacade/capi_test.go
+++ b/cartofacade/capi_test.go
@@ -69,6 +69,7 @@ func TestGetConfig(t *testing.T) {
 		test.That(t, dataDir, test.ShouldResemble, dir)
 
 		test.That(t, vcc.lidar_config, test.ShouldEqual, TwoD)
+		test.That(t, vcc.cloud_story_enabled, test.ShouldBeFalse)
 	})
 
 	t.Run("config properly converted between C and go with an IMU specified", func(t *testing.T) {
@@ -89,6 +90,7 @@ func TestGetConfig(t *testing.T) {
 		test.That(t, dataDir, test.ShouldResemble, dir)
 
 		test.That(t, vcc.lidar_config, test.ShouldEqual, TwoD)
+		test.That(t, vcc.cloud_story_enabled, test.ShouldBeFalse)
 	})
 }
 

--- a/cartofacade/testhelpers.go
+++ b/cartofacade/testhelpers.go
@@ -18,6 +18,7 @@ func GetTestConfig(cameraName, movementSensorName string) (CartoConfig, string, 
 		DataDir:            dir,
 		ComponentReference: "component",
 		LidarConfig:        TwoD,
+		CloudStoryEnabled:  false,
 	}, dir, nil
 }
 

--- a/cartofacade/testhelpers.go
+++ b/cartofacade/testhelpers.go
@@ -19,6 +19,7 @@ func GetTestConfig(cameraName, movementSensorName string) (CartoConfig, string, 
 		ComponentReference: "component",
 		LidarConfig:        TwoD,
 		CloudStoryEnabled:  false,
+		EnableMapping:      false,
 	}, dir, nil
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -47,6 +47,7 @@ func (config *Config) Validate(path string) ([]string, error) {
 		if !ok {
 			return nil, utils.NewConfigValidationError(path, errCameraMustHaveName)
 		}
+
 		dataFreqHz, ok := config.Camera["data_frequency_hz"]
 		if ok {
 			dataFreqHz, err := strconv.Atoi(dataFreqHz)
@@ -57,6 +58,18 @@ func (config *Config) Validate(path string) ([]string, error) {
 				return nil, errors.New("cannot specify camera[data_frequency_hz] less than zero")
 			}
 		}
+
+		mapRateSec, ok := config.Camera["map_rate_sec"]
+		if ok {
+			mapRateSec, err := strconv.Atoi(mapRateSec)
+			if err != nil {
+				return nil, errors.New("camera[map_rate_sec] must only contain digits")
+			}
+			if mapRateSec < 0 {
+				return nil, errors.New("cannot specify map_rate_sec less than zero")
+			}
+		}
+
 		imuName, imuExists = config.MovementSensor["name"]
 	} else {
 		if config.Sensors == nil || len(config.Sensors) < 1 {

--- a/config/config.go
+++ b/config/config.go
@@ -127,9 +127,7 @@ func GetOptionalParameters(config *Config, defaultLidarDataRateMsec, defaultIMUD
 			if err != nil {
 				return OptionalConfigParams{}, newError("camera[data_frequency_hz] must only contain digits")
 			}
-			if lidarDataFreqHz == 0 {
-				optionalConfigParams.LidarDataRateMsec = 0
-			} else {
+			if lidarDataFreqHz != 0 {
 				optionalConfigParams.LidarDataRateMsec = 1000 / lidarDataFreqHz
 			}
 		}
@@ -157,7 +155,6 @@ func GetOptionalParameters(config *Config, defaultLidarDataRateMsec, defaultIMUD
 		}
 	}
 
-	optionalConfigParams.MapRateSec = 0
 	if config.MapRateSec == nil {
 		logger.Debugf("no map_rate_sec given, setting to default value of %d", defaultMapRateSec)
 		optionalConfigParams.MapRateSec = defaultMapRateSec
@@ -165,7 +162,6 @@ func GetOptionalParameters(config *Config, defaultLidarDataRateMsec, defaultIMUD
 		optionalConfigParams.MapRateSec = *config.MapRateSec
 	}
 
-	optionalConfigParams.EnableMapping = false
 	if config.CloudStoryEnabled {
 		if config.EnableMapping == nil {
 			logger.Debugf("no enable_mapping given, setting to default value of false", defaultMapRateSec)

--- a/config/config.go
+++ b/config/config.go
@@ -175,7 +175,7 @@ func GetOptionalParameters(config *Config, defaultLidarDataRateMsec, defaultIMUD
 			optionalConfigParams.EnableMapping = config.CloudStoryEnabled
 		}
 	} else {
-		if config.EnableMapping != nil && *config.EnableMapping == true {
+		if config.EnableMapping != nil && *config.EnableMapping {
 			logger.Warn("enable_mapping set to true while cloud_story_enabled = false will not change any behavior")
 		}
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -153,7 +153,7 @@ func GetOptionalParameters(config *Config, defaultLidarDataRateMsec, defaultIMUD
 
 	if config.CloudStoryEnabled {
 		if config.EnableMapping == nil {
-			logger.Debugf("no enable_mapping given, setting to default value of false", defaultMapRateSec)
+			logger.Debug("no enable_mapping given, setting to default value of false")
 		} else {
 			optionalConfigParams.EnableMapping = config.CloudStoryEnabled
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -29,7 +29,6 @@ type Config struct {
 	ExistingMap       string `json:"existing_map"`
 	EnableMapping     *bool  `json:"enable_mapping"`
 	UseCloudSlam      *bool  `json:"use_cloud_slam"`
-	RunSlam           bool   `json:"run_slam"`
 }
 
 var (

--- a/config/config.go
+++ b/config/config.go
@@ -31,6 +31,7 @@ type Config struct {
 	UseCloudSlam      *bool  `json:"use_cloud_slam"`
 }
 
+// OptionalConfigParams holds the optional config parameters of SLAM.
 type OptionalConfigParams struct {
 	LidarDataRateMsec int
 	ImuName           string

--- a/config/config.go
+++ b/config/config.go
@@ -114,10 +114,7 @@ func (config *Config) Validate(path string) ([]string, error) {
 // and returns them.
 func GetOptionalParameters(config *Config, defaultLidarDataRateMsec, defaultIMUDataRateMsec, defaultMapRateSec int, logger golog.Logger,
 ) (OptionalConfigParams, error) {
-	optionalConfigParams := OptionalConfigParams{}
-	optionalConfigParams.LidarDataRateMsec = 0
-	optionalConfigParams.ImuName = ""
-	optionalConfigParams.ImuDataRateMsec = defaultIMUDataRateMsec
+	optionalConfigParams := OptionalConfigParams{ImuDataRateMsec: defaultIMUDataRateMsec}
 
 	// feature flag for new config
 	if config.IMUIntegrationEnabled {

--- a/config/config.go
+++ b/config/config.go
@@ -68,17 +68,6 @@ func (config *Config) Validate(path string) ([]string, error) {
 			}
 		}
 
-		mapRateSec, ok := config.Camera["map_rate_sec"]
-		if ok {
-			mapRateSec, err := strconv.Atoi(mapRateSec)
-			if err != nil {
-				return nil, errors.New("camera[map_rate_sec] must only contain digits")
-			}
-			if mapRateSec < 0 {
-				return nil, errors.New("cannot specify map_rate_sec less than zero")
-			}
-		}
-
 		imuName, imuExists = config.MovementSensor["name"]
 	} else {
 		if config.Sensors == nil || len(config.Sensors) < 1 {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -212,16 +212,16 @@ func getOptionalParametersTestHelper(
 		cfgService.Attributes["sensors"] = []string{"a"}
 		cfg, err := newConfig(cfgService)
 		test.That(t, err, test.ShouldBeNil)
-		lidarDataRateMsec, _, _, mapRateSec, enableMapping, err := GetOptionalParameters(
+		optionalConfigParams, err := GetOptionalParameters(
 			cfg,
 			1000,
 			1000,
 			1002,
 			logger)
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, mapRateSec, test.ShouldEqual, 1002)
-		test.That(t, lidarDataRateMsec, test.ShouldEqual, 1000)
-		test.That(t, enableMapping, test.ShouldBeFalse)
+		test.That(t, optionalConfigParams.MapRateSec, test.ShouldEqual, 1002)
+		test.That(t, optionalConfigParams.LidarDataRateMsec, test.ShouldEqual, 1000)
+		test.That(t, optionalConfigParams.EnableMapping, test.ShouldBeFalse)
 	})
 
 	t.Run(fmt.Sprintf("Return overrides%s", suffix), func(t *testing.T) {
@@ -243,22 +243,22 @@ func getOptionalParametersTestHelper(
 		dataRate := 50
 		cfg.DataRateMsec = &dataRate
 		test.That(t, err, test.ShouldBeNil)
-		lidarDataRateMsec, imuName, imuDataRateMsec, mapRateSec, enableMapping, err := GetOptionalParameters(
+		optionalConfigParams, err := GetOptionalParameters(
 			cfg,
 			1000,
 			1000,
 			1002,
 			logger)
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, mapRateSec, test.ShouldEqual, 2)
+		test.That(t, optionalConfigParams.MapRateSec, test.ShouldEqual, 2)
 		if imuIntegrationEnabled {
-			test.That(t, imuName, test.ShouldEqual, "testNameSensor")
-			test.That(t, imuDataRateMsec, test.ShouldEqual, 500)
-			test.That(t, lidarDataRateMsec, test.ShouldEqual, 500)
+			test.That(t, optionalConfigParams.ImuName, test.ShouldEqual, "testNameSensor")
+			test.That(t, optionalConfigParams.ImuDataRateMsec, test.ShouldEqual, 500)
+			test.That(t, optionalConfigParams.LidarDataRateMsec, test.ShouldEqual, 500)
 		} else {
-			test.That(t, lidarDataRateMsec, test.ShouldEqual, 50)
+			test.That(t, optionalConfigParams.LidarDataRateMsec, test.ShouldEqual, 50)
 		}
-		test.That(t, enableMapping, test.ShouldBeFalse)
+		test.That(t, optionalConfigParams.EnableMapping, test.ShouldBeFalse)
 	})
 
 	if imuIntegrationEnabled {
@@ -280,7 +280,7 @@ func sensorAttributeTestHelper(
 		}
 		cfg, err := newConfigWithoutValidate(cfgService)
 		test.That(t, err, test.ShouldBeNil)
-		_, _, _, _, _, err = GetOptionalParameters(
+		_, err = GetOptionalParameters(
 			cfg,
 			1000,
 			1000,
@@ -301,7 +301,7 @@ func sensorAttributeTestHelper(
 		}
 		cfg, err := newConfigWithoutValidate(cfgService)
 		test.That(t, err, test.ShouldBeNil)
-		_, _, _, _, _, err = GetOptionalParameters(
+		_, err = GetOptionalParameters(
 			cfg,
 			1000,
 			1000,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -152,26 +152,12 @@ func testValidateTesthelper(
 }
 
 func TestValidate(t *testing.T) {
-	testValidateTesthelper(
-		t,
-		false,
-		false,
-		"with imuIntegrationEnabled = false & cloudStoryEnabled = false")
-	testValidateTesthelper(
-		t,
-		false,
-		true,
-		"with imuIntegrationEnabled = false & cloudStoryEnabled = true")
-	testValidateTesthelper(
-		t,
-		true,
-		false,
-		"with imuIntegrationEnabled = true & cloudStoryEnabled = false")
-	testValidateTesthelper(
-		t,
-		true,
-		true,
-		"with imuIntegrationEnabled = true & cloudStoryEnabled = true")
+	for _, imuEnabled := range []bool{true, false} {
+		for _, cloudStoryEnabled := range []bool{true, false} {
+			suffix := fmt.Sprintf("with imuIntegrationEnabled = %t & cloudStoryEnabled = %t", imuEnabled, cloudStoryEnabled)
+			testValidateTesthelper(t, imuEnabled, cloudStoryEnabled, suffix)
+		}
+	}
 }
 
 // makeCfgService creates the simplest possible config that can pass validation.
@@ -312,10 +298,12 @@ func sensorAttributeTestHelper(
 }
 
 func TestGetOptionalParameters(t *testing.T) {
-	getOptionalParametersTestHelper(t, false, false, "with imuIntegrationEnabled = false & cloudStoryEnabled = false")
-	getOptionalParametersTestHelper(t, false, true, "with imuIntegrationEnabled = false & cloudStoryEnabled = true")
-	getOptionalParametersTestHelper(t, true, false, "with imuIntegrationEnabled = true & cloudStoryEnabled = false")
-	getOptionalParametersTestHelper(t, true, true, "with imuIntegrationEnabled = true & cloudStoryEnabled = true")
+	for _, imuEnabled := range []bool{true, false} {
+		for _, cloudStoryEnabled := range []bool{true, false} {
+			suffix := fmt.Sprintf("with imuIntegrationEnabled = %t & cloudStoryEnabled = %t", imuEnabled, cloudStoryEnabled)
+			getOptionalParametersTestHelper(t, imuEnabled, cloudStoryEnabled, suffix)
+		}
+	}
 }
 
 func newConfig(conf resource.Config) (*Config, error) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/edaniels/golog"
+	"go.uber.org/zap"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/services/slam"
 	"go.viam.com/test"
@@ -198,11 +199,16 @@ func makeCfgService(IMUIntegrationEnabled, cloudStoryEnabled bool) resource.Conf
 	return cfgService
 }
 
-func TestGetOptionalParameters(t *testing.T) {
+func getOptionalParametersTestHelper(
+	t *testing.T,
+	imuIntegrationEnabled bool,
+	cloudStoryEnabled bool,
+	suffix string,
+) {
 	logger := golog.NewTestLogger(t)
 
-	t.Run("Pass default parameters", func(t *testing.T) {
-		cfgService := makeCfgService(false, false)
+	t.Run(fmt.Sprintf("Pass default parameters%s", suffix), func(t *testing.T) {
+		cfgService := makeCfgService(imuIntegrationEnabled, cloudStoryEnabled)
 		cfgService.Attributes["sensors"] = []string{"a"}
 		cfg, err := newConfig(cfgService)
 		test.That(t, err, test.ShouldBeNil)
@@ -218,81 +224,25 @@ func TestGetOptionalParameters(t *testing.T) {
 		test.That(t, enableMapping, test.ShouldBeFalse)
 	})
 
-	t.Run("Return overrides", func(t *testing.T) {
-		cfgService := makeCfgService(false, false)
-		cfgService.Attributes["camera"] = map[string]string{
-			"name":              "a",
-			"data_frequency_hz": "1",
+	t.Run(fmt.Sprintf("Return overrides%s", suffix), func(t *testing.T) {
+		cfgService := makeCfgService(imuIntegrationEnabled, cloudStoryEnabled)
+		if imuIntegrationEnabled {
+			cfgService.Attributes["camera"] = map[string]string{
+				"name":              "testNameCamera",
+				"data_frequency_hz": "2",
+			}
+			cfgService.Attributes["movement_sensor"] = map[string]string{
+				"name":              "testNameSensor",
+				"data_frequency_hz": "2",
+			}
 		}
+
 		cfg, err := newConfig(cfgService)
 		two := 2
 		cfg.MapRateSec = &two
 		dataRate := 50
 		cfg.DataRateMsec = &dataRate
 		test.That(t, err, test.ShouldBeNil)
-		lidarDataRateMsec, _, _, mapRateSec, enableMapping, err := GetOptionalParameters(
-			cfg,
-			1000,
-			1000,
-			1002,
-			logger)
-		test.That(t, err, test.ShouldBeNil)
-		test.That(t, mapRateSec, test.ShouldEqual, 2)
-		test.That(t, lidarDataRateMsec, test.ShouldEqual, 50)
-		test.That(t, enableMapping, test.ShouldBeFalse)
-	})
-}
-
-func newConfig(conf resource.Config) (*Config, error) {
-	slamConf, err := resource.TransformAttributeMap[*Config](conf.Attributes)
-	if err != nil {
-		return &Config{}, newError(err.Error())
-	}
-
-	if _, err := slamConf.Validate("services.slam.attributes.fake"); err != nil {
-		return &Config{}, newError(err.Error())
-	}
-
-	return slamConf, nil
-}
-
-func TestGetOptionalParametersFeatureFlag(t *testing.T) {
-	logger := golog.NewTestLogger(t)
-
-	t.Run("Pass default parameters with feature flag enabled", func(t *testing.T) {
-		cfgService := makeCfgService(true, false)
-		cfgService.Attributes["camera"] = map[string]string{"name": "a"}
-		cfgService.Attributes["movement_sensor"] = map[string]string{"name": "b"}
-		cfg, err := newConfig(cfgService)
-		test.That(t, err, test.ShouldBeNil)
-		lidarDataRateMsec, imuName, imuDataRateMsec, mapRateSec, enableMapping, err := GetOptionalParameters(
-			cfg,
-			1000,
-			1000,
-			1002,
-			logger)
-		test.That(t, err, test.ShouldBeNil)
-		test.That(t, mapRateSec, test.ShouldEqual, 1002)
-		test.That(t, lidarDataRateMsec, test.ShouldEqual, 1000)
-		test.That(t, imuName, test.ShouldEqual, "b")
-		test.That(t, imuDataRateMsec, test.ShouldEqual, 1000)
-		test.That(t, enableMapping, test.ShouldBeFalse)
-	})
-
-	t.Run("Return overrides with feature flag enabled", func(t *testing.T) {
-		cfgService := makeCfgService(true, false)
-		cfgService.Attributes["camera"] = map[string]string{
-			"name":              "a",
-			"data_frequency_hz": "5",
-		}
-		cfgService.Attributes["movement_sensor"] = map[string]string{
-			"name":              "b",
-			"data_frequency_hz": "20",
-		}
-		cfg, err := newConfig(cfgService)
-		two := 2
-		cfg.MapRateSec = &two
-		test.That(t, err, test.ShouldBeNil)
 		lidarDataRateMsec, imuName, imuDataRateMsec, mapRateSec, enableMapping, err := GetOptionalParameters(
 			cfg,
 			1000,
@@ -301,14 +251,29 @@ func TestGetOptionalParametersFeatureFlag(t *testing.T) {
 			logger)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, mapRateSec, test.ShouldEqual, 2)
-		test.That(t, lidarDataRateMsec, test.ShouldEqual, 200)
-		test.That(t, imuName, test.ShouldEqual, "b")
-		test.That(t, imuDataRateMsec, test.ShouldEqual, 50)
+		if imuIntegrationEnabled {
+			test.That(t, imuName, test.ShouldEqual, "testNameSensor")
+			test.That(t, imuDataRateMsec, test.ShouldEqual, 500)
+			test.That(t, lidarDataRateMsec, test.ShouldEqual, 500)
+		} else {
+			test.That(t, lidarDataRateMsec, test.ShouldEqual, 50)
+		}
 		test.That(t, enableMapping, test.ShouldBeFalse)
 	})
 
+	if imuIntegrationEnabled {
+		sensorAttributeTestHelper(t, logger, imuIntegrationEnabled, cloudStoryEnabled)
+	}
+}
+
+func sensorAttributeTestHelper(
+	t *testing.T,
+	logger *zap.SugaredLogger,
+	imuIntegrationEnabled bool,
+	cloudStoryEnabled bool,
+) {
 	t.Run("Unit test return error if lidar data frequency is invalid", func(t *testing.T) {
-		cfgService := makeCfgService(true, false)
+		cfgService := makeCfgService(imuIntegrationEnabled, cloudStoryEnabled)
 		cfgService.Attributes["camera"] = map[string]string{
 			"name":              "a",
 			"data_frequency_hz": "b",
@@ -325,7 +290,7 @@ func TestGetOptionalParametersFeatureFlag(t *testing.T) {
 	})
 
 	t.Run("Unit test return error if imu data frequency is invalid", func(t *testing.T) {
-		cfgService := makeCfgService(true, false)
+		cfgService := makeCfgService(imuIntegrationEnabled, cloudStoryEnabled)
 		cfgService.Attributes["camera"] = map[string]string{
 			"name":              "a",
 			"data_frequency_hz": "1",
@@ -344,6 +309,26 @@ func TestGetOptionalParametersFeatureFlag(t *testing.T) {
 			logger)
 		test.That(t, err, test.ShouldBeError, newError("movement_sensor[data_frequency_hz] must only contain digits"))
 	})
+}
+
+func TestGetOptionalParameters(t *testing.T) {
+	getOptionalParametersTestHelper(t, false, false, " with imuIntegrationEnabled = false & cloudStoryEnabled = false")
+	getOptionalParametersTestHelper(t, false, true, " with imuIntegrationEnabled = false & cloudStoryEnabled = true")
+	getOptionalParametersTestHelper(t, true, false, " with imuIntegrationEnabled = true & cloudStoryEnabled = false")
+	getOptionalParametersTestHelper(t, true, true, " with imuIntegrationEnabled = true & cloudStoryEnabled = true")
+}
+
+func newConfig(conf resource.Config) (*Config, error) {
+	slamConf, err := resource.TransformAttributeMap[*Config](conf.Attributes)
+	if err != nil {
+		return &Config{}, newError(err.Error())
+	}
+
+	if _, err := slamConf.Validate("services.slam.attributes.fake"); err != nil {
+		return &Config{}, newError(err.Error())
+	}
+
+	return slamConf, nil
 }
 
 func newConfigWithoutValidate(conf resource.Config) (*Config, error) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -112,8 +112,8 @@ func testValidateTesthelper(
 			cfgService.Attributes["camera"] = map[string]string{
 				"name":              "a",
 				"data_frequency_hz": "1",
-				"map_rate_sec":      "-1",
 			}
+			cfgService.Attributes["map_rate_sec"] = -1
 
 			_, err = newConfig(cfgService)
 			test.That(t, err, test.ShouldBeError, newError("cannot specify map_rate_sec less than zero"))

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -21,7 +21,7 @@ func testValidateTesthelper(
 	testCfgPath := "services.slam.attributes.fake"
 	logger := golog.NewTestLogger(t)
 
-	t.Run(fmt.Sprintf("Empty config%s", suffix), func(t *testing.T) {
+	t.Run(fmt.Sprintf("Empty config %s", suffix), func(t *testing.T) {
 		model := resource.DefaultModelFamily.WithModel("test")
 		cfgService := resource.Config{Name: "test", API: slam.API, Model: model}
 		if imuIntegrationEnabled || cloudStoryEnabled {
@@ -44,13 +44,13 @@ func testValidateTesthelper(
 		}
 	})
 
-	t.Run(fmt.Sprintf("Simplest valid config%s", suffix), func(t *testing.T) {
+	t.Run(fmt.Sprintf("Simplest valid config %s", suffix), func(t *testing.T) {
 		cfgService := makeCfgService(imuIntegrationEnabled, cloudStoryEnabled)
 		_, err := newConfig(cfgService)
 		test.That(t, err, test.ShouldBeNil)
 	})
 
-	t.Run(fmt.Sprintf("Config without required fields%s", suffix), func(t *testing.T) {
+	t.Run(fmt.Sprintf("Config without required fields %s", suffix), func(t *testing.T) {
 		var requiredFields []string
 		if imuIntegrationEnabled {
 			requiredFields = []string{"data_dir", "camera"}
@@ -83,7 +83,7 @@ func testValidateTesthelper(
 		test.That(t, err, test.ShouldBeError, newError(utils.NewConfigValidationFieldRequiredError(testCfgPath, "config_params[mode]").Error()))
 	})
 
-	t.Run(fmt.Sprintf("Config with invalid parameter type%s", suffix), func(t *testing.T) {
+	t.Run(fmt.Sprintf("Config with invalid parameter type %s", suffix), func(t *testing.T) {
 		key := "data_dir"
 
 		cfgService := makeCfgService(imuIntegrationEnabled, cloudStoryEnabled)
@@ -99,7 +99,7 @@ func testValidateTesthelper(
 		test.That(t, err, test.ShouldBeNil)
 	})
 
-	t.Run(fmt.Sprintf("Config with out of range values%s", suffix), func(t *testing.T) {
+	t.Run(fmt.Sprintf("Config with out of range values %s", suffix), func(t *testing.T) {
 		cfgService := makeCfgService(imuIntegrationEnabled, cloudStoryEnabled)
 		if imuIntegrationEnabled {
 			cfgService.Attributes["camera"] = map[string]string{
@@ -130,7 +130,7 @@ func testValidateTesthelper(
 		}
 	})
 
-	t.Run(fmt.Sprintf("All parameters e2e%s", suffix), func(t *testing.T) {
+	t.Run(fmt.Sprintf("All parameters e2e %s", suffix), func(t *testing.T) {
 		cfgService := makeCfgService(imuIntegrationEnabled, cloudStoryEnabled)
 		cfgService.Attributes["sensors"] = []string{"a", "b"}
 		cfgService.Attributes["data_rate_msec"] = 1001
@@ -156,7 +156,7 @@ func TestValidate(t *testing.T) {
 		t,
 		false,
 		false,
-		" with imuIntegrationEnabled = false & cloudStoryEnabled = false")
+		"with imuIntegrationEnabled = false & cloudStoryEnabled = false")
 	testValidateTesthelper(
 		t,
 		false,
@@ -166,7 +166,7 @@ func TestValidate(t *testing.T) {
 		t,
 		true,
 		false,
-		" with imuIntegrationEnabled = true & cloudStoryEnabled = false")
+		"with imuIntegrationEnabled = true & cloudStoryEnabled = false")
 	testValidateTesthelper(
 		t,
 		true,
@@ -207,7 +207,7 @@ func getOptionalParametersTestHelper(
 ) {
 	logger := golog.NewTestLogger(t)
 
-	t.Run(fmt.Sprintf("Pass default parameters%s", suffix), func(t *testing.T) {
+	t.Run(fmt.Sprintf("Pass default parameters %s", suffix), func(t *testing.T) {
 		cfgService := makeCfgService(imuIntegrationEnabled, cloudStoryEnabled)
 		cfgService.Attributes["sensors"] = []string{"a"}
 		cfg, err := newConfig(cfgService)
@@ -224,7 +224,7 @@ func getOptionalParametersTestHelper(
 		test.That(t, optionalConfigParams.EnableMapping, test.ShouldBeFalse)
 	})
 
-	t.Run(fmt.Sprintf("Return overrides%s", suffix), func(t *testing.T) {
+	t.Run(fmt.Sprintf("Return overrides %s", suffix), func(t *testing.T) {
 		cfgService := makeCfgService(imuIntegrationEnabled, cloudStoryEnabled)
 		if imuIntegrationEnabled {
 			cfgService.Attributes["camera"] = map[string]string{
@@ -312,10 +312,10 @@ func sensorAttributeTestHelper(
 }
 
 func TestGetOptionalParameters(t *testing.T) {
-	getOptionalParametersTestHelper(t, false, false, " with imuIntegrationEnabled = false & cloudStoryEnabled = false")
-	getOptionalParametersTestHelper(t, false, true, " with imuIntegrationEnabled = false & cloudStoryEnabled = true")
-	getOptionalParametersTestHelper(t, true, false, " with imuIntegrationEnabled = true & cloudStoryEnabled = false")
-	getOptionalParametersTestHelper(t, true, true, " with imuIntegrationEnabled = true & cloudStoryEnabled = true")
+	getOptionalParametersTestHelper(t, false, false, "with imuIntegrationEnabled = false & cloudStoryEnabled = false")
+	getOptionalParametersTestHelper(t, false, true, "with imuIntegrationEnabled = false & cloudStoryEnabled = true")
+	getOptionalParametersTestHelper(t, true, false, "with imuIntegrationEnabled = true & cloudStoryEnabled = false")
+	getOptionalParametersTestHelper(t, true, true, "with imuIntegrationEnabled = true & cloudStoryEnabled = true")
 }
 
 func newConfig(conf resource.Config) (*Config, error) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -28,8 +28,7 @@ func testValidateTesthelper(
 	})
 
 	t.Run(fmt.Sprintf("Config without required fields%s", suffix), func(t *testing.T) {
-		var requiredFields []string
-		requiredFields = []string{"data_dir", "sensors"}
+		requiredFields := []string{"data_dir", "sensors"}
 
 		dataDirErr := utils.NewConfigValidationFieldRequiredError(testCfgPath, requiredFields[0])
 		cameraErr := utils.NewConfigValidationError(testCfgPath, errSensorsMustNotBeEmpty)

--- a/sensorprocess/sensorprocess.go
+++ b/sensorprocess/sensorprocess.go
@@ -66,7 +66,6 @@ func addSensorReading(
 	} else {
 		timeToSleep := tryAddSensorReading(ctx, tsr.Reading, tsr.ReadingTime, config)
 		time.Sleep(time.Duration(timeToSleep) * time.Millisecond)
-		config.Logger.Debugf("sleep for %s milliseconds", time.Duration(timeToSleep))
 	}
 	return false
 }

--- a/sensorprocess/sensorprocess.go
+++ b/sensorprocess/sensorprocess.go
@@ -66,6 +66,7 @@ func addSensorReading(
 	} else {
 		timeToSleep := tryAddSensorReading(ctx, tsr.Reading, tsr.ReadingTime, config)
 		time.Sleep(time.Duration(timeToSleep) * time.Millisecond)
+		config.Logger.Debugf("sleep for %s milliseconds", time.Duration(timeToSleep))
 	}
 	return false
 }

--- a/viam-cartographer/src/carto_facade/carto_facade.cc
+++ b/viam-cartographer/src/carto_facade/carto_facade.cc
@@ -920,7 +920,6 @@ extern int viam_carto_lib_terminate(viam_carto_lib **ppVCL) {
 extern int viam_carto_init(viam_carto **ppVC, viam_carto_lib *pVCL,
                            const viam_carto_config c,
                            const viam_carto_algo_config ac) {
-    LOG(ERROR) << "KIM LOG" << c.cloud_story_enabled;
     if (ppVC == nullptr) {
         return VIAM_CARTO_VC_INVALID;
     }

--- a/viam-cartographer/src/carto_facade/carto_facade.cc
+++ b/viam-cartographer/src/carto_facade/carto_facade.cc
@@ -267,11 +267,9 @@ void CartoFacade::IOInit() {
     // Setup file system for saving internal state
     setup_filesystem(config.data_dir, path_to_internal_state);
     if (config.cloud_story_enabled == true) {
-        LOG(ERROR) << "KIM LOG: CLOUD STORY ENABLED";
-        slam_mode =
-            determine_slam_mode_cloud_story_enabled(path_to_internal_state, config.enable_mapping);
+        slam_mode = determine_slam_mode_cloud_story_enabled(
+            path_to_internal_state, config.enable_mapping);
     } else {
-        LOG(ERROR) << "KIM LOG: CLOUD STORY NOT ENABLED";
         slam_mode =
             determine_slam_mode(path_to_internal_state, config.map_rate_sec);
     }
@@ -922,7 +920,6 @@ extern int viam_carto_lib_terminate(viam_carto_lib **ppVCL) {
 extern int viam_carto_init(viam_carto **ppVC, viam_carto_lib *pVCL,
                            const viam_carto_config c,
                            const viam_carto_algo_config ac) {
-    LOG(ERROR) << "KIM LOG" << c.cloud_story_enabled;
     if (ppVC == nullptr) {
         return VIAM_CARTO_VC_INVALID;
     }

--- a/viam-cartographer/src/carto_facade/carto_facade.cc
+++ b/viam-cartographer/src/carto_facade/carto_facade.cc
@@ -920,6 +920,7 @@ extern int viam_carto_lib_terminate(viam_carto_lib **ppVCL) {
 extern int viam_carto_init(viam_carto **ppVC, viam_carto_lib *pVCL,
                            const viam_carto_config c,
                            const viam_carto_algo_config ac) {
+    LOG(ERROR) << "KIM LOG" << c.cloud_story_enabled;
     if (ppVC == nullptr) {
         return VIAM_CARTO_VC_INVALID;
     }

--- a/viam-cartographer/src/carto_facade/carto_facade.cc
+++ b/viam-cartographer/src/carto_facade/carto_facade.cc
@@ -115,6 +115,8 @@ config from_viam_carto_config(viam_carto_config vcc) {
     c.movement_sensor = to_std_string(vcc.movement_sensor);
     c.data_dir = to_std_string(vcc.data_dir);
     c.map_rate_sec = std::chrono::seconds(vcc.map_rate_sec);
+    c.cloud_story_enabled = vcc.cloud_story_enabled;
+    c.enable_mapping = vcc.enable_mapping;
     c.lidar_config = vcc.lidar_config;
     if (c.data_dir.size() == 0) {
         throw VIAM_CARTO_DATA_DIR_NOT_PROVIDED;
@@ -264,8 +266,15 @@ void CartoFacade::IOInit() {
     }
     // Setup file system for saving internal state
     setup_filesystem(config.data_dir, path_to_internal_state);
-    slam_mode =
-        determine_slam_mode(path_to_internal_state, config.map_rate_sec);
+    if (config.cloud_story_enabled == true) {
+        LOG(ERROR) << "KIM LOG: CLOUD STORY ENABLED";
+        slam_mode =
+            determine_slam_mode_cloud_story_enabled(path_to_internal_state, config.enable_mapping);
+    } else {
+        LOG(ERROR) << "KIM LOG: CLOUD STORY NOT ENABLED";
+        slam_mode =
+            determine_slam_mode(path_to_internal_state, config.map_rate_sec);
+    }
     VLOG(1) << "slam slam mode: " << slam_mode;
     // TODO: Make this API user configurable
     auto cd = find_lua_files();
@@ -819,6 +828,40 @@ viam::carto_facade::SlamMode determine_slam_mode(
     return viam::carto_facade::SlamMode::MAPPING;
 }
 
+viam::carto_facade::SlamMode determine_slam_mode_cloud_story_enabled(
+    std::string path_to_internal_state, bool enable_mapping) {
+    // Check if there is an apriori map (internal state) in the
+    // path_to_internal_state directory
+    std::vector<std::string> internal_state_filenames =
+        list_sorted_files_in_directory(path_to_internal_state);
+
+    // Check if there is a *.pbstream internal state in the
+    // path_to_internal_state directory
+    for (auto filename : internal_state_filenames) {
+        if (filename.find(".pbstream") != std::string::npos) {
+            // There is an apriori map (internal state) present, so we're
+            // running either in updating or localization mode.
+            if (!enable_mapping) {
+                // This log line is needed by rdk integration tests.
+                LOG(INFO) << "Running in localization only mode";
+                return viam::carto_facade::SlamMode::LOCALIZING;
+            }
+            // This log line is needed by rdk integration tests.
+            LOG(INFO) << "Running in updating mode";
+            return viam::carto_facade::SlamMode::UPDATING;
+        }
+    }
+    if (!enable_mapping) {
+        LOG(ERROR)
+            << "set to localization mode (map_rate_sec = 0) but "
+               "couldn't find apriori map (internal state) to localize on";
+        throw VIAM_CARTO_SLAM_MODE_INVALID;
+    }
+    // This log line is needed by rdk integration tests.
+    LOG(INFO) << "Running in mapping mode";
+    return viam::carto_facade::SlamMode::MAPPING;
+}
+
 int slam_mode_to_vc_slam_mode(viam::carto_facade::SlamMode sm) {
     if (sm == viam::carto_facade::SlamMode::MAPPING) {
         return VIAM_CARTO_SLAM_MODE_MAPPING;
@@ -879,6 +922,7 @@ extern int viam_carto_lib_terminate(viam_carto_lib **ppVCL) {
 extern int viam_carto_init(viam_carto **ppVC, viam_carto_lib *pVCL,
                            const viam_carto_config c,
                            const viam_carto_algo_config ac) {
+    LOG(ERROR) << "KIM LOG" << c.cloud_story_enabled;
     if (ppVC == nullptr) {
         return VIAM_CARTO_VC_INVALID;
     }

--- a/viam-cartographer/src/carto_facade/carto_facade.cc
+++ b/viam-cartographer/src/carto_facade/carto_facade.cc
@@ -851,7 +851,7 @@ viam::carto_facade::SlamMode determine_slam_mode_cloud_story_enabled(
     }
     if (!enable_mapping) {
         LOG(ERROR)
-            << "set to localization mode (map_rate_sec = 0) but "
+            << "set to localization mode (enable_mapping = false) but "
                "couldn't find apriori map (internal state) to localize on";
         throw VIAM_CARTO_SLAM_MODE_INVALID;
     }

--- a/viam-cartographer/src/carto_facade/carto_facade.h
+++ b/viam-cartographer/src/carto_facade/carto_facade.h
@@ -316,8 +316,8 @@ const std::string configuration_update_basename = "updating_a_map.lua";
 carto_facade::SlamMode determine_slam_mode(std::string path_to_map,
                                            std::chrono::seconds map_rate_sec);
 
-carto_facade::SlamMode determine_slam_mode_cloud_story_enabled(
-    std::string path_to_map, bool enable_mapping);
+carto_facade::SlamMode determine_slam_mode_cloud_story_enabled(std::string path_to_map,
+                                                               bool enable_mapping);
 
 int slam_mode_to_vc_slam_mode(viam::carto_facade::SlamMode sm);
 

--- a/viam-cartographer/src/carto_facade/carto_facade.h
+++ b/viam-cartographer/src/carto_facade/carto_facade.h
@@ -316,8 +316,8 @@ const std::string configuration_update_basename = "updating_a_map.lua";
 carto_facade::SlamMode determine_slam_mode(std::string path_to_map,
                                            std::chrono::seconds map_rate_sec);
 
-carto_facade::SlamMode determine_slam_mode_cloud_story_enabled(std::string path_to_map,
-                                                               bool enable_mapping);
+carto_facade::SlamMode determine_slam_mode_cloud_story_enabled(
+    std::string path_to_map, bool enable_mapping);
 
 int slam_mode_to_vc_slam_mode(viam::carto_facade::SlamMode sm);
 

--- a/viam-cartographer/src/carto_facade/carto_facade.h
+++ b/viam-cartographer/src/carto_facade/carto_facade.h
@@ -134,6 +134,8 @@ typedef struct viam_carto_config {
     int map_rate_sec;
     bstring data_dir;
     viam_carto_LIDAR_CONFIG lidar_config;
+    bool cloud_story_enabled;
+    bool enable_mapping;
 } viam_carto_config;
 
 // viam_carto_lib_init/4 takes an empty viam_carto_lib pointer to pointer
@@ -297,6 +299,8 @@ typedef struct config {
     std::string data_dir;
     bstring component_reference;
     viam_carto_LIDAR_CONFIG lidar_config;
+    bool cloud_story_enabled;
+    bool enable_mapping;
 } config;
 
 // function to convert viam_carto_config into  viam::carto_facade::config
@@ -311,6 +315,9 @@ const std::string configuration_update_basename = "updating_a_map.lua";
 
 carto_facade::SlamMode determine_slam_mode(std::string path_to_map,
                                            std::chrono::seconds map_rate_sec);
+
+carto_facade::SlamMode determine_slam_mode_cloud_story_enabled(std::string path_to_map,
+                                                               bool enable_mapping);
 
 int slam_mode_to_vc_slam_mode(viam::carto_facade::SlamMode sm);
 

--- a/viam-cartographer/src/carto_facade/carto_facade_test.cc
+++ b/viam-cartographer/src/carto_facade/carto_facade_test.cc
@@ -28,13 +28,10 @@ const auto tol = tt::tolerance(0.001);
 
 namespace viam {
 namespace carto_facade {
-viam_carto_config viam_carto_config_setup(int map_rate_sec,
-                                          viam_carto_LIDAR_CONFIG lidar_config,
-                                          std::string data_dir,
-                                          std::string camera,
-                                          std::string movement_sensor,
-                                          bool cloud_story_enabled,
-                                          bool enable_mapping) {
+viam_carto_config viam_carto_config_setup(
+    int map_rate_sec, viam_carto_LIDAR_CONFIG lidar_config,
+    std::string data_dir, std::string camera, std::string movement_sensor,
+    bool cloud_story_enabled, bool enable_mapping) {
     struct viam_carto_config vcc;
     vcc.map_rate_sec = map_rate_sec;
     vcc.lidar_config = lidar_config;

--- a/viam-cartographer/src/carto_facade/carto_facade_test.cc
+++ b/viam-cartographer/src/carto_facade/carto_facade_test.cc
@@ -1107,7 +1107,7 @@ BOOST_AUTO_TEST_CASE(CartoFacade_config) {
     struct viam_carto_config vcc =
         viam_carto_config_setup(1, VIAM_CARTO_THREE_D, tmp_dir.string(),
 
-                                camera, movement_sensor, false, false);
+                                camera, movement_sensor, true, false);
 
     struct config c = viam::carto_facade::from_viam_carto_config(vcc);
 
@@ -1117,6 +1117,8 @@ BOOST_AUTO_TEST_CASE(CartoFacade_config) {
     BOOST_TEST(c.map_rate_sec.count() == 1);
     BOOST_TEST(c.camera == "lidar");
     BOOST_TEST(c.movement_sensor == "imu");
+    BOOST_TEST(c.cloud_story_enabled == true);
+    BOOST_TEST(c.enable_mapping == false);
 
     viam_carto_config_teardown(vcc);
     BOOST_TEST(bdestroy(c.component_reference) == BSTR_OK);

--- a/viam-cartographer/src/carto_facade/carto_facade_test.cc
+++ b/viam-cartographer/src/carto_facade/carto_facade_test.cc
@@ -28,10 +28,13 @@ const auto tol = tt::tolerance(0.001);
 
 namespace viam {
 namespace carto_facade {
-viam_carto_config viam_carto_config_setup(
-    int map_rate_sec, viam_carto_LIDAR_CONFIG lidar_config,
-    std::string data_dir, std::string camera, std::string movement_sensor,
-    bool cloud_story_enabled, bool enable_mapping) {
+viam_carto_config viam_carto_config_setup(int map_rate_sec,
+                                          viam_carto_LIDAR_CONFIG lidar_config,
+                                          std::string data_dir,
+                                          std::string camera,
+                                          std::string movement_sensor,
+                                          bool cloud_story_enabled,
+                                          bool enable_mapping) {
     struct viam_carto_config vcc;
     vcc.map_rate_sec = map_rate_sec;
     vcc.lidar_config = lidar_config;
@@ -128,23 +131,39 @@ BOOST_AUTO_TEST_CASE(CartoFacade_init_validate) {
     std::string camera2 = "";
     std::string movement_sensor2 = "";
 
+<<<<<<< HEAD
     struct viam_carto_config vcc_empty_component_ref =
         viam_carto_config_setup(1, VIAM_CARTO_THREE_D, tmp_dir.string(),
                                 camera2, movement_sensor2, false, false);
+=======
+    struct viam_carto_config vcc_empty_component_ref = viam_carto_config_setup(
+        1, VIAM_CARTO_THREE_D, tmp_dir.string(), camera2, movement_sensor2, false, false);
+>>>>>>> 716b385 (WIP: tests passing with enable mapping cloud story changes)
 
     BOOST_TEST(viam_carto_init(&vc, lib, vcc_empty_component_ref, ac) ==
                VIAM_CARTO_COMPONENT_REFERENCE_INVALID);
 
+<<<<<<< HEAD
     struct viam_carto_config vcc_invalid_map_rate_sec =
         viam_carto_config_setup(-1, VIAM_CARTO_THREE_D, tmp_dir.string(),
                                 camera, movement_sensor, false, false);
+=======
+    struct viam_carto_config vcc_invalid_map_rate_sec = viam_carto_config_setup(
+        -1, VIAM_CARTO_THREE_D, tmp_dir.string(), camera, movement_sensor, false, false);
+>>>>>>> 716b385 (WIP: tests passing with enable mapping cloud story changes)
 
     BOOST_TEST(viam_carto_init(&vc, lib, vcc_invalid_map_rate_sec, ac) ==
                VIAM_CARTO_MAP_RATE_SEC_INVALID);
 
+<<<<<<< HEAD
     struct viam_carto_config vcc_invalid_lidar_config = viam_carto_config_setup(
         1, static_cast<viam_carto_LIDAR_CONFIG>(-1), tmp_dir.string(), camera,
         movement_sensor, false, false);
+=======
+    struct viam_carto_config vcc_invalid_lidar_config =
+        viam_carto_config_setup(1, static_cast<viam_carto_LIDAR_CONFIG>(-1),
+                                tmp_dir.string(), camera, movement_sensor, false, false);
+>>>>>>> 716b385 (WIP: tests passing with enable mapping cloud story changes)
 
     BOOST_TEST(viam_carto_init(&vc, lib, vcc_invalid_lidar_config, ac) ==
                VIAM_CARTO_LIDAR_CONFIG_INVALID);
@@ -161,6 +180,7 @@ BOOST_AUTO_TEST_CASE(CartoFacade_init_validate) {
     fs::path invalid_path = tmp_dir / fs::path(bfs::unique_path().string()) /
                             fs::path(bfs::unique_path().string());
 
+<<<<<<< HEAD
     struct viam_carto_config vcc_invalid_path =
         viam_carto_config_setup(1, VIAM_CARTO_THREE_D, invalid_path.string(),
                                 camera, movement_sensor, false, false);
@@ -170,6 +190,15 @@ BOOST_AUTO_TEST_CASE(CartoFacade_init_validate) {
     struct viam_carto_config vcc =
         viam_carto_config_setup(1, VIAM_CARTO_THREE_D, tmp_dir.string(), camera,
                                 movement_sensor, false, false);
+=======
+    struct viam_carto_config vcc_invalid_path = viam_carto_config_setup(
+        1, VIAM_CARTO_THREE_D, invalid_path.string(), camera, movement_sensor, false, false);
+    BOOST_TEST(viam_carto_init(&vc, lib, vcc_invalid_path, ac) ==
+               VIAM_CARTO_DATA_DIR_FILE_SYSTEM_ERROR);
+
+    struct viam_carto_config vcc = viam_carto_config_setup(
+        1, VIAM_CARTO_THREE_D, tmp_dir.string(), camera, movement_sensor, false, false);
+>>>>>>> 716b385 (WIP: tests passing with enable mapping cloud story changes)
 
     BOOST_TEST(viam_carto_init(nullptr, lib, vcc, ac) == VIAM_CARTO_VC_INVALID);
     BOOST_TEST(viam_carto_init(nullptr, nullptr, vcc, ac) ==
@@ -341,6 +370,10 @@ BOOST_AUTO_TEST_CASE(CartoFacade_init_derive_slam_mode) {
         struct viam_carto_config vcc_localizing = viam_carto_config_setup(
             0, VIAM_CARTO_THREE_D, updating_dir.string(), camera,
             movement_sensor, false, false);
+<<<<<<< HEAD
+=======
+        LOG(ERROR) << "KIM LOG test: " << vcc_localizing.cloud_story_enabled;    
+>>>>>>> 716b385 (WIP: tests passing with enable mapping cloud story changes)
         BOOST_TEST(viam_carto_init(&vc4, lib, vcc_localizing, ac) ==
                    VIAM_CARTO_SUCCESS);
         BOOST_TEST(vc4->slam_mode == VIAM_CARTO_SLAM_MODE_LOCALIZING);
@@ -390,9 +423,14 @@ BOOST_AUTO_TEST_CASE(CartoFacade_init_derive_slam_mode) {
         auto empty_dir = tmp_dir / fs::path(bfs::unique_path().string());
         ;
         viam_carto *vc6;
+<<<<<<< HEAD
         struct viam_carto_config vcc_invalid =
             viam_carto_config_setup(0, VIAM_CARTO_THREE_D, empty_dir.string(),
                                     camera, movement_sensor, false, false);
+=======
+        struct viam_carto_config vcc_invalid = viam_carto_config_setup(
+            0, VIAM_CARTO_THREE_D, empty_dir.string(), camera, movement_sensor, false, false);
+>>>>>>> 716b385 (WIP: tests passing with enable mapping cloud story changes)
         BOOST_TEST(viam_carto_init(&vc6, lib, vcc_invalid, ac) ==
                    VIAM_CARTO_SLAM_MODE_INVALID);
         viam_carto_config_teardown(vcc_invalid);
@@ -414,9 +452,14 @@ BOOST_AUTO_TEST_CASE(CartoFacade_init_terminate) {
     std::string movement_sensor = "imu";
     fs::path tmp_dir =
         fs::temp_directory_path() / fs::path(bfs::unique_path().string());
+<<<<<<< HEAD
     struct viam_carto_config vcc =
         viam_carto_config_setup(1, VIAM_CARTO_THREE_D, tmp_dir.string(), camera,
                                 movement_sensor, false, false);
+=======
+    struct viam_carto_config vcc = viam_carto_config_setup(
+        1, VIAM_CARTO_THREE_D, tmp_dir.string(), camera, movement_sensor, false, false);
+>>>>>>> 716b385 (WIP: tests passing with enable mapping cloud story changes)
     struct viam_carto_algo_config ac = viam_carto_algo_config_setup();
     BOOST_TEST(viam_carto_init(&vc, lib, vcc, ac) == VIAM_CARTO_SUCCESS);
     BOOST_TEST(vc->slam_mode == VIAM_CARTO_SLAM_MODE_MAPPING);

--- a/viam-cartographer/src/carto_facade/carto_facade_test.cc
+++ b/viam-cartographer/src/carto_facade/carto_facade_test.cc
@@ -28,13 +28,10 @@ const auto tol = tt::tolerance(0.001);
 
 namespace viam {
 namespace carto_facade {
-viam_carto_config viam_carto_config_setup(int map_rate_sec,
-                                          viam_carto_LIDAR_CONFIG lidar_config,
-                                          std::string data_dir,
-                                          std::string camera,
-                                          std::string movement_sensor,
-                                          bool cloud_story_enabled,
-                                          bool enable_mapping) {
+viam_carto_config viam_carto_config_setup(
+    int map_rate_sec, viam_carto_LIDAR_CONFIG lidar_config,
+    std::string data_dir, std::string camera, std::string movement_sensor,
+    bool cloud_story_enabled, bool enable_mapping) {
     struct viam_carto_config vcc;
     vcc.map_rate_sec = map_rate_sec;
     vcc.lidar_config = lidar_config;
@@ -131,21 +128,23 @@ BOOST_AUTO_TEST_CASE(CartoFacade_init_validate) {
     std::string camera2 = "";
     std::string movement_sensor2 = "";
 
-    struct viam_carto_config vcc_empty_component_ref = viam_carto_config_setup(
-        1, VIAM_CARTO_THREE_D, tmp_dir.string(), camera2, movement_sensor2, false, false);
+    struct viam_carto_config vcc_empty_component_ref =
+        viam_carto_config_setup(1, VIAM_CARTO_THREE_D, tmp_dir.string(),
+                                camera2, movement_sensor2, false, false);
 
     BOOST_TEST(viam_carto_init(&vc, lib, vcc_empty_component_ref, ac) ==
                VIAM_CARTO_COMPONENT_REFERENCE_INVALID);
 
-    struct viam_carto_config vcc_invalid_map_rate_sec = viam_carto_config_setup(
-        -1, VIAM_CARTO_THREE_D, tmp_dir.string(), camera, movement_sensor, false, false);
+    struct viam_carto_config vcc_invalid_map_rate_sec =
+        viam_carto_config_setup(-1, VIAM_CARTO_THREE_D, tmp_dir.string(),
+                                camera, movement_sensor, false, false);
 
     BOOST_TEST(viam_carto_init(&vc, lib, vcc_invalid_map_rate_sec, ac) ==
                VIAM_CARTO_MAP_RATE_SEC_INVALID);
 
-    struct viam_carto_config vcc_invalid_lidar_config =
-        viam_carto_config_setup(1, static_cast<viam_carto_LIDAR_CONFIG>(-1),
-                                tmp_dir.string(), camera, movement_sensor, false, false);
+    struct viam_carto_config vcc_invalid_lidar_config = viam_carto_config_setup(
+        1, static_cast<viam_carto_LIDAR_CONFIG>(-1), tmp_dir.string(), camera,
+        movement_sensor, false, false);
 
     BOOST_TEST(viam_carto_init(&vc, lib, vcc_invalid_lidar_config, ac) ==
                VIAM_CARTO_LIDAR_CONFIG_INVALID);
@@ -162,13 +161,15 @@ BOOST_AUTO_TEST_CASE(CartoFacade_init_validate) {
     fs::path invalid_path = tmp_dir / fs::path(bfs::unique_path().string()) /
                             fs::path(bfs::unique_path().string());
 
-    struct viam_carto_config vcc_invalid_path = viam_carto_config_setup(
-        1, VIAM_CARTO_THREE_D, invalid_path.string(), camera, movement_sensor, false, false);
+    struct viam_carto_config vcc_invalid_path =
+        viam_carto_config_setup(1, VIAM_CARTO_THREE_D, invalid_path.string(),
+                                camera, movement_sensor, false, false);
     BOOST_TEST(viam_carto_init(&vc, lib, vcc_invalid_path, ac) ==
                VIAM_CARTO_DATA_DIR_FILE_SYSTEM_ERROR);
 
-    struct viam_carto_config vcc = viam_carto_config_setup(
-        1, VIAM_CARTO_THREE_D, tmp_dir.string(), camera, movement_sensor, false, false);
+    struct viam_carto_config vcc =
+        viam_carto_config_setup(1, VIAM_CARTO_THREE_D, tmp_dir.string(), camera,
+                                movement_sensor, false, false);
 
     BOOST_TEST(viam_carto_init(nullptr, lib, vcc, ac) == VIAM_CARTO_VC_INVALID);
     BOOST_TEST(viam_carto_init(nullptr, nullptr, vcc, ac) ==
@@ -340,7 +341,6 @@ BOOST_AUTO_TEST_CASE(CartoFacade_init_derive_slam_mode) {
         struct viam_carto_config vcc_localizing = viam_carto_config_setup(
             0, VIAM_CARTO_THREE_D, updating_dir.string(), camera,
             movement_sensor, false, false);
-        LOG(ERROR) << "KIM LOG test: " << vcc_localizing.cloud_story_enabled;    
         BOOST_TEST(viam_carto_init(&vc4, lib, vcc_localizing, ac) ==
                    VIAM_CARTO_SUCCESS);
         BOOST_TEST(vc4->slam_mode == VIAM_CARTO_SLAM_MODE_LOCALIZING);
@@ -390,8 +390,9 @@ BOOST_AUTO_TEST_CASE(CartoFacade_init_derive_slam_mode) {
         auto empty_dir = tmp_dir / fs::path(bfs::unique_path().string());
         ;
         viam_carto *vc6;
-        struct viam_carto_config vcc_invalid = viam_carto_config_setup(
-            0, VIAM_CARTO_THREE_D, empty_dir.string(), camera, movement_sensor, false, false);
+        struct viam_carto_config vcc_invalid =
+            viam_carto_config_setup(0, VIAM_CARTO_THREE_D, empty_dir.string(),
+                                    camera, movement_sensor, false, false);
         BOOST_TEST(viam_carto_init(&vc6, lib, vcc_invalid, ac) ==
                    VIAM_CARTO_SLAM_MODE_INVALID);
         viam_carto_config_teardown(vcc_invalid);
@@ -413,8 +414,9 @@ BOOST_AUTO_TEST_CASE(CartoFacade_init_terminate) {
     std::string movement_sensor = "imu";
     fs::path tmp_dir =
         fs::temp_directory_path() / fs::path(bfs::unique_path().string());
-    struct viam_carto_config vcc = viam_carto_config_setup(
-        1, VIAM_CARTO_THREE_D, tmp_dir.string(), camera, movement_sensor, false, false);
+    struct viam_carto_config vcc =
+        viam_carto_config_setup(1, VIAM_CARTO_THREE_D, tmp_dir.string(), camera,
+                                movement_sensor, false, false);
     struct viam_carto_algo_config ac = viam_carto_algo_config_setup();
     BOOST_TEST(viam_carto_init(&vc, lib, vcc, ac) == VIAM_CARTO_SUCCESS);
     BOOST_TEST(vc->slam_mode == VIAM_CARTO_SLAM_MODE_MAPPING);

--- a/viam-cartographer/src/carto_facade/carto_facade_test.cc
+++ b/viam-cartographer/src/carto_facade/carto_facade_test.cc
@@ -131,39 +131,23 @@ BOOST_AUTO_TEST_CASE(CartoFacade_init_validate) {
     std::string camera2 = "";
     std::string movement_sensor2 = "";
 
-<<<<<<< HEAD
     struct viam_carto_config vcc_empty_component_ref =
         viam_carto_config_setup(1, VIAM_CARTO_THREE_D, tmp_dir.string(),
                                 camera2, movement_sensor2, false, false);
-=======
-    struct viam_carto_config vcc_empty_component_ref = viam_carto_config_setup(
-        1, VIAM_CARTO_THREE_D, tmp_dir.string(), camera2, movement_sensor2, false, false);
->>>>>>> 716b385 (WIP: tests passing with enable mapping cloud story changes)
 
     BOOST_TEST(viam_carto_init(&vc, lib, vcc_empty_component_ref, ac) ==
                VIAM_CARTO_COMPONENT_REFERENCE_INVALID);
 
-<<<<<<< HEAD
     struct viam_carto_config vcc_invalid_map_rate_sec =
         viam_carto_config_setup(-1, VIAM_CARTO_THREE_D, tmp_dir.string(),
                                 camera, movement_sensor, false, false);
-=======
-    struct viam_carto_config vcc_invalid_map_rate_sec = viam_carto_config_setup(
-        -1, VIAM_CARTO_THREE_D, tmp_dir.string(), camera, movement_sensor, false, false);
->>>>>>> 716b385 (WIP: tests passing with enable mapping cloud story changes)
 
     BOOST_TEST(viam_carto_init(&vc, lib, vcc_invalid_map_rate_sec, ac) ==
                VIAM_CARTO_MAP_RATE_SEC_INVALID);
 
-<<<<<<< HEAD
     struct viam_carto_config vcc_invalid_lidar_config = viam_carto_config_setup(
         1, static_cast<viam_carto_LIDAR_CONFIG>(-1), tmp_dir.string(), camera,
         movement_sensor, false, false);
-=======
-    struct viam_carto_config vcc_invalid_lidar_config =
-        viam_carto_config_setup(1, static_cast<viam_carto_LIDAR_CONFIG>(-1),
-                                tmp_dir.string(), camera, movement_sensor, false, false);
->>>>>>> 716b385 (WIP: tests passing with enable mapping cloud story changes)
 
     BOOST_TEST(viam_carto_init(&vc, lib, vcc_invalid_lidar_config, ac) ==
                VIAM_CARTO_LIDAR_CONFIG_INVALID);
@@ -180,7 +164,6 @@ BOOST_AUTO_TEST_CASE(CartoFacade_init_validate) {
     fs::path invalid_path = tmp_dir / fs::path(bfs::unique_path().string()) /
                             fs::path(bfs::unique_path().string());
 
-<<<<<<< HEAD
     struct viam_carto_config vcc_invalid_path =
         viam_carto_config_setup(1, VIAM_CARTO_THREE_D, invalid_path.string(),
                                 camera, movement_sensor, false, false);
@@ -190,15 +173,6 @@ BOOST_AUTO_TEST_CASE(CartoFacade_init_validate) {
     struct viam_carto_config vcc =
         viam_carto_config_setup(1, VIAM_CARTO_THREE_D, tmp_dir.string(), camera,
                                 movement_sensor, false, false);
-=======
-    struct viam_carto_config vcc_invalid_path = viam_carto_config_setup(
-        1, VIAM_CARTO_THREE_D, invalid_path.string(), camera, movement_sensor, false, false);
-    BOOST_TEST(viam_carto_init(&vc, lib, vcc_invalid_path, ac) ==
-               VIAM_CARTO_DATA_DIR_FILE_SYSTEM_ERROR);
-
-    struct viam_carto_config vcc = viam_carto_config_setup(
-        1, VIAM_CARTO_THREE_D, tmp_dir.string(), camera, movement_sensor, false, false);
->>>>>>> 716b385 (WIP: tests passing with enable mapping cloud story changes)
 
     BOOST_TEST(viam_carto_init(nullptr, lib, vcc, ac) == VIAM_CARTO_VC_INVALID);
     BOOST_TEST(viam_carto_init(nullptr, nullptr, vcc, ac) ==
@@ -231,6 +205,206 @@ BOOST_AUTO_TEST_CASE(CartoFacade_init_validate) {
     BOOST_TEST(viam_carto_lib_terminate(&lib) == VIAM_CARTO_SUCCESS);
     // can't terminate a lib that has already been terminated
     BOOST_TEST(viam_carto_lib_terminate(&lib) == VIAM_CARTO_LIB_INVALID);
+}
+
+BOOST_AUTO_TEST_CASE(CartoFacade_init_derive_slam_mode_cloud_story_enabled) {
+    viam_carto_lib *lib;
+    BOOST_TEST(viam_carto_lib_init(&lib, 0, 1) == VIAM_CARTO_SUCCESS);
+
+    std::string camera = "lidar";
+    std::string movement_sensor = "imu";
+    fs::path tmp_dir =
+        fs::temp_directory_path() / fs::path(bfs::unique_path().string());
+    struct viam_carto_algo_config ac = viam_carto_algo_config_setup();
+
+    fs::create_directory(tmp_dir);
+    {
+        // mapping
+        viam_carto *vc1;
+        auto mapping_dir = tmp_dir / fs::path("mapping_dir");
+        struct viam_carto_config vcc_mapping =
+            viam_carto_config_setup(1, VIAM_CARTO_THREE_D, mapping_dir.string(),
+                                    camera, movement_sensor, true, true);
+        BOOST_TEST(viam_carto_init(&vc1, lib, vcc_mapping, ac) ==
+                   VIAM_CARTO_SUCCESS);
+        BOOST_TEST(vc1->slam_mode == VIAM_CARTO_SLAM_MODE_MAPPING);
+        viam::carto_facade::CartoFacade *cf1 =
+            static_cast<viam::carto_facade::CartoFacade *>(vc1->carto_obj);
+        BOOST_TEST(cf1->slam_mode == SlamMode::MAPPING);
+        BOOST_TEST(cf1->map_builder.GetOptimizeEveryNNodes() ==
+                   ac.optimize_every_n_nodes);
+        BOOST_TEST(cf1->map_builder.GetNumRangeData() == ac.num_range_data);
+        BOOST_TEST(cf1->map_builder.GetMissingDataRayLength() ==
+                       ac.missing_data_ray_length,
+                   tol);
+        BOOST_TEST(cf1->map_builder.GetMaxRange() == ac.max_range, tol);
+        BOOST_TEST(cf1->map_builder.GetMinRange() == ac.min_range, tol);
+        BOOST_TEST(cf1->map_builder.GetOccupiedSpaceWeight() ==
+                       ac.occupied_space_weight,
+                   tol);
+        BOOST_TEST(
+            cf1->map_builder.GetTranslationWeight() == ac.translation_weight,
+            tol);
+        BOOST_TEST(cf1->map_builder.GetRotationWeight() == ac.rotation_weight,
+                   tol);
+        // END TEST
+        BOOST_TEST(viam_carto_terminate(&vc1) == VIAM_CARTO_SUCCESS);
+        viam_carto_config_teardown(vcc_mapping);
+    }
+
+    auto updating_dir = tmp_dir / fs::path("updating_dir");
+    // updating setup
+    {
+        auto internal_state_dir = updating_dir / fs::path("internal_state");
+        fs::create_directories(internal_state_dir);
+        // we need to copy a valid internal state when we boot in updating mode
+        // otherwise cartographer terminates the entire os process
+        // see: https://viam.atlassian.net/browse/RSDK-3553
+        auto internal_state_artifact_source =
+            fs::current_path() /
+            fs::path(
+                ".artifact/data/viam-cartographer/outputs/viam-office-02-22-3/"
+                "internal_state/internal_state_0.pbstream");
+
+        VLOG(1) << "internal_state_artifact_source: "
+                << internal_state_artifact_source;
+        VLOG(1) << "exists(internal_state_artifact_source): "
+                << exists(internal_state_artifact_source);
+        VLOG(1) << "internal_state_dir: " << internal_state_dir;
+        VLOG(1) << "exists(internal_state_dir): " << exists(internal_state_dir);
+        auto internal_state_artifact_target =
+            internal_state_dir /
+            fs::path("map_data_2022-02-11T01:44:53.1903Z.pbstream");
+        fs::copy_file(internal_state_artifact_source,
+                      internal_state_artifact_target);
+    }
+
+    {
+        // updating
+        viam_carto *vc2;
+
+        struct viam_carto_config vcc_updating = viam_carto_config_setup(
+            1, VIAM_CARTO_THREE_D, updating_dir.string(), camera,
+            movement_sensor, true, true);
+        BOOST_TEST(viam_carto_init(&vc2, lib, vcc_updating, ac) ==
+                   VIAM_CARTO_SUCCESS);
+        BOOST_TEST(vc2->slam_mode == VIAM_CARTO_SLAM_MODE_UPDATING);
+        viam::carto_facade::CartoFacade *cf2 =
+            static_cast<viam::carto_facade::CartoFacade *>(vc2->carto_obj);
+        BOOST_TEST(cf2->slam_mode == SlamMode::UPDATING);
+        BOOST_TEST(cf2->map_builder.GetOptimizeEveryNNodes() ==
+                   ac.optimize_every_n_nodes);
+        BOOST_TEST(cf2->map_builder.GetNumRangeData() == ac.num_range_data);
+        BOOST_TEST(cf2->map_builder.GetMissingDataRayLength() ==
+                       ac.missing_data_ray_length,
+                   tol);
+        BOOST_TEST(cf2->map_builder.GetMaxRange() == ac.max_range, tol);
+        BOOST_TEST(cf2->map_builder.GetMinRange() == ac.min_range, tol);
+        BOOST_TEST(cf2->map_builder.GetFreshSubmapsCount() ==
+                   ac.fresh_submaps_count);
+        BOOST_TEST(cf2->map_builder.GetMinCoveredArea() == ac.min_covered_area,
+                   tol);
+        BOOST_TEST(cf2->map_builder.GetMinAddedSubmapsCount() ==
+                   ac.min_added_submaps_count);
+        BOOST_TEST(cf2->map_builder.GetOccupiedSpaceWeight() ==
+                       ac.occupied_space_weight,
+                   tol);
+        BOOST_TEST(
+            cf2->map_builder.GetTranslationWeight() == ac.translation_weight,
+            tol);
+        BOOST_TEST(cf2->map_builder.GetRotationWeight() == ac.rotation_weight,
+                   tol);
+        BOOST_TEST(viam_carto_terminate(&vc2) == VIAM_CARTO_SUCCESS);
+        viam_carto_config_teardown(vcc_updating);
+    }
+    struct viam_carto_algo_config ac_optimize_on_start =
+        viam_carto_algo_config_setup();
+    ac_optimize_on_start.optimize_on_start = true;
+
+    {
+        // updating optimize_on_start
+        viam_carto *vc3;
+        struct viam_carto_config vcc_updating = viam_carto_config_setup(
+            1, VIAM_CARTO_THREE_D, updating_dir.string(), camera,
+            movement_sensor, true, true);
+
+        BOOST_TEST(viam_carto_init(&vc3, lib, vcc_updating,
+                                   ac_optimize_on_start) == VIAM_CARTO_SUCCESS);
+        BOOST_TEST(vc3->slam_mode == VIAM_CARTO_SLAM_MODE_UPDATING);
+        viam::carto_facade::CartoFacade *cf2 =
+            static_cast<viam::carto_facade::CartoFacade *>(vc3->carto_obj);
+        BOOST_TEST(cf2->slam_mode == SlamMode::UPDATING);
+        BOOST_TEST(viam_carto_terminate(&vc3) == VIAM_CARTO_SUCCESS);
+        viam_carto_config_teardown(vcc_updating);
+    }
+
+    {
+        // localizing
+        viam_carto *vc4;
+        struct viam_carto_config vcc_localizing = viam_carto_config_setup(
+            0, VIAM_CARTO_THREE_D, updating_dir.string(), camera,
+            movement_sensor, true, false);
+        BOOST_TEST(viam_carto_init(&vc4, lib, vcc_localizing, ac) ==
+                   VIAM_CARTO_SUCCESS);
+        BOOST_TEST(vc4->slam_mode == VIAM_CARTO_SLAM_MODE_LOCALIZING);
+        viam::carto_facade::CartoFacade *cf3 =
+            static_cast<viam::carto_facade::CartoFacade *>(vc4->carto_obj);
+        BOOST_TEST(cf3->slam_mode == SlamMode::LOCALIZING);
+        BOOST_TEST(cf3->map_builder.GetOptimizeEveryNNodes() ==
+                   ac.optimize_every_n_nodes);
+        BOOST_TEST(cf3->map_builder.GetNumRangeData() == ac.num_range_data);
+        BOOST_TEST(cf3->map_builder.GetMissingDataRayLength() ==
+                       ac.missing_data_ray_length,
+                   tol);
+        BOOST_TEST(cf3->map_builder.GetMaxRange() == ac.max_range, tol);
+        BOOST_TEST(cf3->map_builder.GetMinRange() == ac.min_range, tol);
+        BOOST_TEST(cf3->map_builder.GetMaxSubmapsToKeep() ==
+                   ac.max_submaps_to_keep);
+        BOOST_TEST(cf3->map_builder.GetOccupiedSpaceWeight() ==
+                       ac.occupied_space_weight,
+                   tol);
+        BOOST_TEST(
+            cf3->map_builder.GetTranslationWeight() == ac.translation_weight,
+            tol);
+        BOOST_TEST(cf3->map_builder.GetRotationWeight() == ac.rotation_weight,
+                   tol);
+        BOOST_TEST(viam_carto_terminate(&vc4) == VIAM_CARTO_SUCCESS);
+        viam_carto_config_teardown(vcc_localizing);
+    }
+
+    {
+        // localizing optimize_on_start
+        viam_carto *vc5;
+        struct viam_carto_config vcc_localizing = viam_carto_config_setup(
+            0, VIAM_CARTO_THREE_D, updating_dir.string(), camera,
+            movement_sensor, true, false);
+        BOOST_TEST(viam_carto_init(&vc5, lib, vcc_localizing,
+                                   ac_optimize_on_start) == VIAM_CARTO_SUCCESS);
+        BOOST_TEST(vc5->slam_mode == VIAM_CARTO_SLAM_MODE_LOCALIZING);
+        viam::carto_facade::CartoFacade *cf3 =
+            static_cast<viam::carto_facade::CartoFacade *>(vc5->carto_obj);
+        BOOST_TEST(cf3->slam_mode == SlamMode::LOCALIZING);
+        BOOST_TEST(viam_carto_terminate(&vc5) == VIAM_CARTO_SUCCESS);
+        viam_carto_config_teardown(vcc_localizing);
+    }
+
+    {
+        // invalid
+        auto empty_dir = tmp_dir / fs::path(bfs::unique_path().string());
+        ;
+        viam_carto *vc6;
+        struct viam_carto_config vcc_invalid =
+            viam_carto_config_setup(0, VIAM_CARTO_THREE_D, empty_dir.string(),
+                                    camera, movement_sensor, false, false);
+        BOOST_TEST(viam_carto_init(&vc6, lib, vcc_invalid, ac) ==
+                   VIAM_CARTO_SLAM_MODE_INVALID);
+        viam_carto_config_teardown(vcc_invalid);
+    }
+
+    // TODO: Move all suite level setup & teardown to boost test hook
+    fs::remove_all(tmp_dir);
+
+    BOOST_TEST(viam_carto_lib_terminate(&lib) == VIAM_CARTO_SUCCESS);
 }
 
 BOOST_AUTO_TEST_CASE(CartoFacade_init_derive_slam_mode) {
@@ -370,10 +544,6 @@ BOOST_AUTO_TEST_CASE(CartoFacade_init_derive_slam_mode) {
         struct viam_carto_config vcc_localizing = viam_carto_config_setup(
             0, VIAM_CARTO_THREE_D, updating_dir.string(), camera,
             movement_sensor, false, false);
-<<<<<<< HEAD
-=======
-        LOG(ERROR) << "KIM LOG test: " << vcc_localizing.cloud_story_enabled;    
->>>>>>> 716b385 (WIP: tests passing with enable mapping cloud story changes)
         BOOST_TEST(viam_carto_init(&vc4, lib, vcc_localizing, ac) ==
                    VIAM_CARTO_SUCCESS);
         BOOST_TEST(vc4->slam_mode == VIAM_CARTO_SLAM_MODE_LOCALIZING);
@@ -423,14 +593,9 @@ BOOST_AUTO_TEST_CASE(CartoFacade_init_derive_slam_mode) {
         auto empty_dir = tmp_dir / fs::path(bfs::unique_path().string());
         ;
         viam_carto *vc6;
-<<<<<<< HEAD
         struct viam_carto_config vcc_invalid =
             viam_carto_config_setup(0, VIAM_CARTO_THREE_D, empty_dir.string(),
                                     camera, movement_sensor, false, false);
-=======
-        struct viam_carto_config vcc_invalid = viam_carto_config_setup(
-            0, VIAM_CARTO_THREE_D, empty_dir.string(), camera, movement_sensor, false, false);
->>>>>>> 716b385 (WIP: tests passing with enable mapping cloud story changes)
         BOOST_TEST(viam_carto_init(&vc6, lib, vcc_invalid, ac) ==
                    VIAM_CARTO_SLAM_MODE_INVALID);
         viam_carto_config_teardown(vcc_invalid);
@@ -452,14 +617,9 @@ BOOST_AUTO_TEST_CASE(CartoFacade_init_terminate) {
     std::string movement_sensor = "imu";
     fs::path tmp_dir =
         fs::temp_directory_path() / fs::path(bfs::unique_path().string());
-<<<<<<< HEAD
     struct viam_carto_config vcc =
         viam_carto_config_setup(1, VIAM_CARTO_THREE_D, tmp_dir.string(), camera,
                                 movement_sensor, false, false);
-=======
-    struct viam_carto_config vcc = viam_carto_config_setup(
-        1, VIAM_CARTO_THREE_D, tmp_dir.string(), camera, movement_sensor, false, false);
->>>>>>> 716b385 (WIP: tests passing with enable mapping cloud story changes)
     struct viam_carto_algo_config ac = viam_carto_algo_config_setup();
     BOOST_TEST(viam_carto_init(&vc, lib, vcc, ac) == VIAM_CARTO_SUCCESS);
     BOOST_TEST(vc->slam_mode == VIAM_CARTO_SLAM_MODE_MAPPING);

--- a/viam_cartographer.go
+++ b/viam_cartographer.go
@@ -173,7 +173,7 @@ func New(
 			c.Model.Name, svcConfig.ConfigParams["mode"])
 	}
 
-	lidarDataRateMsec, imuName, imuDataRateMsec, mapRateSec, err := vcConfig.GetOptionalParameters(
+	lidarDataRateMsec, imuName, imuDataRateMsec, mapRateSec, enableMapping, err := vcConfig.GetOptionalParameters(
 		svcConfig,
 		defaultLidarDataRateMsec,
 		defaultIMUDataRateMsec,
@@ -250,6 +250,8 @@ func New(
 		sensorValidationIntervalSec:   sensorValidationMaxTimeoutSec,
 		cartoFacadeTimeout:            cartoFacadeTimeout,
 		mapTimestamp:                  time.Now().UTC(),
+		cloudStoryEnabled:             svcConfig.CloudStoryEnabled,
+		enableMapping:                 enableMapping,
 	}
 
 	defer func() {
@@ -420,6 +422,8 @@ func initCartoFacade(ctx context.Context, cartoSvc *CartographerService) error {
 		DataDir:            cartoSvc.dataDirectory,
 		ComponentReference: cartoSvc.lidar.name,
 		LidarConfig:        cartofacade.TwoD,
+		CloudStoryEnabled:  cartoSvc.cloudStoryEnabled,
+		EnableMapping:      cartoSvc.enableMapping,
 	}
 
 	cf := cartofacade.New(&cartoLib, cartoCfg, cartoAlgoConfig)
@@ -510,6 +514,9 @@ type CartographerService struct {
 	sensorValidationMaxTimeoutSec int
 	sensorValidationIntervalSec   int
 	jobDone                       atomic.Bool
+
+	cloudStoryEnabled bool
+	enableMapping     bool
 }
 
 // GetPosition forwards the request for positional data to the slam library's gRPC service. Once a response is received,

--- a/viam_cartographer.go
+++ b/viam_cartographer.go
@@ -173,7 +173,7 @@ func New(
 			c.Model.Name, svcConfig.ConfigParams["mode"])
 	}
 
-	lidarDataRateMsec, imuName, imuDataRateMsec, mapRateSec, enableMapping, err := vcConfig.GetOptionalParameters(
+	optionalConfigParams, err := vcConfig.GetOptionalParameters(
 		svcConfig,
 		defaultLidarDataRateMsec,
 		defaultIMUDataRateMsec,
@@ -199,7 +199,7 @@ func New(
 	}
 
 	// Get the IMU if one is configured
-	imuObject, err := s.NewIMU(ctx, deps, imuName, logger)
+	imuObject, err := s.NewIMU(ctx, deps, optionalConfigParams.ImuName, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -222,14 +222,14 @@ func New(
 
 	lidar := Lidar{
 		name:         lidarName,
-		dataRateMsec: lidarDataRateMsec,
+		dataRateMsec: optionalConfigParams.LidarDataRateMsec,
 		actual:       lidarObject,
 		testing:      timedLidar,
 	}
 
 	imu := IMU{
-		name:         imuName,
-		dataRateMsec: imuDataRateMsec,
+		name:         optionalConfigParams.ImuName,
+		dataRateMsec: optionalConfigParams.ImuDataRateMsec,
 		actual:       imuObject,
 		testing:      timedIMU,
 	}
@@ -242,7 +242,7 @@ func New(
 		subAlgo:                       subAlgo,
 		configParams:                  svcConfig.ConfigParams,
 		dataDirectory:                 svcConfig.DataDirectory,
-		mapRateSec:                    mapRateSec,
+		mapRateSec:                    optionalConfigParams.MapRateSec,
 		cancelSensorProcessFunc:       cancelSensorProcessFunc,
 		cancelCartoFacadeFunc:         cancelCartoFacadeFunc,
 		logger:                        logger,
@@ -251,7 +251,7 @@ func New(
 		cartoFacadeTimeout:            cartoFacadeTimeout,
 		mapTimestamp:                  time.Now().UTC(),
 		cloudStoryEnabled:             svcConfig.CloudStoryEnabled,
-		enableMapping:                 enableMapping,
+		enableMapping:                 optionalConfigParams.EnableMapping,
 	}
 
 	defer func() {


### PR DESCRIPTION
## High Level Cloud Story Config Changes overview
1.  **add `enable_mapping` to config. If `cloud_story_enabled` == true: use `enable_mapping=false` in place of `map_rate_sec = 0` to determine if we are in `LOCALIZING` mode or not**
2. if cloud story is enabled, do not validate `map_rate_sec`. Remove logic to save internal state to the `data_dir`
3. If cloud story is enabled stop validating `data_dir`, add `existing_map` to optional parameters. Use `existing_state` to get any existing map 

**This PR implements number 1**

## Changes
* remove config validatation for `cloud_story_enabled`
* pass `cloud_story_enabled` feature flag all the way to C++ code
* add `enable_mapping` to config & pass it all the way down to C++ code
* 

## Testing Changes
* remove old testing logic associated with incorrect validations
* add in new config params to test