### PR TITLE
[RSDK-4487] Rename lidar functions

### DIFF
--- a/cartofacade/capi.go
+++ b/cartofacade/capi.go
@@ -54,7 +54,7 @@ type CartoInterface interface {
 	start() error
 	stop() error
 	terminate() error
-	addSensorReading(string, []byte, time.Time) error
+	addLidarReading(string, []byte, time.Time) error
 	getPosition() (GetPosition, error)
 	getPointCloudMap() ([]byte, error)
 	getInternalState() ([]byte, error)
@@ -206,17 +206,17 @@ func (vc *Carto) terminate() error {
 	return nil
 }
 
-// AddSensorReading is a wrapper for viam_carto_add_sensor_reading
-func (vc *Carto) addSensorReading(sensor string, readings []byte, timestamp time.Time) error {
-	value := toSensorReading(sensor, readings, timestamp)
+// AddLidarReading is a wrapper for viam_carto_add_lidar_reading
+func (vc *Carto) addLidarReading(lidar string, readings []byte, timestamp time.Time) error {
+	value := toLidarReading(lidar, readings, timestamp)
 
-	status := C.viam_carto_add_sensor_reading(vc.value, &value)
+	status := C.viam_carto_add_lidar_reading(vc.value, &value)
 
 	if err := toError(status); err != nil {
 		return err
 	}
 
-	status = C.viam_carto_add_sensor_reading_destroy(&value)
+	status = C.viam_carto_add_lidar_reading_destroy(&value)
 	if err := toError(status); err != nil {
 		return err
 	}
@@ -377,15 +377,15 @@ func toGetPositionResponse(value C.viam_carto_get_position_response) GetPosition
 	}
 }
 
-func toSensorReading(sensor string, readings []byte, timestamp time.Time) C.viam_carto_sensor_reading {
-	sr := C.viam_carto_sensor_reading{}
-	sensorCStr := C.CString(sensor)
+func toLidarReading(lidar string, readings []byte, timestamp time.Time) C.viam_carto_lidar_reading {
+	sr := C.viam_carto_lidar_reading{}
+	sensorCStr := C.CString(lidar)
 	defer C.free(unsafe.Pointer(sensorCStr))
-	sr.sensor = C.blk2bstr(unsafe.Pointer(sensorCStr), C.int(len(sensor)))
+	sr.lidar = C.blk2bstr(unsafe.Pointer(sensorCStr), C.int(len(lidar)))
 	readingsCBytes := C.CBytes(readings)
 	defer C.free(readingsCBytes)
-	sr.sensor_reading = C.blk2bstr(readingsCBytes, C.int(len(readings)))
-	sr.sensor_reading_time_unix_milli = C.int64_t(timestamp.UnixMilli())
+	sr.lidar_reading = C.blk2bstr(readingsCBytes, C.int(len(readings)))
+	sr.lidar_reading_time_unix_milli = C.int64_t(timestamp.UnixMilli())
 	return sr
 }
 
@@ -433,10 +433,10 @@ func toError(status C.int) error {
 		return errors.New("VIAM_CARTO_MAP_CREATION_ERROR")
 	case C.VIAM_CARTO_SENSOR_NOT_IN_SENSOR_LIST:
 		return errors.New("VIAM_CARTO_SENSOR_NOT_IN_SENSOR_LIST")
-	case C.VIAM_CARTO_SENSOR_READING_EMPTY:
-		return errors.New("VIAM_CARTO_SENSOR_READING_EMPTY")
-	case C.VIAM_CARTO_SENSOR_READING_INVALID:
-		return errors.New("VIAM_CARTO_SENSOR_READING_INVALID")
+	case C.VIAM_CARTO_LIDAR_READING_EMPTY:
+		return errors.New("VIAM_CARTO_LIDAR_READING_EMPTY")
+	case C.VIAM_CARTO_LIDAR_READING_INVALID:
+		return errors.New("VIAM_CARTO_LIDAR_READING_INVALID")
 	case C.VIAM_CARTO_GET_POSITION_RESPONSE_INVALID:
 		return errors.New("VIAM_CARTO_GET_POSITION_RESPONSE_INVALID")
 	case C.VIAM_CARTO_POINTCLOUD_MAP_EMPTY:

--- a/cartofacade/capi_mock.go
+++ b/cartofacade/capi_mock.go
@@ -25,7 +25,7 @@ type CartoMock struct {
 	StartFunc            func() error
 	StopFunc             func() error
 	TerminateFunc        func() error
-	AddSensorReadingFunc func(string, []byte, time.Time) error
+	AddLidarReadingFunc  func(string, []byte, time.Time) error
 	GetPositionFunc      func() (GetPosition, error)
 	GetPointCloudMapFunc func() ([]byte, error)
 	GetInternalStateFunc func() ([]byte, error)
@@ -55,12 +55,12 @@ func (cf *CartoMock) terminate() error {
 	return cf.TerminateFunc()
 }
 
-// AddSensorReading calls the injected AddSensorReadingFunc or the real version.
-func (cf *CartoMock) addSensorReading(sensor string, readings []byte, time time.Time) error {
-	if cf.AddSensorReadingFunc == nil {
-		return cf.Carto.addSensorReading(sensor, readings, time)
+// AddLidarReading calls the injected AddLidarReadingFunc or the real version.
+func (cf *CartoMock) addLidarReading(lidar string, readings []byte, time time.Time) error {
+	if cf.AddLidarReadingFunc == nil {
+		return cf.Carto.addLidarReading(lidar, readings, time)
 	}
-	return cf.AddSensorReadingFunc(sensor, readings, time)
+	return cf.AddLidarReadingFunc(lidar, readings, time)
 }
 
 // GetPosition calls the injected GetPositionFunc or the real version.

--- a/cartofacade/capi_test.go
+++ b/cartofacade/capi_test.go
@@ -49,7 +49,7 @@ func testAddSensorReading(t *testing.T, vc Carto, pcdPath string, timestamp time
 	err = pointcloud.ToPCD(pc, buf, pcdType)
 	test.That(t, err, test.ShouldBeNil)
 
-	err = vc.addSensorReading("mysensor", buf.Bytes(), timestamp)
+	err = vc.addLidarReading("mysensor", buf.Bytes(), timestamp)
 	test.That(t, err, test.ShouldBeNil)
 }
 
@@ -121,12 +121,12 @@ func TestGetPositionResponse(t *testing.T) {
 }
 
 func TestToSensorReading(t *testing.T) {
-	t.Run("sensor reading properly converted between c and go", func(t *testing.T) {
+	t.Run("lidar reading properly converted between c and go", func(t *testing.T) {
 		timestamp := time.Date(2021, 8, 15, 14, 30, 45, 100, time.UTC)
-		sr := toSensorReading("mysensor", []byte("he0llo"), timestamp)
-		test.That(t, bstringToGoString(sr.sensor), test.ShouldResemble, "mysensor")
-		test.That(t, bstringToGoString(sr.sensor_reading), test.ShouldResemble, "he0llo")
-		test.That(t, sr.sensor_reading_time_unix_milli, test.ShouldEqual, timestamp.UnixMilli())
+		sr := toLidarReading("mysensor", []byte("he0llo"), timestamp)
+		test.That(t, bstringToGoString(sr.lidar), test.ShouldResemble, "mysensor")
+		test.That(t, bstringToGoString(sr.lidar_reading), test.ShouldResemble, "he0llo")
+		test.That(t, sr.lidar_reading_time_unix_milli, test.ShouldEqual, timestamp.UnixMilli())
 	})
 }
 
@@ -195,23 +195,24 @@ func TestCGoAPI(t *testing.T) {
 		test.That(t, len(internalState), test.ShouldBeGreaterThan, 0)
 		lastInternalState := internalState
 
-		// test invalid addSensorReading: not in sensor list
+		// test invalid addLidarReading: not in sensor list
+		// PATRICIA REVISIT
 		timestamp := time.Date(2021, 8, 15, 14, 30, 45, 100, time.UTC)
-		err = vc.addSensorReading("not my sensor", []byte("he0llo"), timestamp)
+		err = vc.addLidarReading("not my sensor", []byte("he0llo"), timestamp)
 		test.That(t, err, test.ShouldBeError)
 		test.That(t, err.Error(), test.ShouldResemble, "VIAM_CARTO_SENSOR_NOT_IN_SENSOR_LIST")
 
-		// test invalid addSensorReading: empty reading
+		// test invalid addLidarReading: empty reading
 		timestamp = timestamp.Add(time.Second * 2)
-		err = vc.addSensorReading("mysensor", []byte(""), timestamp)
+		err = vc.addLidarReading("mysensor", []byte(""), timestamp)
 		test.That(t, err, test.ShouldBeError)
-		test.That(t, err.Error(), test.ShouldResemble, "VIAM_CARTO_SENSOR_READING_EMPTY")
+		test.That(t, err.Error(), test.ShouldResemble, "VIAM_CARTO_LIDAR_READING_EMPTY")
 
-		// test invalid addSensorReading: invalid reading
+		// test invalid addLidarReading: invalid reading
 		timestamp = timestamp.Add(time.Second * 2)
-		err = vc.addSensorReading("mysensor", []byte("he0llo"), timestamp)
+		err = vc.addLidarReading("mysensor", []byte("he0llo"), timestamp)
 		test.That(t, err, test.ShouldBeError)
-		test.That(t, err.Error(), test.ShouldResemble, "VIAM_CARTO_SENSOR_READING_INVALID")
+		test.That(t, err.Error(), test.ShouldResemble, "VIAM_CARTO_LIDAR_READING_INVALID")
 
 		confirmBinaryCompressedUnsupported(t)
 
@@ -224,7 +225,7 @@ func TestCGoAPI(t *testing.T) {
 		// why or when it does / does not update the map.
 		// As a result, these tests show best case behavior.
 
-		// 1. test valid addSensorReading: valid reading ascii
+		// 1. test valid addLidarReading: valid reading ascii
 		t.Log("sensor reading 1")
 		timestamp = timestamp.Add(time.Second * 2)
 		testAddSensorReading(t, vc, "viam-cartographer/mock_lidar/0.pcd", timestamp, pointcloud.PCDAscii)
@@ -249,7 +250,7 @@ func TestCGoAPI(t *testing.T) {
 		test.That(t, internalState, test.ShouldNotEqual, lastInternalState)
 		lastInternalState = internalState
 
-		// 2. test valid addSensorReading: valid reading binary
+		// 2. test valid addLidarReading: valid reading binary
 		t.Log("sensor reading 2")
 		timestamp = timestamp.Add(time.Second * 2)
 		testAddSensorReading(t, vc, "viam-cartographer/mock_lidar/1.pcd", timestamp, pointcloud.PCDBinary)

--- a/cartofacade/capi_test.go
+++ b/cartofacade/capi_test.go
@@ -196,7 +196,7 @@ func TestCGoAPI(t *testing.T) {
 		lastInternalState := internalState
 
 		// test invalid addLidarReading: not in sensor list
-		// PATRICIA REVISIT
+		// PATRICIA TODO: #242
 		timestamp := time.Date(2021, 8, 15, 14, 30, 45, 100, time.UTC)
 		err = vc.addLidarReading("not my sensor", []byte("he0llo"), timestamp)
 		test.That(t, err, test.ShouldBeError)

--- a/cartofacade/carto_facade.go
+++ b/cartofacade/carto_facade.go
@@ -13,7 +13,7 @@ import (
 
 var emptyRequestParams = map[RequestParamType]interface{}{}
 
-// ErrUnableToAcquireLock is the error returned from AddSensorReading when lock can't be acquired.
+// ErrUnableToAcquireLock is the error returned from AddLidarReading when lock can't be acquired.
 var ErrUnableToAcquireLock = errors.New("VIAM_CARTO_UNABLE_TO_ACQUIRE_LOCK")
 
 // Initialize calls into the cartofacade C code.
@@ -64,21 +64,21 @@ func (cf *CartoFacade) Terminate(ctx context.Context, timeout time.Duration) err
 	return nil
 }
 
-// AddSensorReading calls into the cartofacade C code.
-func (cf *CartoFacade) AddSensorReading(
+// AddLidarReading calls into the cartofacade C code.
+func (cf *CartoFacade) AddLidarReading(
 	ctx context.Context,
 	timeout time.Duration,
-	sensorName string,
+	lidarName string,
 	currentReading []byte,
 	readingTimestamp time.Time,
 ) error {
 	requestParams := map[RequestParamType]interface{}{
-		sensor:    sensorName,
+		lidar:     lidarName,
 		reading:   currentReading,
 		timestamp: readingTimestamp,
 	}
 
-	_, err := cf.request(ctx, addSensorReading, requestParams, timeout)
+	_, err := cf.request(ctx, addLidarReading, requestParams, timeout)
 	if err != nil {
 		return err
 	}
@@ -143,8 +143,8 @@ const (
 	stop
 	// terminate represents the viam_carto_terminate in c.
 	terminate
-	// addSensorReading represents the viam_carto_add_sensor_reading in c.
-	addSensorReading
+	// addLidarReading represents the viam_carto_add_lidar_reading in c.
+	addLidarReading
 	// position represents the viam_carto_get_position call in c.
 	position
 	// internalState represents the viam_carto_get_internal_state call in c.
@@ -157,8 +157,8 @@ const (
 type RequestParamType int64
 
 const (
-	// sensor represents a sensor name input into c funcs.
-	sensor RequestParamType = iota
+	// lidar represents a lidar name input into c funcs.
+	lidar RequestParamType = iota
 	// reading represents a lidar reading input into c funcs.
 	reading
 	// timestamp represents the timestamp input into c funcs.
@@ -219,7 +219,7 @@ type Interface interface {
 		ctx context.Context,
 		timeout time.Duration,
 	) error
-	AddSensorReading(
+	AddLidarReading(
 		ctx context.Context,
 		timeout time.Duration,
 		sensorName string,
@@ -272,10 +272,10 @@ func (r *Request) doWork(
 		return nil, cf.carto.stop()
 	case terminate:
 		return nil, cf.carto.terminate()
-	case addSensorReading:
-		sensor, ok := r.requestParams[sensor].(string)
+	case addLidarReading:
+		lidar, ok := r.requestParams[lidar].(string)
 		if !ok {
-			return nil, errors.New("could not cast inputted sensor name to string")
+			return nil, errors.New("could not cast inputted lidar name to string")
 		}
 
 		reading, ok := r.requestParams[reading].([]byte)
@@ -288,7 +288,7 @@ func (r *Request) doWork(
 			return nil, errors.New("could not cast inputted timestamp to times.Time")
 		}
 
-		return nil, cf.carto.addSensorReading(sensor, reading, timestamp)
+		return nil, cf.carto.addLidarReading(lidar, reading, timestamp)
 	case position:
 		return cf.carto.getPosition()
 	case internalState:

--- a/cartofacade/carto_facade_mock.go
+++ b/cartofacade/carto_facade_mock.go
@@ -51,7 +51,7 @@ type Mock struct {
 		ctx context.Context,
 		timeout time.Duration,
 	) error
-	AddSensorReadingFunc func(
+	AddLidarReadingFunc func(
 		ctx context.Context,
 		timeout time.Duration,
 		sensorName string,
@@ -141,18 +141,18 @@ func (cf *Mock) Terminate(
 	return cf.TerminateFunc(ctx, timeout)
 }
 
-// AddSensorReading calls the injected AddSensorReadingFunc or the real version.
-func (cf *Mock) AddSensorReading(
+// AddLidarReading calls the injected AddLidarReadingFunc or the real version.
+func (cf *Mock) AddLidarReading(
 	ctx context.Context,
 	timeout time.Duration,
 	sensorName string,
 	currentReading []byte,
 	readingTimestamp time.Time,
 ) error {
-	if cf.AddSensorReadingFunc == nil {
-		return cf.CartoFacade.AddSensorReading(ctx, timeout, sensorName, currentReading, readingTimestamp)
+	if cf.AddLidarReadingFunc == nil {
+		return cf.CartoFacade.AddLidarReading(ctx, timeout, sensorName, currentReading, readingTimestamp)
 	}
-	return cf.AddSensorReadingFunc(ctx, timeout, sensorName, currentReading, readingTimestamp)
+	return cf.AddLidarReadingFunc(ctx, timeout, sensorName, currentReading, readingTimestamp)
 }
 
 // GetPosition calls the injected GetPositionFunc or the real version.

--- a/cartofacade/carto_facade_test.go
+++ b/cartofacade/carto_facade_test.go
@@ -331,13 +331,13 @@ func TestAddSensorReading(t *testing.T) {
 
 	cartoFacade := New(&lib, cfg, algoCfg)
 	carto := CartoMock{}
-	carto.AddSensorReadingFunc = func(name string, reading []byte, time time.Time) error {
+	carto.AddLidarReadingFunc = func(name string, reading []byte, time time.Time) error {
 		return nil
 	}
 	cartoFacade.carto = &carto
 	cartoFacade.startCGoroutine(cancelCtx, &activeBackgroundWorkers)
 
-	t.Run("testing AddSensorReading", func(t *testing.T) {
+	t.Run("testing AddLidarReading", func(t *testing.T) {
 		timestamp := time.Date(2021, 8, 15, 14, 30, 45, 100, time.UTC)
 
 		// read PCD
@@ -350,27 +350,27 @@ func TestAddSensorReading(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 
 		// success case
-		err = cartoFacade.AddSensorReading(cancelCtx, 5*time.Second, "mysensor", buf.Bytes(), timestamp)
+		err = cartoFacade.AddLidarReading(cancelCtx, 5*time.Second, "mysensor", buf.Bytes(), timestamp)
 		test.That(t, err, test.ShouldBeNil)
 
-		carto.AddSensorReadingFunc = func(name string, reading []byte, time time.Time) error {
+		carto.AddLidarReadingFunc = func(name string, reading []byte, time time.Time) error {
 			return errors.New("test error 4")
 		}
 		cartoFacade.carto = &carto
 
 		// returns error
-		err = cartoFacade.AddSensorReading(cancelCtx, 5*time.Second, "mysensor", buf.Bytes(), timestamp)
+		err = cartoFacade.AddLidarReading(cancelCtx, 5*time.Second, "mysensor", buf.Bytes(), timestamp)
 		test.That(t, err, test.ShouldBeError)
 		test.That(t, err, test.ShouldResemble, errors.New("test error 4"))
 
-		carto.AddSensorReadingFunc = func(name string, reading []byte, timestamp time.Time) error {
+		carto.AddLidarReadingFunc = func(name string, reading []byte, timestamp time.Time) error {
 			time.Sleep(50 * time.Millisecond)
 			return nil
 		}
 		cartoFacade.carto = &carto
 
 		// times out
-		err = cartoFacade.AddSensorReading(cancelCtx, 1*time.Millisecond, "mysensor", buf.Bytes(), timestamp)
+		err = cartoFacade.AddLidarReading(cancelCtx, 1*time.Millisecond, "mysensor", buf.Bytes(), timestamp)
 		test.That(t, err, test.ShouldBeError)
 		expectedErr := multierr.Combine(errors.New(timeoutErrMessage), context.DeadlineExceeded)
 		test.That(t, err, test.ShouldResemble, expectedErr)

--- a/sensorprocess/sensorprocess.go
+++ b/sensorprocess/sensorprocess.go
@@ -36,15 +36,15 @@ func Start(
 		case <-ctx.Done():
 			return false
 		default:
-			if jobDone := addSensorReading(ctx, config); jobDone {
+			if jobDone := addLidarReading(ctx, config); jobDone {
 				return true
 			}
 		}
 	}
 }
 
-// addSensorReading adds a lidar reading to the cartofacade.
-func addSensorReading(
+// addLidarReading adds a lidar reading to the cartofacade.
+func addLidarReading(
 	ctx context.Context,
 	config Config,
 ) bool {
@@ -62,18 +62,18 @@ func addSensorReading(
 	 mode and ensure every scan gets processed by cartographer
 	*/
 	if config.LidarDataRateMsec == 0 {
-		tryAddSensorReadingUntilSuccess(ctx, tsr.Reading, tsr.ReadingTime, config)
+		tryAddLidarReadingUntilSuccess(ctx, tsr.Reading, tsr.ReadingTime, config)
 	} else {
-		timeToSleep := tryAddSensorReading(ctx, tsr.Reading, tsr.ReadingTime, config)
+		timeToSleep := tryAddLidarReading(ctx, tsr.Reading, tsr.ReadingTime, config)
 		time.Sleep(time.Duration(timeToSleep) * time.Millisecond)
 		config.Logger.Debugf("sleep for %s milliseconds", time.Duration(timeToSleep))
 	}
 	return false
 }
 
-// tryAddSensorReadingUntilSuccess adds a reading to the cartofacade
+// tryAddLidarReadingUntilSuccess adds a reading to the cartofacade
 // retries on error (offline mode).
-func tryAddSensorReadingUntilSuccess(ctx context.Context, reading []byte, readingTime time.Time, config Config) {
+func tryAddLidarReadingUntilSuccess(ctx context.Context, reading []byte, readingTime time.Time, config Config) {
 	/*
 		while add sensor reading fails, keep trying to add the same reading - in offline mode
 		we want to process each reading so if we cannot acquire the lock we should try again
@@ -83,7 +83,7 @@ func tryAddSensorReadingUntilSuccess(ctx context.Context, reading []byte, readin
 		case <-ctx.Done():
 			return
 		default:
-			err := config.CartoFacade.AddSensorReading(ctx, config.Timeout, config.LidarName, reading, readingTime)
+			err := config.CartoFacade.AddLidarReading(ctx, config.Timeout, config.LidarName, reading, readingTime)
 			if err == nil {
 				return
 			}
@@ -94,11 +94,11 @@ func tryAddSensorReadingUntilSuccess(ctx context.Context, reading []byte, readin
 	}
 }
 
-// tryAddSensorReading adds a reading to the carto facade
+// tryAddLidarReading adds a reading to the carto facade
 // does not retry (online).
-func tryAddSensorReading(ctx context.Context, reading []byte, readingTime time.Time, config Config) int {
+func tryAddLidarReading(ctx context.Context, reading []byte, readingTime time.Time, config Config) int {
 	startTime := time.Now()
-	err := config.CartoFacade.AddSensorReading(ctx, config.Timeout, config.LidarName, reading, readingTime)
+	err := config.CartoFacade.AddLidarReading(ctx, config.Timeout, config.LidarName, reading, readingTime)
 	if err != nil {
 		if errors.Is(err, cartofacade.ErrUnableToAcquireLock) {
 			config.Logger.Debugw("Skipping sensor reading due to lock contention in cartofacade", "error", err)

--- a/sensorprocess/sensorprocess.go
+++ b/sensorprocess/sensorprocess.go
@@ -75,7 +75,7 @@ func addLidarReading(
 // retries on error (offline mode).
 func tryAddLidarReadingUntilSuccess(ctx context.Context, reading []byte, readingTime time.Time, config Config) {
 	/*
-		while add sensor reading fails, keep trying to add the same reading - in offline mode
+		while add lidar reading fails, keep trying to add the same reading - in offline mode
 		we want to process each reading so if we cannot acquire the lock we should try again
 	*/
 	for {
@@ -101,9 +101,9 @@ func tryAddLidarReading(ctx context.Context, reading []byte, readingTime time.Ti
 	err := config.CartoFacade.AddLidarReading(ctx, config.Timeout, config.LidarName, reading, readingTime)
 	if err != nil {
 		if errors.Is(err, cartofacade.ErrUnableToAcquireLock) {
-			config.Logger.Debugw("Skipping sensor reading due to lock contention in cartofacade", "error", err)
+			config.Logger.Debugw("Skipping lidar reading due to lock contention in cartofacade", "error", err)
 		} else {
-			config.Logger.Warnw("Skipping sensor reading due to error from cartofacade", "error", err)
+			config.Logger.Warnw("Skipping lidar reading due to error from cartofacade", "error", err)
 		}
 	}
 	timeElapsedMs := int(time.Since(startTime).Milliseconds())

--- a/sensorprocess/sensorprocess_test.go
+++ b/sensorprocess/sensorprocess_test.go
@@ -47,8 +47,8 @@ func TestAddSensorReadingOffline(t *testing.T) {
 		LidarDataRateMsec: 200,
 		Timeout:           10 * time.Second,
 	}
-	t.Run("When addSensorReading returns successfully, no infinite loop", func(t *testing.T) {
-		cf.AddSensorReadingFunc = func(
+	t.Run("When addLidarReading returns successfully, no infinite loop", func(t *testing.T) {
+		cf.AddLidarReadingFunc = func(
 			ctx context.Context,
 			timeout time.Duration,
 			sensorName string,
@@ -57,11 +57,11 @@ func TestAddSensorReadingOffline(t *testing.T) {
 		) error {
 			return nil
 		}
-		tryAddSensorReadingUntilSuccess(context.Background(), reading, readingTimestamp, config)
+		tryAddLidarReadingUntilSuccess(context.Background(), reading, readingTimestamp, config)
 	})
 
-	t.Run("AddSensorReading returns UNABLE_TO_ACQUIRE_LOCK error and the context is cancelled, no infinite loop", func(t *testing.T) {
-		cf.AddSensorReadingFunc = func(
+	t.Run("AddLidarReading returns UNABLE_TO_ACQUIRE_LOCK error and the context is cancelled, no infinite loop", func(t *testing.T) {
+		cf.AddLidarReadingFunc = func(
 			ctx context.Context,
 			timeout time.Duration,
 			sensorName string,
@@ -73,11 +73,11 @@ func TestAddSensorReadingOffline(t *testing.T) {
 
 		cancelCtx, cancelFunc := context.WithCancel(context.Background())
 		cancelFunc()
-		tryAddSensorReadingUntilSuccess(cancelCtx, reading, readingTimestamp, config)
+		tryAddLidarReadingUntilSuccess(cancelCtx, reading, readingTimestamp, config)
 	})
 
-	t.Run("When AddSensorReading returns a different error and the context is cancelled, no infinite loop", func(t *testing.T) {
-		cf.AddSensorReadingFunc = func(
+	t.Run("When AddLidarReading returns a different error and the context is cancelled, no infinite loop", func(t *testing.T) {
+		cf.AddLidarReadingFunc = func(
 			ctx context.Context,
 			timeout time.Duration,
 			sensorName string,
@@ -89,15 +89,15 @@ func TestAddSensorReadingOffline(t *testing.T) {
 
 		cancelCtx, cancelFunc := context.WithCancel(context.Background())
 		cancelFunc()
-		tryAddSensorReadingUntilSuccess(cancelCtx, reading, readingTimestamp, config)
+		tryAddLidarReadingUntilSuccess(cancelCtx, reading, readingTimestamp, config)
 	})
 
-	t.Run("When AddSensorReading hits errors a few times, retries, and then succeeds", func(t *testing.T) {
+	t.Run("When AddLidarReading hits errors a few times, retries, and then succeeds", func(t *testing.T) {
 		cancelCtx, cancelFunc := context.WithCancel(context.Background())
 
 		var calls []addSensorReadingArgs
 
-		cf.AddSensorReadingFunc = func(
+		cf.AddLidarReadingFunc = func(
 			ctx context.Context,
 			timeout time.Duration,
 			sensorName string,
@@ -119,7 +119,7 @@ func TestAddSensorReadingOffline(t *testing.T) {
 			}
 			return nil
 		}
-		tryAddSensorReadingUntilSuccess(cancelCtx, reading, readingTimestamp, config)
+		tryAddLidarReadingUntilSuccess(cancelCtx, reading, readingTimestamp, config)
 		test.That(t, len(calls), test.ShouldEqual, 4)
 		for i, args := range calls {
 			t.Logf("addSensorReadingArgsHistory %d", i)
@@ -145,8 +145,8 @@ func TestAddSensorReadingOnline(t *testing.T) {
 		Timeout:           10 * time.Second,
 	}
 
-	t.Run("When AddSensorReading blocks for more than the DataFreqHz and succeeds, time to sleep is 0", func(t *testing.T) {
-		cf.AddSensorReadingFunc = func(
+	t.Run("When AddLidarReading blocks for more than the DataFreqHz and succeeds, time to sleep is 0", func(t *testing.T) {
+		cf.AddLidarReadingFunc = func(
 			ctx context.Context,
 			timeout time.Duration,
 			sensorName string,
@@ -157,12 +157,12 @@ func TestAddSensorReadingOnline(t *testing.T) {
 			return nil
 		}
 
-		timeToSleep := tryAddSensorReading(context.Background(), reading, readingTimestamp, config)
+		timeToSleep := tryAddLidarReading(context.Background(), reading, readingTimestamp, config)
 		test.That(t, timeToSleep, test.ShouldEqual, 0)
 	})
 
-	t.Run("AddSensorReading slower than DataFreqHz and returns lock error, time to sleep is 0", func(t *testing.T) {
-		cf.AddSensorReadingFunc = func(
+	t.Run("AddLidarReading slower than DataFreqHz and returns lock error, time to sleep is 0", func(t *testing.T) {
+		cf.AddLidarReadingFunc = func(
 			ctx context.Context,
 			timeout time.Duration,
 			sensorName string,
@@ -173,12 +173,12 @@ func TestAddSensorReadingOnline(t *testing.T) {
 			return cartofacade.ErrUnableToAcquireLock
 		}
 
-		timeToSleep := tryAddSensorReading(context.Background(), reading, readingTimestamp, config)
+		timeToSleep := tryAddLidarReading(context.Background(), reading, readingTimestamp, config)
 		test.That(t, timeToSleep, test.ShouldEqual, 0)
 	})
 
-	t.Run("When AddSensorReading blocks for more than the DataFreqHz and returns an unexpected error, time to sleep is 0", func(t *testing.T) {
-		cf.AddSensorReadingFunc = func(
+	t.Run("When AddLidarReading blocks for more than the DataFreqHz and returns an unexpected error, time to sleep is 0", func(t *testing.T) {
+		cf.AddLidarReadingFunc = func(
 			ctx context.Context,
 			timeout time.Duration,
 			sensorName string,
@@ -189,12 +189,12 @@ func TestAddSensorReadingOnline(t *testing.T) {
 			return errUnknown
 		}
 
-		timeToSleep := tryAddSensorReading(context.Background(), reading, readingTimestamp, config)
+		timeToSleep := tryAddLidarReading(context.Background(), reading, readingTimestamp, config)
 		test.That(t, timeToSleep, test.ShouldEqual, 0)
 	})
 
-	t.Run("AddSensorReading faster than the DataFreqHz and succeeds, time to sleep is <= DataFreqHz", func(t *testing.T) {
-		cf.AddSensorReadingFunc = func(
+	t.Run("AddLidarReading faster than the DataFreqHz and succeeds, time to sleep is <= DataFreqHz", func(t *testing.T) {
+		cf.AddLidarReadingFunc = func(
 			ctx context.Context,
 			timeout time.Duration,
 			sensorName string,
@@ -204,13 +204,13 @@ func TestAddSensorReadingOnline(t *testing.T) {
 			return nil
 		}
 
-		timeToSleep := tryAddSensorReading(context.Background(), reading, readingTimestamp, config)
+		timeToSleep := tryAddLidarReading(context.Background(), reading, readingTimestamp, config)
 		test.That(t, timeToSleep, test.ShouldBeGreaterThan, 0)
 		test.That(t, timeToSleep, test.ShouldBeLessThanOrEqualTo, config.LidarDataRateMsec)
 	})
 
-	t.Run("AddSensorReading faster than the DataFreqHz and returns lock error, time to sleep is <= DataFreqHz", func(t *testing.T) {
-		cf.AddSensorReadingFunc = func(
+	t.Run("AddLidarReading faster than the DataFreqHz and returns lock error, time to sleep is <= DataFreqHz", func(t *testing.T) {
+		cf.AddLidarReadingFunc = func(
 			ctx context.Context,
 			timeout time.Duration,
 			sensorName string,
@@ -220,13 +220,13 @@ func TestAddSensorReadingOnline(t *testing.T) {
 			return cartofacade.ErrUnableToAcquireLock
 		}
 
-		timeToSleep := tryAddSensorReading(context.Background(), reading, readingTimestamp, config)
+		timeToSleep := tryAddLidarReading(context.Background(), reading, readingTimestamp, config)
 		test.That(t, timeToSleep, test.ShouldBeGreaterThan, 0)
 		test.That(t, timeToSleep, test.ShouldBeLessThanOrEqualTo, config.LidarDataRateMsec)
 	})
 
-	t.Run("AddSensorReading faster than DataFreqHz and returns unexpected error, time to sleep is <= DataFreqHz", func(t *testing.T) {
-		cf.AddSensorReadingFunc = func(
+	t.Run("AddLidarReading faster than DataFreqHz and returns unexpected error, time to sleep is <= DataFreqHz", func(t *testing.T) {
+		cf.AddLidarReadingFunc = func(
 			ctx context.Context,
 			timeout time.Duration,
 			sensorName string,
@@ -236,7 +236,7 @@ func TestAddSensorReadingOnline(t *testing.T) {
 			return errUnknown
 		}
 
-		timeToSleep := tryAddSensorReading(context.Background(), reading, readingTimestamp, config)
+		timeToSleep := tryAddLidarReading(context.Background(), reading, readingTimestamp, config)
 		test.That(t, timeToSleep, test.ShouldBeGreaterThan, 0)
 		test.That(t, timeToSleep, test.ShouldBeLessThanOrEqualTo, config.LidarDataRateMsec)
 	})
@@ -254,7 +254,7 @@ func onlineModeTestHelper(
 	test.That(t, err, test.ShouldBeNil)
 
 	var calls []addSensorReadingArgs
-	cf.AddSensorReadingFunc = func(
+	cf.AddLidarReadingFunc = func(
 		ctx context.Context,
 		timeout time.Duration,
 		sensorName string,
@@ -282,15 +282,15 @@ func onlineModeTestHelper(
 	config.LidarName = onlineSensor.Name
 	config.LidarDataRateMsec = 10
 
-	jobDone := addSensorReading(ctx, config)
+	jobDone := addLidarReading(ctx, config)
 	test.That(t, len(calls), test.ShouldEqual, 1)
 	test.That(t, jobDone, test.ShouldBeFalse)
 
-	jobDone = addSensorReading(ctx, config)
+	jobDone = addLidarReading(ctx, config)
 	test.That(t, len(calls), test.ShouldEqual, 2)
 	test.That(t, jobDone, test.ShouldBeFalse)
 
-	jobDone = addSensorReading(ctx, config)
+	jobDone = addLidarReading(ctx, config)
 	test.That(t, len(calls), test.ShouldEqual, 3)
 	test.That(t, jobDone, test.ShouldBeFalse)
 
@@ -324,11 +324,11 @@ func invalidSensorTestHelper(
 	lidarDataRateMsec int,
 ) {
 	logger := golog.NewTestLogger(t)
-	sensor, err := s.NewLidar(context.Background(), s.SetupDeps(cameraName, ""), cameraName, logger)
+	lidar, err := s.NewLidar(context.Background(), s.SetupDeps(cameraName, ""), cameraName, logger)
 	test.That(t, err, test.ShouldBeNil)
 
 	var calls []addSensorReadingArgs
-	cartoFacadeMock.AddSensorReadingFunc = func(
+	cartoFacadeMock.AddLidarReadingFunc = func(
 		ctx context.Context,
 		timeout time.Duration,
 		sensorName string,
@@ -344,11 +344,11 @@ func invalidSensorTestHelper(
 		calls = append(calls, args)
 		return nil
 	}
-	config.Lidar = sensor
-	config.LidarName = sensor.Name
+	config.Lidar = lidar
+	config.LidarName = lidar.Name
 	config.LidarDataRateMsec = lidarDataRateMsec
 
-	jobDone := addSensorReading(ctx, config)
+	jobDone := addLidarReading(ctx, config)
 	test.That(t, len(calls), test.ShouldEqual, 0)
 	test.That(t, jobDone, test.ShouldBeFalse)
 }
@@ -365,7 +365,7 @@ func TestAddSensorReading(t *testing.T) {
 	}
 	ctx := context.Background()
 
-	t.Run("returns error in online mode when lidar GetData returns error, doesn't try to add sensor data", func(t *testing.T) {
+	t.Run("returns error in online mode when lidar GetData returns error, doesn't try to add lidar data", func(t *testing.T) {
 		cam := "invalid_lidar"
 		invalidSensorTestHelper(
 			ctx,
@@ -396,7 +396,7 @@ func TestAddSensorReading(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 
 		var calls []addSensorReadingArgs
-		cf.AddSensorReadingFunc = func(
+		cf.AddLidarReadingFunc = func(
 			ctx context.Context,
 			timeout time.Duration,
 			sensorName string,
@@ -422,7 +422,7 @@ func TestAddSensorReading(t *testing.T) {
 		config.LidarName = replaySensor.Name
 		config.LidarDataRateMsec = 0
 
-		jobDone := addSensorReading(ctx, config)
+		jobDone := addLidarReading(ctx, config)
 		test.That(t, len(calls), test.ShouldEqual, 3)
 		test.That(t, jobDone, test.ShouldBeFalse)
 
@@ -453,7 +453,7 @@ func TestAddSensorReading(t *testing.T) {
 		config.Lidar = replaySensor
 		config.LidarDataRateMsec = 0
 
-		jobDone := addSensorReading(ctx, config)
+		jobDone := addLidarReading(ctx, config)
 		test.That(t, jobDone, test.ShouldBeTrue)
 	})
 }

--- a/viam-cartographer/src/carto_facade/carto_facade.cc
+++ b/viam-cartographer/src/carto_facade/carto_facade.cc
@@ -748,29 +748,29 @@ void CartoFacade::Stop() {
     StopSaveInternalState();
 };
 
-void CartoFacade::AddSensorReading(const viam_carto_sensor_reading *sr) {
+void CartoFacade::AddLidarReading(const viam_carto_lidar_reading *sr) {
     if (state != CartoFacadeState::STARTED) {
         LOG(ERROR) << "carto facade is in state: " << state
                    << " expected it to be in state: "
                    << CartoFacadeState::STARTED;
         throw VIAM_CARTO_NOT_IN_STARTED_STATE;
     }
-    if (biseq(config.component_reference, sr->sensor) == false) {
-        VLOG(1) << "expected sensor: " << to_std_string(sr->sensor) << " to be "
+    if (biseq(config.component_reference, sr->lidar) == false) {
+        VLOG(1) << "expected sensor: " << to_std_string(sr->lidar) << " to be "
                 << config.component_reference;
         throw VIAM_CARTO_SENSOR_NOT_IN_SENSOR_LIST;
     }
-    std::string sensor_reading = to_std_string(sr->sensor_reading);
-    if (sensor_reading.length() == 0) {
-        throw VIAM_CARTO_SENSOR_READING_EMPTY;
+    std::string lidar_reading = to_std_string(sr->lidar_reading);
+    if (lidar_reading.length() == 0) {
+        throw VIAM_CARTO_LIDAR_READING_EMPTY;
     }
 
-    int64_t sensor_reading_time_unix_milli = sr->sensor_reading_time_unix_milli;
+    int64_t lidar_reading_time_unix_milli = sr->lidar_reading_time_unix_milli;
     auto [success, measurement] =
         viam::carto_facade::util::carto_sensor_reading(
-            sensor_reading, sensor_reading_time_unix_milli);
+            lidar_reading, lidar_reading_time_unix_milli);
     if (!success) {
-        throw VIAM_CARTO_SENSOR_READING_INVALID;
+        throw VIAM_CARTO_LIDAR_READING_INVALID;
     }
 
     cartographer::transform::Rigid3d tmp_global_pose;
@@ -1025,20 +1025,20 @@ extern int viam_carto_terminate(viam_carto **ppVC) {
     return VIAM_CARTO_SUCCESS;
 };
 
-extern int viam_carto_add_sensor_reading(viam_carto *vc,
-                                         const viam_carto_sensor_reading *sr) {
+extern int viam_carto_add_lidar_reading(viam_carto *vc,
+                                         const viam_carto_lidar_reading *sr) {
     if (vc == nullptr) {
         return VIAM_CARTO_VC_INVALID;
     }
 
     if (sr == nullptr) {
-        return VIAM_CARTO_SENSOR_READING_INVALID;
+        return VIAM_CARTO_LIDAR_READING_INVALID;
     }
 
     try {
         viam::carto_facade::CartoFacade *cf =
             static_cast<viam::carto_facade::CartoFacade *>(vc->carto_obj);
-        cf->AddSensorReading(sr);
+        cf->AddLidarReading(sr);
     } catch (int err) {
         return err;
     } catch (std::exception &e) {
@@ -1048,26 +1048,26 @@ extern int viam_carto_add_sensor_reading(viam_carto *vc,
     return VIAM_CARTO_SUCCESS;
 };
 
-extern int viam_carto_add_sensor_reading_destroy(
-    viam_carto_sensor_reading *sr) {
+extern int viam_carto_add_lidar_reading_destroy(
+    viam_carto_lidar_reading *sr) {
     if (sr == nullptr) {
-        return VIAM_CARTO_SENSOR_READING_INVALID;
+        return VIAM_CARTO_LIDAR_READING_INVALID;
     }
     int return_code = VIAM_CARTO_SUCCESS;
     int rc = BSTR_OK;
-    // destroy sensor_reading
-    rc = bdestroy(sr->sensor_reading);
+    // destroy lidar_reading
+    rc = bdestroy(sr->lidar_reading);
     if (rc != BSTR_OK) {
         return_code = VIAM_CARTO_DESTRUCTOR_ERROR;
     }
-    sr->sensor_reading = nullptr;
+    sr->lidar_reading = nullptr;
 
     // destroy sensor
-    rc = bdestroy(sr->sensor);
+    rc = bdestroy(sr->lidar);
     if (rc != BSTR_OK) {
         return_code = VIAM_CARTO_DESTRUCTOR_ERROR;
     }
-    sr->sensor = nullptr;
+    sr->lidar = nullptr;
 
     return return_code;
 };

--- a/viam-cartographer/src/carto_facade/carto_facade.cc
+++ b/viam-cartographer/src/carto_facade/carto_facade.cc
@@ -766,9 +766,8 @@ void CartoFacade::AddLidarReading(const viam_carto_lidar_reading *sr) {
     }
 
     int64_t lidar_reading_time_unix_milli = sr->lidar_reading_time_unix_milli;
-    auto [success, measurement] =
-        viam::carto_facade::util::carto_lidar_reading(
-            lidar_reading, lidar_reading_time_unix_milli);
+    auto [success, measurement] = viam::carto_facade::util::carto_lidar_reading(
+        lidar_reading, lidar_reading_time_unix_milli);
     if (!success) {
         throw VIAM_CARTO_LIDAR_READING_INVALID;
     }
@@ -1026,7 +1025,7 @@ extern int viam_carto_terminate(viam_carto **ppVC) {
 };
 
 extern int viam_carto_add_lidar_reading(viam_carto *vc,
-                                         const viam_carto_lidar_reading *sr) {
+                                        const viam_carto_lidar_reading *sr) {
     if (vc == nullptr) {
         return VIAM_CARTO_VC_INVALID;
     }
@@ -1048,8 +1047,7 @@ extern int viam_carto_add_lidar_reading(viam_carto *vc,
     return VIAM_CARTO_SUCCESS;
 };
 
-extern int viam_carto_add_lidar_reading_destroy(
-    viam_carto_lidar_reading *sr) {
+extern int viam_carto_add_lidar_reading_destroy(viam_carto_lidar_reading *sr) {
     if (sr == nullptr) {
         return VIAM_CARTO_LIDAR_READING_INVALID;
     }

--- a/viam-cartographer/src/carto_facade/carto_facade.cc
+++ b/viam-cartographer/src/carto_facade/carto_facade.cc
@@ -767,7 +767,7 @@ void CartoFacade::AddLidarReading(const viam_carto_lidar_reading *sr) {
 
     int64_t lidar_reading_time_unix_milli = sr->lidar_reading_time_unix_milli;
     auto [success, measurement] =
-        viam::carto_facade::util::carto_sensor_reading(
+        viam::carto_facade::util::carto_lidar_reading(
             lidar_reading, lidar_reading_time_unix_milli);
     if (!success) {
         throw VIAM_CARTO_LIDAR_READING_INVALID;

--- a/viam-cartographer/src/carto_facade/carto_facade.h
+++ b/viam-cartographer/src/carto_facade/carto_facade.h
@@ -199,8 +199,8 @@ extern int viam_carto_terminate(viam_carto **vc  //
 // An expected error is VIAM_CARTO_UNABLE_TO_ACQUIRE_LOCK(1)
 //
 // On success: Returns 0, adds lidar reading to cartographer's data model
-extern int viam_carto_add_lidar_reading(viam_carto *vc,                      //
-                                         const viam_carto_lidar_reading *sr  //
+extern int viam_carto_add_lidar_reading(viam_carto *vc,                     //
+                                        const viam_carto_lidar_reading *sr  //
 );
 
 // viam_carto_add_lidar_reading_destroy/2 takes a viam_carto pointer
@@ -208,8 +208,7 @@ extern int viam_carto_add_lidar_reading(viam_carto *vc,                      //
 // On error: Returns a non 0 error code
 //
 // On success: Returns 0, frees the viam_carto_lidar_reading.
-extern int viam_carto_add_lidar_reading_destroy(
-    viam_carto_lidar_reading *sr  //
+extern int viam_carto_add_lidar_reading_destroy(viam_carto_lidar_reading *sr  //
 );
 
 // viam_carto_get_position/3 takes a viam_carto pointer, a

--- a/viam-cartographer/src/carto_facade/carto_facade.h
+++ b/viam-cartographer/src/carto_facade/carto_facade.h
@@ -67,11 +67,11 @@ typedef struct viam_carto_get_internal_state_response {
     bstring internal_state;
 } viam_carto_get_internal_state_response;
 
-typedef struct viam_carto_sensor_reading {
-    bstring sensor;
-    bstring sensor_reading;
-    int64_t sensor_reading_time_unix_milli;
-} viam_carto_sensor_reading;
+typedef struct viam_carto_lidar_reading {
+    bstring lidar;
+    bstring lidar_reading;
+    int64_t lidar_reading_time_unix_milli;
+} viam_carto_lidar_reading;
 
 typedef enum viam_carto_LIDAR_CONFIG {
     VIAM_CARTO_TWO_D = 0,
@@ -98,8 +98,8 @@ typedef enum viam_carto_LIDAR_CONFIG {
 #define VIAM_CARTO_DATA_DIR_FILE_SYSTEM_ERROR 17
 #define VIAM_CARTO_MAP_CREATION_ERROR 18
 #define VIAM_CARTO_SENSOR_NOT_IN_SENSOR_LIST 19
-#define VIAM_CARTO_SENSOR_READING_EMPTY 20
-#define VIAM_CARTO_SENSOR_READING_INVALID 21
+#define VIAM_CARTO_LIDAR_READING_EMPTY 20
+#define VIAM_CARTO_LIDAR_READING_INVALID 21
 #define VIAM_CARTO_GET_POSITION_RESPONSE_INVALID 22
 #define VIAM_CARTO_POINTCLOUD_MAP_EMPTY 23
 #define VIAM_CARTO_GET_POINT_CLOUD_MAP_RESPONSE_INVLALID 24
@@ -191,25 +191,25 @@ extern int viam_carto_stop(viam_carto *vc  // OUT
 extern int viam_carto_terminate(viam_carto **vc  //
 );
 
-// viam_carto_add_sensor_reading/3 takes a viam_carto pointer, a
-// viam_carto_sensor_reading
+// viam_carto_add_lidar_reading/3 takes a viam_carto pointer, a
+// viam_carto_lidar_reading
 //
 // On error: Returns a non 0 error code
 //
 // An expected error is VIAM_CARTO_UNABLE_TO_ACQUIRE_LOCK(1)
 //
 // On success: Returns 0, adds lidar reading to cartographer's data model
-extern int viam_carto_add_sensor_reading(viam_carto *vc,                      //
-                                         const viam_carto_sensor_reading *sr  //
+extern int viam_carto_add_lidar_reading(viam_carto *vc,                      //
+                                         const viam_carto_lidar_reading *sr  //
 );
 
-// viam_carto_add_sensor_reading_destroy/2 takes a viam_carto pointer
+// viam_carto_add_lidar_reading_destroy/2 takes a viam_carto pointer
 //
 // On error: Returns a non 0 error code
 //
-// On success: Returns 0, frees the viam_carto_sensor_reading.
-extern int viam_carto_add_sensor_reading_destroy(
-    viam_carto_sensor_reading *sr  //
+// On success: Returns 0, frees the viam_carto_lidar_reading.
+extern int viam_carto_add_lidar_reading_destroy(
+    viam_carto_lidar_reading *sr  //
 );
 
 // viam_carto_get_position/3 takes a viam_carto pointer, a
@@ -354,7 +354,7 @@ class CartoFacade {
     // maximumGRPCByteChunkSize
     void GetInternalState(viam_carto_get_internal_state_response *r);
 
-    void AddSensorReading(const viam_carto_sensor_reading *sr);
+    void AddLidarReading(const viam_carto_lidar_reading *sr);
 
     void Start();
 

--- a/viam-cartographer/src/carto_facade/carto_facade_test.cc
+++ b/viam-cartographer/src/carto_facade/carto_facade_test.cc
@@ -905,8 +905,7 @@ BOOST_AUTO_TEST_CASE(CartoFacade_demo) {
         viam_carto_lidar_reading sr = new_test_lidar_reading(
             "lidar", ".artifact/data/viam-cartographer/mock_lidar/0.pcd",
             1629037851000000);
-        BOOST_TEST(viam_carto_add_lidar_reading(vc, &sr) ==
-                   VIAM_CARTO_SUCCESS);
+        BOOST_TEST(viam_carto_add_lidar_reading(vc, &sr) == VIAM_CARTO_SUCCESS);
         BOOST_TEST(viam_carto_add_lidar_reading_destroy(&sr) ==
                    VIAM_CARTO_SUCCESS);
     }
@@ -952,8 +951,7 @@ BOOST_AUTO_TEST_CASE(CartoFacade_demo) {
         viam_carto_lidar_reading sr = new_test_lidar_reading(
             "lidar", ".artifact/data/viam-cartographer/mock_lidar/1.pcd",
             1629037853000000);
-        BOOST_TEST(viam_carto_add_lidar_reading(vc, &sr) ==
-                   VIAM_CARTO_SUCCESS);
+        BOOST_TEST(viam_carto_add_lidar_reading(vc, &sr) == VIAM_CARTO_SUCCESS);
         BOOST_TEST(viam_carto_add_lidar_reading_destroy(&sr) ==
                    VIAM_CARTO_SUCCESS);
     }
@@ -1010,8 +1008,7 @@ BOOST_AUTO_TEST_CASE(CartoFacade_demo) {
         viam_carto_lidar_reading sr = new_test_lidar_reading(
             "lidar", ".artifact/data/viam-cartographer/mock_lidar/2.pcd",
             1629037855000000);
-        BOOST_TEST(viam_carto_add_lidar_reading(vc, &sr) ==
-                   VIAM_CARTO_SUCCESS);
+        BOOST_TEST(viam_carto_add_lidar_reading(vc, &sr) == VIAM_CARTO_SUCCESS);
         BOOST_TEST(viam_carto_add_lidar_reading_destroy(&sr) ==
                    VIAM_CARTO_SUCCESS);
     }

--- a/viam-cartographer/src/carto_facade/carto_facade_test.cc
+++ b/viam-cartographer/src/carto_facade/carto_facade_test.cc
@@ -48,15 +48,15 @@ void viam_carto_config_teardown(viam_carto_config vcc) {
     BOOST_TEST(bdestroy(vcc.camera) == BSTR_OK);
     BOOST_TEST(bdestroy(vcc.movement_sensor) == BSTR_OK);
 }
-viam_carto_sensor_reading new_test_sensor_reading(
-    std::string sensor, std::string pcd_path,
-    int64_t sensor_reading_time_unix_milli) {
-    viam_carto_sensor_reading sr;
-    sr.sensor = bfromcstr(sensor.c_str());
+viam_carto_lidar_reading new_test_sensor_reading(
+    std::string lidar, std::string pcd_path,
+    int64_t lidar_reading_time_unix_milli) {
+    viam_carto_lidar_reading sr;
+    sr.lidar = bfromcstr(lidar.c_str());
     std::string pcd = help::read_file(pcd_path);
-    sr.sensor_reading = blk2bstr(pcd.c_str(), pcd.length());
-    BOOST_TEST(sr.sensor_reading != nullptr);
-    sr.sensor_reading_time_unix_milli = sensor_reading_time_unix_milli;
+    sr.lidar_reading = blk2bstr(pcd.c_str(), pcd.length());
+    BOOST_TEST(sr.lidar_reading != nullptr);
+    sr.lidar_reading_time_unix_milli = lidar_reading_time_unix_milli;
     return sr;
 }
 
@@ -676,16 +676,16 @@ BOOST_AUTO_TEST_CASE(CartoFacade_demo) {
     BOOST_TEST(vc->slam_mode == VIAM_CARTO_SLAM_MODE_MAPPING);
 
     // behavior of methods before start
-    // AddSensorReading
+    // AddLidarReading
     {
-        viam_carto_sensor_reading sr = new_test_sensor_reading(
+        viam_carto_lidar_reading sr = new_test_sensor_reading(
             "lidar", ".artifact/data/viam-cartographer/mock_lidar/0.pcd",
             1687900053773475);
         viam::carto_facade::CartoFacade *cf =
             static_cast<viam::carto_facade::CartoFacade *>(vc->carto_obj);
-        BOOST_TEST(viam_carto_add_sensor_reading(vc, &sr) ==
+        BOOST_TEST(viam_carto_add_lidar_reading(vc, &sr) ==
                    VIAM_CARTO_NOT_IN_STARTED_STATE);
-        BOOST_TEST(viam_carto_add_sensor_reading_destroy(&sr) ==
+        BOOST_TEST(viam_carto_add_lidar_reading_destroy(&sr) ==
                    VIAM_CARTO_SUCCESS);
     }
 
@@ -750,89 +750,90 @@ BOOST_AUTO_TEST_CASE(CartoFacade_demo) {
         {0.007000, 0.006000, 0.001000, 16711938}};
     // vc nullptr
     {
-        BOOST_TEST(viam_carto_add_sensor_reading(nullptr, nullptr) ==
+        BOOST_TEST(viam_carto_add_lidar_reading(nullptr, nullptr) ==
                    VIAM_CARTO_VC_INVALID);
     }
 
-    // viam_carto_sensor_reading nullptr
+    // viam_carto_lidar_reading nullptr
     {
-        BOOST_TEST(viam_carto_add_sensor_reading(vc, nullptr) ==
-                   VIAM_CARTO_SENSOR_READING_INVALID);
+        BOOST_TEST(viam_carto_add_lidar_reading(vc, nullptr) ==
+                   VIAM_CARTO_LIDAR_READING_INVALID);
     }
-    BOOST_TEST(viam_carto_add_sensor_reading_destroy(nullptr) ==
-               VIAM_CARTO_SENSOR_READING_INVALID);
+    BOOST_TEST(viam_carto_add_lidar_reading_destroy(nullptr) ==
+               VIAM_CARTO_LIDAR_READING_INVALID);
 
     {
-        viam_carto_sensor_reading sr;
+        viam_carto_lidar_reading sr;
         // must be they first sensor in the sensor list
-        sr.sensor = bfromcstr("never heard of it sensor");
+        sr.lidar = bfromcstr("never heard of it sensor");
         std::string pcd = help::binary_pcd(points);
-        sr.sensor_reading = blk2bstr(pcd.c_str(), pcd.length());
-        BOOST_TEST(sr.sensor_reading != nullptr);
-        sr.sensor_reading_time_unix_milli = 1687899990420347;
-        BOOST_TEST(viam_carto_add_sensor_reading(vc, &sr) ==
+        sr.lidar_reading = blk2bstr(pcd.c_str(), pcd.length());
+        BOOST_TEST(sr.lidar_reading != nullptr);
+        sr.lidar_reading_time_unix_milli = 1687899990420347;
+        BOOST_TEST(viam_carto_add_lidar_reading(vc, &sr) ==
                    VIAM_CARTO_SENSOR_NOT_IN_SENSOR_LIST);
-        BOOST_TEST(viam_carto_add_sensor_reading_destroy(&sr) ==
+        BOOST_TEST(viam_carto_add_lidar_reading_destroy(&sr) ==
                    VIAM_CARTO_SUCCESS);
     }
 
+    // PATRICIA REVISIT
     // non first sensor
     {
-        viam_carto_sensor_reading sr;
+        viam_carto_lidar_reading sr;
         // must be they first sensor in the sensor list
-        sr.sensor = bfromcstr("sensor_2");
+        sr.lidar = bfromcstr("sensor_2");
         std::string pcd = help::binary_pcd(points);
-        sr.sensor_reading = blk2bstr(pcd.c_str(), pcd.length());
-        BOOST_TEST(sr.sensor_reading != nullptr);
-        sr.sensor_reading_time_unix_milli = 1687900014152474;
-        BOOST_TEST(viam_carto_add_sensor_reading(vc, &sr) ==
+        sr.lidar_reading = blk2bstr(pcd.c_str(), pcd.length());
+        BOOST_TEST(sr.lidar_reading != nullptr);
+        sr.lidar_reading_time_unix_milli = 1687900014152474;
+        BOOST_TEST(viam_carto_add_lidar_reading(vc, &sr) ==
                    VIAM_CARTO_SENSOR_NOT_IN_SENSOR_LIST);
-        BOOST_TEST(viam_carto_add_sensor_reading_destroy(&sr) ==
+        BOOST_TEST(viam_carto_add_lidar_reading_destroy(&sr) ==
                    VIAM_CARTO_SUCCESS);
     }
 
     // empty sensor reading
     {
-        viam_carto_sensor_reading sr;
+        viam_carto_lidar_reading sr;
         // must be they first sensor in the sensor list
-        sr.sensor = bfromcstr("lidar");
+        sr.lidar = bfromcstr("lidar");
         std::string pcd = "empty lidar reading";
         // passing 0 as the second parameter makes the string empty
-        sr.sensor_reading = blk2bstr(pcd.c_str(), 0);
-        BOOST_TEST(sr.sensor_reading != nullptr);
-        sr.sensor_reading_time_unix_milli = 1687900021820215;
-        BOOST_TEST(viam_carto_add_sensor_reading(vc, &sr) ==
-                   VIAM_CARTO_SENSOR_READING_EMPTY);
-        BOOST_TEST(viam_carto_add_sensor_reading_destroy(&sr) ==
+        sr.lidar_reading = blk2bstr(pcd.c_str(), 0);
+        BOOST_TEST(sr.lidar_reading != nullptr);
+        sr.lidar_reading_time_unix_milli = 1687900021820215;
+        BOOST_TEST(viam_carto_add_lidar_reading(vc, &sr) ==
+                   VIAM_CARTO_LIDAR_READING_EMPTY);
+        BOOST_TEST(viam_carto_add_lidar_reading_destroy(&sr) ==
                    VIAM_CARTO_SUCCESS);
     }
 
     // invalid reading
     {
-        viam_carto_sensor_reading sr;
+        viam_carto_lidar_reading sr;
         // must be they first sensor in the sensor list
-        sr.sensor = bfromcstr("lidar");
+        sr.lidar = bfromcstr("lidar");
         std::string pcd = "invalid lidar reading";
-        sr.sensor_reading = blk2bstr(pcd.c_str(), pcd.length());
-        BOOST_TEST(sr.sensor_reading != nullptr);
-        sr.sensor_reading_time_unix_milli = 1687900029557335;
-        BOOST_TEST(viam_carto_add_sensor_reading(vc, &sr) ==
-                   VIAM_CARTO_SENSOR_READING_INVALID);
-        BOOST_TEST(viam_carto_add_sensor_reading_destroy(&sr) ==
+        sr.lidar_reading = blk2bstr(pcd.c_str(), pcd.length());
+        BOOST_TEST(sr.lidar_reading != nullptr);
+        sr.lidar_reading_time_unix_milli = 1687900029557335;
+        BOOST_TEST(viam_carto_add_lidar_reading(vc, &sr) ==
+                   VIAM_CARTO_LIDAR_READING_INVALID);
+        BOOST_TEST(viam_carto_add_lidar_reading_destroy(&sr) ==
                    VIAM_CARTO_SUCCESS);
     }
 
     // unable to aquire lock
     {
-        viam_carto_sensor_reading sr = new_test_sensor_reading(
+        viam_carto_lidar_reading sr = new_test_sensor_reading(
             "lidar", ".artifact/data/viam-cartographer/mock_lidar/0.pcd",
             1687900053773475);
         viam::carto_facade::CartoFacade *cf =
             static_cast<viam::carto_facade::CartoFacade *>(vc->carto_obj);
         std::lock_guard<std::mutex> lk(cf->map_builder_mutex);
-        BOOST_TEST(viam_carto_add_sensor_reading(vc, &sr) ==
+        BOOST_TEST(viam_carto_add_lidar_reading(vc, &sr) ==
                    VIAM_CARTO_UNABLE_TO_ACQUIRE_LOCK);
-        BOOST_TEST(viam_carto_add_sensor_reading_destroy(&sr) ==
+        BOOST_TEST(viam_carto_add_lidar_reading_destroy(&sr) ==
                    VIAM_CARTO_SUCCESS);
     }
 
@@ -870,7 +871,7 @@ BOOST_AUTO_TEST_CASE(CartoFacade_demo) {
                    VIAM_CARTO_SUCCESS);
     }
 
-    // GetPosition unchanged from failed AddSensorReading requests
+    // GetPosition unchanged from failed AddLidarReading requests
     {
         viam_carto_get_position_response pr;
         // Test get position before any data is provided
@@ -889,7 +890,7 @@ BOOST_AUTO_TEST_CASE(CartoFacade_demo) {
                    VIAM_CARTO_SUCCESS);
     }
 
-    // GetPosition is unchanged from first AddSensorReading request
+    // GetPosition is unchanged from first AddLidarReading request
     // as cartographer needs at least 3 lidar readings to compute a
     // position and the first position computed is zero.
     // As a result it takes a minimum of 3 lidar readings before
@@ -900,13 +901,13 @@ BOOST_AUTO_TEST_CASE(CartoFacade_demo) {
 
     // first sensor reading
     {
-        VLOG(1) << "viam_carto_add_sensor_reading 1";
-        viam_carto_sensor_reading sr = new_test_sensor_reading(
+        VLOG(1) << "viam_carto_add_lidar_reading 1";
+        viam_carto_lidar_reading sr = new_test_sensor_reading(
             "lidar", ".artifact/data/viam-cartographer/mock_lidar/0.pcd",
             1629037851000000);
-        BOOST_TEST(viam_carto_add_sensor_reading(vc, &sr) ==
+        BOOST_TEST(viam_carto_add_lidar_reading(vc, &sr) ==
                    VIAM_CARTO_SUCCESS);
-        BOOST_TEST(viam_carto_add_sensor_reading_destroy(&sr) ==
+        BOOST_TEST(viam_carto_add_lidar_reading_destroy(&sr) ==
                    VIAM_CARTO_SUCCESS);
     }
 
@@ -936,7 +937,7 @@ BOOST_AUTO_TEST_CASE(CartoFacade_demo) {
         viam_carto_get_internal_state_response isr;
         BOOST_TEST(viam_carto_get_internal_state(vc, &isr) ==
                    VIAM_CARTO_SUCCESS);
-        // special case: the first call to AddSensorReading doesn't
+        // special case: the first call to AddLidarReading doesn't
         // change the internal state but subsequent calls do.
         BOOST_TEST(blength(isr.internal_state) ==
                    last_internal_state_response_size);
@@ -947,17 +948,17 @@ BOOST_AUTO_TEST_CASE(CartoFacade_demo) {
 
     // second sensor reading
     {
-        VLOG(1) << "viam_carto_add_sensor_reading 2";
-        viam_carto_sensor_reading sr = new_test_sensor_reading(
+        VLOG(1) << "viam_carto_add_lidar_reading 2";
+        viam_carto_lidar_reading sr = new_test_sensor_reading(
             "lidar", ".artifact/data/viam-cartographer/mock_lidar/1.pcd",
             1629037853000000);
-        BOOST_TEST(viam_carto_add_sensor_reading(vc, &sr) ==
+        BOOST_TEST(viam_carto_add_lidar_reading(vc, &sr) ==
                    VIAM_CARTO_SUCCESS);
-        BOOST_TEST(viam_carto_add_sensor_reading_destroy(&sr) ==
+        BOOST_TEST(viam_carto_add_lidar_reading_destroy(&sr) ==
                    VIAM_CARTO_SUCCESS);
     }
 
-    // GetPosition returning origin position from 2 successful AddSensorReading
+    // GetPosition returning origin position from 2 successful AddLidarReading
     // requests
     {
         viam_carto_get_position_response pr;
@@ -1005,17 +1006,17 @@ BOOST_AUTO_TEST_CASE(CartoFacade_demo) {
 
     // third sensor reading
     {
-        VLOG(1) << "viam_carto_add_sensor_reading 3";
-        viam_carto_sensor_reading sr = new_test_sensor_reading(
+        VLOG(1) << "viam_carto_add_lidar_reading 3";
+        viam_carto_lidar_reading sr = new_test_sensor_reading(
             "lidar", ".artifact/data/viam-cartographer/mock_lidar/2.pcd",
             1629037855000000);
-        BOOST_TEST(viam_carto_add_sensor_reading(vc, &sr) ==
+        BOOST_TEST(viam_carto_add_lidar_reading(vc, &sr) ==
                    VIAM_CARTO_SUCCESS);
-        BOOST_TEST(viam_carto_add_sensor_reading_destroy(&sr) ==
+        BOOST_TEST(viam_carto_add_lidar_reading_destroy(&sr) ==
                    VIAM_CARTO_SUCCESS);
     }
 
-    // GetPosition changed from 3 successful AddSensorReading requests
+    // GetPosition changed from 3 successful AddLidarReading requests
     {
         viam_carto_get_position_response pr;
         BOOST_TEST(viam_carto_get_position(vc, &pr) == VIAM_CARTO_SUCCESS);
@@ -1052,16 +1053,16 @@ BOOST_AUTO_TEST_CASE(CartoFacade_demo) {
     BOOST_TEST(viam_carto_stop(vc) == VIAM_CARTO_NOT_IN_STARTED_STATE);
 
     // behavior of methods after stop
-    // AddSensorReading
+    // AddLidarReading
     {
-        viam_carto_sensor_reading sr = new_test_sensor_reading(
+        viam_carto_lidar_reading sr = new_test_sensor_reading(
             "lidar", ".artifact/data/viam-cartographer/mock_lidar/0.pcd",
             1687900053773475);
         viam::carto_facade::CartoFacade *cf =
             static_cast<viam::carto_facade::CartoFacade *>(vc->carto_obj);
-        BOOST_TEST(viam_carto_add_sensor_reading(vc, &sr) ==
+        BOOST_TEST(viam_carto_add_lidar_reading(vc, &sr) ==
                    VIAM_CARTO_NOT_IN_STARTED_STATE);
-        BOOST_TEST(viam_carto_add_sensor_reading_destroy(&sr) ==
+        BOOST_TEST(viam_carto_add_lidar_reading_destroy(&sr) ==
                    VIAM_CARTO_SUCCESS);
     }
 

--- a/viam-cartographer/src/carto_facade/carto_facade_test.cc
+++ b/viam-cartographer/src/carto_facade/carto_facade_test.cc
@@ -48,7 +48,7 @@ void viam_carto_config_teardown(viam_carto_config vcc) {
     BOOST_TEST(bdestroy(vcc.camera) == BSTR_OK);
     BOOST_TEST(bdestroy(vcc.movement_sensor) == BSTR_OK);
 }
-viam_carto_lidar_reading new_test_sensor_reading(
+viam_carto_lidar_reading new_test_lidar_reading(
     std::string lidar, std::string pcd_path,
     int64_t lidar_reading_time_unix_milli) {
     viam_carto_lidar_reading sr;
@@ -678,7 +678,7 @@ BOOST_AUTO_TEST_CASE(CartoFacade_demo) {
     // behavior of methods before start
     // AddLidarReading
     {
-        viam_carto_lidar_reading sr = new_test_sensor_reading(
+        viam_carto_lidar_reading sr = new_test_lidar_reading(
             "lidar", ".artifact/data/viam-cartographer/mock_lidar/0.pcd",
             1687900053773475);
         viam::carto_facade::CartoFacade *cf =
@@ -825,7 +825,7 @@ BOOST_AUTO_TEST_CASE(CartoFacade_demo) {
 
     // unable to aquire lock
     {
-        viam_carto_lidar_reading sr = new_test_sensor_reading(
+        viam_carto_lidar_reading sr = new_test_lidar_reading(
             "lidar", ".artifact/data/viam-cartographer/mock_lidar/0.pcd",
             1687900053773475);
         viam::carto_facade::CartoFacade *cf =
@@ -902,7 +902,7 @@ BOOST_AUTO_TEST_CASE(CartoFacade_demo) {
     // first sensor reading
     {
         VLOG(1) << "viam_carto_add_lidar_reading 1";
-        viam_carto_lidar_reading sr = new_test_sensor_reading(
+        viam_carto_lidar_reading sr = new_test_lidar_reading(
             "lidar", ".artifact/data/viam-cartographer/mock_lidar/0.pcd",
             1629037851000000);
         BOOST_TEST(viam_carto_add_lidar_reading(vc, &sr) ==
@@ -949,7 +949,7 @@ BOOST_AUTO_TEST_CASE(CartoFacade_demo) {
     // second sensor reading
     {
         VLOG(1) << "viam_carto_add_lidar_reading 2";
-        viam_carto_lidar_reading sr = new_test_sensor_reading(
+        viam_carto_lidar_reading sr = new_test_lidar_reading(
             "lidar", ".artifact/data/viam-cartographer/mock_lidar/1.pcd",
             1629037853000000);
         BOOST_TEST(viam_carto_add_lidar_reading(vc, &sr) ==
@@ -1007,7 +1007,7 @@ BOOST_AUTO_TEST_CASE(CartoFacade_demo) {
     // third sensor reading
     {
         VLOG(1) << "viam_carto_add_lidar_reading 3";
-        viam_carto_lidar_reading sr = new_test_sensor_reading(
+        viam_carto_lidar_reading sr = new_test_lidar_reading(
             "lidar", ".artifact/data/viam-cartographer/mock_lidar/2.pcd",
             1629037855000000);
         BOOST_TEST(viam_carto_add_lidar_reading(vc, &sr) ==
@@ -1055,7 +1055,7 @@ BOOST_AUTO_TEST_CASE(CartoFacade_demo) {
     // behavior of methods after stop
     // AddLidarReading
     {
-        viam_carto_lidar_reading sr = new_test_sensor_reading(
+        viam_carto_lidar_reading sr = new_test_lidar_reading(
             "lidar", ".artifact/data/viam-cartographer/mock_lidar/0.pcd",
             1687900053773475);
         viam::carto_facade::CartoFacade *cf =

--- a/viam-cartographer/src/carto_facade/carto_facade_test.cc
+++ b/viam-cartographer/src/carto_facade/carto_facade_test.cc
@@ -776,7 +776,7 @@ BOOST_AUTO_TEST_CASE(CartoFacade_demo) {
                    VIAM_CARTO_SUCCESS);
     }
 
-    // PATRICIA REVISIT
+    // PATRICIA TODO: #242
     // non first sensor
     {
         viam_carto_lidar_reading sr;
@@ -792,7 +792,7 @@ BOOST_AUTO_TEST_CASE(CartoFacade_demo) {
                    VIAM_CARTO_SUCCESS);
     }
 
-    // empty sensor reading
+    // empty lidar reading
     {
         viam_carto_lidar_reading sr;
         // must be they first sensor in the sensor list

--- a/viam-cartographer/src/carto_facade/util.cc
+++ b/viam-cartographer/src/carto_facade/util.cc
@@ -160,7 +160,7 @@ int read_pcd(std::string pcd, pcl::PCLPointCloud2 &blob) {
 }
 
 std::tuple<bool, cartographer::sensor::TimedPointCloudData>
-carto_sensor_reading(std::string lidar_reading,
+carto_lidar_reading(std::string lidar_reading,
                      int64_t lidar_reading_time_unix_milli) {
     cartographer::sensor::TimedPointCloudData point_cloud;
     cartographer::sensor::TimedPointCloud ranges;

--- a/viam-cartographer/src/carto_facade/util.cc
+++ b/viam-cartographer/src/carto_facade/util.cc
@@ -160,15 +160,15 @@ int read_pcd(std::string pcd, pcl::PCLPointCloud2 &blob) {
 }
 
 std::tuple<bool, cartographer::sensor::TimedPointCloudData>
-carto_sensor_reading(std::string sensor_reading,
-                     int64_t sensor_reading_time_unix_milli) {
+carto_sensor_reading(std::string lidar_reading,
+                     int64_t lidar_reading_time_unix_milli) {
     cartographer::sensor::TimedPointCloudData point_cloud;
     cartographer::sensor::TimedPointCloud ranges;
 
     pcl::PCLPointCloud2 blob;
 
     try {
-        int err = read_pcd(sensor_reading, blob);
+        int err = read_pcd(lidar_reading, blob);
         if (err) {
             return {false, point_cloud};
         }
@@ -196,7 +196,7 @@ carto_sensor_reading(std::string sensor_reading,
 
     point_cloud.time =
         cartographer::common::FromUniversal(0) +
-        cartographer::common::FromMilliseconds(sensor_reading_time_unix_milli);
+        cartographer::common::FromMilliseconds(lidar_reading_time_unix_milli);
     point_cloud.origin = Eigen::Vector3f::Zero();
     point_cloud.ranges = ranges;
 

--- a/viam-cartographer/src/carto_facade/util.cc
+++ b/viam-cartographer/src/carto_facade/util.cc
@@ -159,9 +159,8 @@ int read_pcd(std::string pcd, pcl::PCLPointCloud2 &blob) {
     return res;
 }
 
-std::tuple<bool, cartographer::sensor::TimedPointCloudData>
-carto_lidar_reading(std::string lidar_reading,
-                     int64_t lidar_reading_time_unix_milli) {
+std::tuple<bool, cartographer::sensor::TimedPointCloudData> carto_lidar_reading(
+    std::string lidar_reading, int64_t lidar_reading_time_unix_milli) {
     cartographer::sensor::TimedPointCloudData point_cloud;
     cartographer::sensor::TimedPointCloud ranges;
 

--- a/viam-cartographer/src/carto_facade/util.h
+++ b/viam-cartographer/src/carto_facade/util.h
@@ -50,8 +50,8 @@ void write_float_to_buffer_in_bytes(std::string &buffer, float f);
 void write_int_to_buffer_in_bytes(std::string &buffer, int d);
 
 std::tuple<bool, cartographer::sensor::TimedPointCloudData>
-carto_sensor_reading(std::string sensor_reading,
-                     int64_t sensor_reading_time_unix_milli);
+carto_sensor_reading(std::string lidar_reading,
+                     int64_t lidar_reading_time_unix_milli);
 int read_pcd(std::string pcd, pcl::PCLPointCloud2 &blob);
 }  // namespace util
 }  // namespace carto_facade

--- a/viam-cartographer/src/carto_facade/util.h
+++ b/viam-cartographer/src/carto_facade/util.h
@@ -50,7 +50,7 @@ void write_float_to_buffer_in_bytes(std::string &buffer, float f);
 void write_int_to_buffer_in_bytes(std::string &buffer, int d);
 
 std::tuple<bool, cartographer::sensor::TimedPointCloudData>
-carto_sensor_reading(std::string lidar_reading,
+carto_lidar_reading(std::string lidar_reading,
                      int64_t lidar_reading_time_unix_milli);
 int read_pcd(std::string pcd, pcl::PCLPointCloud2 &blob);
 }  // namespace util

--- a/viam-cartographer/src/carto_facade/util.h
+++ b/viam-cartographer/src/carto_facade/util.h
@@ -49,9 +49,8 @@ void write_float_to_buffer_in_bytes(std::string &buffer, float f);
 
 void write_int_to_buffer_in_bytes(std::string &buffer, int d);
 
-std::tuple<bool, cartographer::sensor::TimedPointCloudData>
-carto_lidar_reading(std::string lidar_reading,
-                     int64_t lidar_reading_time_unix_milli);
+std::tuple<bool, cartographer::sensor::TimedPointCloudData> carto_lidar_reading(
+    std::string lidar_reading, int64_t lidar_reading_time_unix_milli);
 int read_pcd(std::string pcd, pcl::PCLPointCloud2 &blob);
 }  // namespace util
 }  // namespace carto_facade

--- a/viam-cartographer/src/carto_facade/util_test.cc
+++ b/viam-cartographer/src/carto_facade/util_test.cc
@@ -51,8 +51,8 @@ BOOST_AUTO_TEST_CASE(carto_lidar_reading_too_few_points_ascii_failure) {
     std::vector<std::vector<double>> too_few_points = {
         {0.007000, 0.006000, 0.001000, 16711938}};
 
-    auto [success, _] = carto_lidar_reading(help::ascii_pcd(too_few_points),
-                                             16409988000001121);
+    auto [success, _] =
+        carto_lidar_reading(help::ascii_pcd(too_few_points), 16409988000001121);
     BOOST_TEST(!success);
 }
 
@@ -61,7 +61,7 @@ BOOST_AUTO_TEST_CASE(carto_lidar_reading_too_few_points_binary_failure) {
         {0.007000, 0.006000, 0.001000, 16711938}};
 
     auto [success, _] = carto_lidar_reading(help::binary_pcd(too_few_points),
-                                             16409988000001121);
+                                            16409988000001121);
     BOOST_TEST(!success);
 }
 
@@ -127,8 +127,8 @@ BOOST_AUTO_TEST_CASE(carto_lidar_reading_wrong_shape_binary_failure) {
         {0.007000, 0.006000, 0.001000},
         {0.007000, 0.006000, 0.001000}};
 
-    auto [success, _] = carto_lidar_reading(
-        help::binary_pcd(wrong_point_shape), 16409988000001121);
+    auto [success, _] = carto_lidar_reading(help::binary_pcd(wrong_point_shape),
+                                            16409988000001121);
     BOOST_TEST(!success);
 }
 

--- a/viam-cartographer/src/carto_facade/util_test.cc
+++ b/viam-cartographer/src/carto_facade/util_test.cc
@@ -18,63 +18,63 @@ namespace util {
 
 BOOST_AUTO_TEST_SUITE(CartoFacade_io_demo)
 
-BOOST_AUTO_TEST_CASE(carto_sensor_reading_empty_failure) {
-    auto [success, _] = carto_sensor_reading("", 16409988000001121);
+BOOST_AUTO_TEST_CASE(carto_lidar_reading_empty_failure) {
+    auto [success, _] = carto_lidar_reading("", 16409988000001121);
     BOOST_TEST(!success);
 }
 
-BOOST_AUTO_TEST_CASE(carto_sensor_reading_corrupt_header_ascii_failure) {
+BOOST_AUTO_TEST_CASE(carto_lidar_reading_corrupt_header_ascii_failure) {
     std::vector<std::vector<double>> points = {
         {-0.001000, 0.002000, 0.005000, 16711938},
         {0.582000, 0.012000, 0.000000, 16711938},
         {0.007000, 0.006000, 0.001000, 16711938}};
 
-    auto [success, _] = carto_sensor_reading(
+    auto [success, _] = carto_lidar_reading(
         help::ascii_pcd(points).substr(1, std::string::npos),
         16409988000001121);
     BOOST_TEST(!success);
 }
 
-BOOST_AUTO_TEST_CASE(carto_sensor_reading_corrupt_header_binary_failure) {
+BOOST_AUTO_TEST_CASE(carto_lidar_reading_corrupt_header_binary_failure) {
     std::vector<std::vector<double>> points = {
         {-0.001000, 0.002000, 0.005000, 16711938},
         {0.582000, 0.012000, 0.000000, 16711938},
         {0.007000, 0.006000, 0.001000, 16711938}};
 
-    auto [success, _] = carto_sensor_reading(
+    auto [success, _] = carto_lidar_reading(
         help::binary_pcd(points).substr(1, std::string::npos),
         16409988000001121);
     BOOST_TEST(!success);
 }
 
-BOOST_AUTO_TEST_CASE(carto_sensor_reading_too_few_points_ascii_failure) {
+BOOST_AUTO_TEST_CASE(carto_lidar_reading_too_few_points_ascii_failure) {
     std::vector<std::vector<double>> too_few_points = {
         {0.007000, 0.006000, 0.001000, 16711938}};
 
-    auto [success, _] = carto_sensor_reading(help::ascii_pcd(too_few_points),
+    auto [success, _] = carto_lidar_reading(help::ascii_pcd(too_few_points),
                                              16409988000001121);
     BOOST_TEST(!success);
 }
 
-BOOST_AUTO_TEST_CASE(carto_sensor_reading_too_few_points_binary_failure) {
+BOOST_AUTO_TEST_CASE(carto_lidar_reading_too_few_points_binary_failure) {
     std::vector<std::vector<double>> too_few_points = {
         {0.007000, 0.006000, 0.001000, 16711938}};
 
-    auto [success, _] = carto_sensor_reading(help::binary_pcd(too_few_points),
+    auto [success, _] = carto_lidar_reading(help::binary_pcd(too_few_points),
                                              16409988000001121);
     BOOST_TEST(!success);
 }
 
 // The lib we use will parse as many points as the header specifies
 // and ignore any others
-BOOST_AUTO_TEST_CASE(carto_sensor_reading_too_many_points_ascii_success) {
+BOOST_AUTO_TEST_CASE(carto_lidar_reading_too_many_points_ascii_success) {
     std::vector<std::vector<double>> too_many_points = {
         {-0.001000, 0.002000, 0.005000, 16711938},
         {0.582000, 0.012000, 0.000000, 16711938},
         {0.007000, 0.006000, 0.001000, 16711938},
         {0.001000, 0.102000, 0.105000, 16711938}};
 
-    auto [success, timed_pcd] = carto_sensor_reading(
+    auto [success, timed_pcd] = carto_lidar_reading(
         help::ascii_pcd(too_many_points), 16409988000001121);
     BOOST_TEST(success);
     BOOST_TEST(timed_pcd.ranges.size() == 3);
@@ -89,14 +89,14 @@ BOOST_AUTO_TEST_CASE(carto_sensor_reading_too_many_points_ascii_success) {
 
 // The lib we use will parse as many points as the header specifies
 // and ignore any others
-BOOST_AUTO_TEST_CASE(carto_sensor_reading_too_many_points_binary_success) {
+BOOST_AUTO_TEST_CASE(carto_lidar_reading_too_many_points_binary_success) {
     std::vector<std::vector<double>> too_many_points = {
         {-0.001000, 0.002000, 0.005000, 16711938},
         {0.582000, 0.012000, 0.000000, 16711938},
         {0.007000, 0.006000, 0.001000, 16711938},
         {0.001000, 0.102000, 0.105000, 16711938}};
 
-    auto [success, timed_pcd] = carto_sensor_reading(
+    auto [success, timed_pcd] = carto_lidar_reading(
         help::binary_pcd(too_many_points), 16409988000001121);
     BOOST_TEST(success);
     BOOST_TEST(timed_pcd.ranges.size() == 3);
@@ -110,29 +110,29 @@ BOOST_AUTO_TEST_CASE(carto_sensor_reading_too_many_points_binary_success) {
 }
 
 // THIS PASSES on linux but fails on mac
-/* BOOST_AUTO_TEST_CASE(carto_sensor_reading_wrong_shape_ascii_failure) { */
+/* BOOST_AUTO_TEST_CASE(carto_lidar_reading_wrong_shape_ascii_failure) { */
 /*     std::vector<std::vector<double>> wrong_point_shape = { */
 /*         {0.007000, 0.006000, 0.001000}, */
 /*         {0.007000, 0.006000, 0.001000}, */
 /*         {0.007000, 0.006000, 0.001000}}; */
 /*     auto data = help::ascii_pcd(wrong_point_shape); */
 /*     BOOST_TEST_CHECKPOINT("checkpoint_message"); */
-/*     auto [success, _] = carto_sensor_reading(data, 16409988000001121); */
+/*     auto [success, _] = carto_lidar_reading(data, 16409988000001121); */
 /*     BOOST_TEST(!success); */
 /* } */
 
-BOOST_AUTO_TEST_CASE(carto_sensor_reading_wrong_shape_binary_failure) {
+BOOST_AUTO_TEST_CASE(carto_lidar_reading_wrong_shape_binary_failure) {
     std::vector<std::vector<double>> wrong_point_shape = {
         {0.007000, 0.006000, 0.001000},
         {0.007000, 0.006000, 0.001000},
         {0.007000, 0.006000, 0.001000}};
 
-    auto [success, _] = carto_sensor_reading(
+    auto [success, _] = carto_lidar_reading(
         help::binary_pcd(wrong_point_shape), 16409988000001121);
     BOOST_TEST(!success);
 }
 
-BOOST_AUTO_TEST_CASE(carto_sensor_reading_binary_success) {
+BOOST_AUTO_TEST_CASE(carto_lidar_reading_binary_success) {
     // Create a mini PCD file and save it in a tmp directory
     std::string filename = "rplidar_data_2022-01-01T01:00:00.0001Z.pcd";
     std::vector<std::vector<double>> points = {
@@ -160,7 +160,7 @@ BOOST_AUTO_TEST_CASE(carto_sensor_reading_binary_success) {
     boost::filesystem::remove_all(tmp_dir);
 
     auto [success, timed_pcd_from_string] =
-        carto_sensor_reading(pcd, 16409988000001121);
+        carto_lidar_reading(pcd, 16409988000001121);
     BOOST_TEST(success);
     BOOST_TEST(timed_pcd_from_string.ranges.size() == points.size());
     help::timed_pcd_contains(timed_pcd_from_string, points);
@@ -169,7 +169,7 @@ BOOST_AUTO_TEST_CASE(carto_sensor_reading_binary_success) {
                cartographer::common::FromUniversal(-1920816663374754544));
 }
 
-BOOST_AUTO_TEST_CASE(carto_sensor_reading_ascii_success) {
+BOOST_AUTO_TEST_CASE(carto_lidar_reading_ascii_success) {
     // Create a mini PCD file and save it in a tmp directory
     std::string filename = "rplidar_data_2022-01-01T01:00:00.0001Z.pcd";
     std::vector<std::vector<double>> points = {
@@ -197,7 +197,7 @@ BOOST_AUTO_TEST_CASE(carto_sensor_reading_ascii_success) {
     boost::filesystem::remove_all(tmp_dir);
 
     auto [success, timed_pcd_from_string] =
-        carto_sensor_reading(pcd, 16409988000001121);
+        carto_lidar_reading(pcd, 16409988000001121);
     BOOST_TEST(success);
     BOOST_TEST(timed_pcd_from_string.ranges.size() == points.size());
     help::timed_pcd_contains(timed_pcd_from_string, points);


### PR DESCRIPTION
Rename functions currently using 'sensor' to denote lidar to explicitly use 'lidar', to be able to better distinguish between lidar and IMU