### PR TITLE
Minor fixes & refactor

### DIFF
--- a/cartofacade/capi.go
+++ b/cartofacade/capi.go
@@ -186,7 +186,7 @@ func NewCarto(cfg CartoConfig, acfg CartoAlgoConfig, vcl CartoLibInterface) (Car
 	return carto, nil
 }
 
-// Start is a wrapper for viam_carto_start
+// start is a wrapper for viam_carto_start
 func (vc *Carto) start() error {
 	status := C.viam_carto_start(vc.value)
 
@@ -197,7 +197,7 @@ func (vc *Carto) start() error {
 	return nil
 }
 
-// Stop is a wrapper for viam_carto_stop
+// stop is a wrapper for viam_carto_stop
 func (vc *Carto) stop() error {
 	status := C.viam_carto_stop(vc.value)
 
@@ -208,7 +208,7 @@ func (vc *Carto) stop() error {
 	return nil
 }
 
-// Terminate calls viam_carto_terminate to clean up memory for viam carto
+// terminate calls viam_carto_terminate to clean up memory for viam carto
 func (vc *Carto) terminate() error {
 	status := C.viam_carto_terminate(&vc.value)
 
@@ -326,7 +326,7 @@ func (vc *Carto) runFinalOptimization() error {
 	return nil
 }
 
-// this function is only used for testing purposes, but needs to be in this file as CGo is not supported in go test files
+// getTestPositionResponse is only used for testing purposes, but needs to be in this file as CGo is not supported in go test files
 func getTestPositionResponse() C.viam_carto_get_position_response {
 	gpr := C.viam_carto_get_position_response{}
 

--- a/cartofacade/capi_mock.go
+++ b/cartofacade/capi_mock.go
@@ -33,7 +33,7 @@ type CartoMock struct {
 	RunFinalOptimizationFunc func() error
 }
 
-// Start calls the injected StartFunc or the real version.
+// start calls the injected StartFunc or the real version.
 func (cf *CartoMock) start() error {
 	if cf.StartFunc == nil {
 		return cf.Carto.start()
@@ -41,7 +41,7 @@ func (cf *CartoMock) start() error {
 	return cf.StartFunc()
 }
 
-// Stop calls the injected StopFunc or the real version.
+// stop calls the injected StopFunc or the real version.
 func (cf *CartoMock) stop() error {
 	if cf.StopFunc == nil {
 		return cf.Carto.stop()
@@ -49,7 +49,7 @@ func (cf *CartoMock) stop() error {
 	return cf.StopFunc()
 }
 
-// Terminate calls the injected TerminateFunc or the real version.
+// terminate calls the injected TerminateFunc or the real version.
 func (cf *CartoMock) terminate() error {
 	if cf.TerminateFunc == nil {
 		return cf.Carto.terminate()
@@ -97,7 +97,7 @@ func (cf *CartoMock) internalState() ([]byte, error) {
 	return cf.InternalStateFunc()
 }
 
-// runFinalOptimization calls the injected GetInternalState or the real version.
+// runFinalOptimization calls the injected RunFinalOptimization or the real version.
 func (cf *CartoMock) runFinalOptimization() error {
 	if cf.RunFinalOptimizationFunc == nil {
 		return cf.Carto.runFinalOptimization()

--- a/cartofacade/carto_facade_test.go
+++ b/cartofacade/carto_facade_test.go
@@ -26,7 +26,7 @@ func TestRequest(t *testing.T) {
 		return nil
 	}
 	testErr := errors.New("error")
-	t.Run("successful request", func(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
 		cancelCtx, cancelFunc := context.WithCancel(context.Background())
 		activeBackgroundWorkers := sync.WaitGroup{}
 
@@ -52,7 +52,7 @@ func TestRequest(t *testing.T) {
 		activeBackgroundWorkers.Wait()
 	})
 
-	t.Run("failed request", func(t *testing.T) {
+	t.Run("failure", func(t *testing.T) {
 		cancelCtx, cancelFunc := context.WithCancel(context.Background())
 		activeBackgroundWorkers := sync.WaitGroup{}
 
@@ -78,7 +78,7 @@ func TestRequest(t *testing.T) {
 		activeBackgroundWorkers.Wait()
 	})
 
-	t.Run("request with a cancelled context", func(t *testing.T) {
+	t.Run("failure due to cancelled context", func(t *testing.T) {
 		cancelCtx, cancelFunc := context.WithCancel(context.Background())
 		activeBackgroundWorkers := sync.WaitGroup{}
 
@@ -106,7 +106,7 @@ func TestRequest(t *testing.T) {
 		test.That(t, err, test.ShouldResemble, expectedErr)
 	})
 
-	t.Run("request with a work function that takes longer than the timeout", func(t *testing.T) {
+	t.Run("failure due to timeout", func(t *testing.T) {
 		cancelCtx, cancelFunc := context.WithCancel(context.Background())
 		activeBackgroundWorkers := sync.WaitGroup{}
 

--- a/cartofacade/carto_facade_test.go
+++ b/cartofacade/carto_facade_test.go
@@ -577,7 +577,6 @@ func TestPointCloudMap(t *testing.T) {
 		internalState, err := cartoFacade.PointCloudMap(cancelCtx, 5*time.Second)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, internalState, test.ShouldResemble, internalState)
-
 	})
 
 	t.Run("failure", func(t *testing.T) {

--- a/cartofacade/carto_facade_test.go
+++ b/cartofacade/carto_facade_test.go
@@ -26,7 +26,7 @@ func TestRequest(t *testing.T) {
 		return nil
 	}
 	testErr := errors.New("error")
-	t.Run("test successful request", func(t *testing.T) {
+	t.Run("successful request", func(t *testing.T) {
 		cancelCtx, cancelFunc := context.WithCancel(context.Background())
 		activeBackgroundWorkers := sync.WaitGroup{}
 
@@ -52,7 +52,7 @@ func TestRequest(t *testing.T) {
 		activeBackgroundWorkers.Wait()
 	})
 
-	t.Run("test failed request", func(t *testing.T) {
+	t.Run("failed request", func(t *testing.T) {
 		cancelCtx, cancelFunc := context.WithCancel(context.Background())
 		activeBackgroundWorkers := sync.WaitGroup{}
 
@@ -78,7 +78,7 @@ func TestRequest(t *testing.T) {
 		activeBackgroundWorkers.Wait()
 	})
 
-	t.Run("test requesting with a canceled context", func(t *testing.T) {
+	t.Run("request with a cancelled context", func(t *testing.T) {
 		cancelCtx, cancelFunc := context.WithCancel(context.Background())
 		activeBackgroundWorkers := sync.WaitGroup{}
 
@@ -106,7 +106,7 @@ func TestRequest(t *testing.T) {
 		test.That(t, err, test.ShouldResemble, expectedErr)
 	})
 
-	t.Run("test requesting with when the work function takes longer than the timeout", func(t *testing.T) {
+	t.Run("request with a work function that takes longer than the timeout", func(t *testing.T) {
 		cancelCtx, cancelFunc := context.WithCancel(context.Background())
 		activeBackgroundWorkers := sync.WaitGroup{}
 
@@ -153,7 +153,7 @@ func TestInitialize(t *testing.T) {
 
 	cartoFacade := New(&lib, cfg, algoCfg)
 
-	t.Run("test Initialize - successful case", func(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
 		slamMode, err := cartoFacade.Initialize(cancelCtx, 5*time.Second, &activeBackgroundWorkers)
 		test.That(t, slamMode, test.ShouldEqual, MappingMode)
 		test.That(t, err, test.ShouldBeNil)
@@ -180,34 +180,35 @@ func TestStart(t *testing.T) {
 
 	cartoFacade := New(&lib, cfg, algoCfg)
 	carto := CartoMock{}
-	carto.StartFunc = func() error {
-		return nil
-	}
 	cartoFacade.carto = &carto
 	cartoFacade.startCGoroutine(cancelCtx, &activeBackgroundWorkers)
 
-	t.Run("testing Start", func(t *testing.T) {
-		// success case
-		err = cartoFacade.Start(cancelCtx, 5*time.Second)
-		test.That(t, err, test.ShouldBeNil)
-
+	t.Run("success", func(t *testing.T) {
 		carto.StartFunc = func() error {
-			return errors.New("test error 1")
+			return nil
 		}
 		cartoFacade.carto = &carto
+		err = cartoFacade.Start(cancelCtx, 5*time.Second)
+		test.That(t, err, test.ShouldBeNil)
+	})
 
-		// returns error
+	t.Run("failure", func(t *testing.T) {
+		expectedErr := errors.New("Start failed")
+		carto.StartFunc = func() error {
+			return expectedErr
+		}
+		cartoFacade.carto = &carto
 		err = cartoFacade.Start(cancelCtx, 5*time.Second)
 		test.That(t, err, test.ShouldBeError)
-		test.That(t, err, test.ShouldResemble, errors.New("test error 1"))
+		test.That(t, err, test.ShouldResemble, expectedErr)
+	})
 
+	t.Run("times out", func(t *testing.T) {
 		carto.StartFunc = func() error {
 			time.Sleep(50 * time.Millisecond)
 			return nil
 		}
 		cartoFacade.carto = &carto
-
-		// times out
 		err = cartoFacade.Start(cancelCtx, 1*time.Millisecond)
 		test.That(t, err, test.ShouldBeError)
 		expectedErr := multierr.Combine(errors.New(timeoutErrMessage), context.DeadlineExceeded)
@@ -231,34 +232,34 @@ func TestStop(t *testing.T) {
 
 	cartoFacade := New(&lib, cfg, algoCfg)
 	carto := CartoMock{}
-	carto.StopFunc = func() error {
-		return nil
-	}
 	cartoFacade.carto = &carto
 	cartoFacade.startCGoroutine(cancelCtx, &activeBackgroundWorkers)
 
-	t.Run("testing Stop", func(t *testing.T) {
-		// success case
+	t.Run("success", func(t *testing.T) {
+		carto.StopFunc = func() error {
+			return nil
+		}
 		err = cartoFacade.Stop(cancelCtx, 5*time.Second)
 		test.That(t, err, test.ShouldBeNil)
+	})
 
+	t.Run("failure", func(t *testing.T) {
+		expectedErr := errors.New("Stop failed")
 		carto.StopFunc = func() error {
-			return errors.New("test error 2")
+			return expectedErr
 		}
 		cartoFacade.carto = &carto
-
-		// returns error
 		err = cartoFacade.Stop(cancelCtx, 5*time.Second)
 		test.That(t, err, test.ShouldBeError)
-		test.That(t, err, test.ShouldResemble, errors.New("test error 2"))
+		test.That(t, err, test.ShouldResemble, expectedErr)
+	})
 
+	t.Run("times out", func(t *testing.T) {
 		carto.StopFunc = func() error {
 			time.Sleep(50 * time.Millisecond)
 			return nil
 		}
 		cartoFacade.carto = &carto
-
-		// times out
 		err = cartoFacade.Stop(cancelCtx, 1*time.Millisecond)
 		test.That(t, err, test.ShouldBeError)
 		expectedErr := multierr.Combine(errors.New(timeoutErrMessage), context.DeadlineExceeded)
@@ -282,34 +283,34 @@ func TestTerminate(t *testing.T) {
 
 	cartoFacade := New(&lib, cfg, algoCfg)
 	carto := CartoMock{}
-	carto.TerminateFunc = func() error {
-		return nil
-	}
 	cartoFacade.carto = &carto
 	cartoFacade.startCGoroutine(cancelCtx, &activeBackgroundWorkers)
 
-	t.Run("testing Terminate", func(t *testing.T) {
-		// success case
+	t.Run("success", func(t *testing.T) {
+		carto.TerminateFunc = func() error {
+			return nil
+		}
 		err = cartoFacade.Terminate(cancelCtx, 5*time.Second)
 		test.That(t, err, test.ShouldBeNil)
+	})
 
+	t.Run("failure", func(t *testing.T) {
+		expectedErr := errors.New("Terminate failed")
 		carto.TerminateFunc = func() error {
-			return errors.New("test error 3")
+			return expectedErr
 		}
 		cartoFacade.carto = &carto
-
-		// returns error
 		err = cartoFacade.Terminate(cancelCtx, 5*time.Second)
 		test.That(t, err, test.ShouldBeError)
-		test.That(t, err, test.ShouldResemble, errors.New("test error 3"))
+		test.That(t, err, test.ShouldResemble, expectedErr)
+	})
 
+	t.Run("times out", func(t *testing.T) {
 		carto.TerminateFunc = func() error {
 			time.Sleep(50 * time.Millisecond)
 			return nil
 		}
 		cartoFacade.carto = &carto
-
-		// times out
 		err = cartoFacade.Terminate(cancelCtx, 1*time.Millisecond)
 		test.That(t, err, test.ShouldBeError)
 		expectedErr := multierr.Combine(errors.New(timeoutErrMessage), context.DeadlineExceeded)
@@ -333,45 +334,45 @@ func TestAddLidarReading(t *testing.T) {
 
 	cartoFacade := New(&lib, cfg, algoCfg)
 	carto := CartoMock{}
-	carto.AddLidarReadingFunc = func(name string, reading []byte, time time.Time) error {
-		return nil
-	}
 	cartoFacade.carto = &carto
 	cartoFacade.startCGoroutine(cancelCtx, &activeBackgroundWorkers)
 
-	t.Run("testing AddLidarReading", func(t *testing.T) {
-		timestamp := time.Date(2021, 8, 15, 14, 30, 45, 100, time.UTC)
+	timestamp := time.Date(2021, 8, 15, 14, 30, 45, 100, time.UTC)
 
-		// read PCD
-		file, err := os.Open(artifact.MustPath("viam-cartographer/mock_lidar/0.pcd"))
-		test.That(t, err, test.ShouldBeNil)
-		buf := new(bytes.Buffer)
-		pc, err := pointcloud.ReadPCD(file)
-		test.That(t, err, test.ShouldBeNil)
-		err = pointcloud.ToPCD(pc, buf, 0)
-		test.That(t, err, test.ShouldBeNil)
+	// read PCD
+	file, err := os.Open(artifact.MustPath("viam-cartographer/mock_lidar/0.pcd"))
+	test.That(t, err, test.ShouldBeNil)
+	buf := new(bytes.Buffer)
+	pc, err := pointcloud.ReadPCD(file)
+	test.That(t, err, test.ShouldBeNil)
+	err = pointcloud.ToPCD(pc, buf, 0)
+	test.That(t, err, test.ShouldBeNil)
 
-		// success case
+	t.Run("success", func(t *testing.T) {
+		carto.AddLidarReadingFunc = func(name string, reading []byte, time time.Time) error {
+			return nil
+		}
 		err = cartoFacade.AddLidarReading(cancelCtx, 5*time.Second, "mysensor", buf.Bytes(), timestamp)
 		test.That(t, err, test.ShouldBeNil)
+	})
 
+	t.Run("failure", func(t *testing.T) {
+		expectedErr := errors.New("AddLidarReading failed")
 		carto.AddLidarReadingFunc = func(name string, reading []byte, time time.Time) error {
-			return errors.New("test error 4")
+			return expectedErr
 		}
 		cartoFacade.carto = &carto
-
-		// returns error
 		err = cartoFacade.AddLidarReading(cancelCtx, 5*time.Second, "mysensor", buf.Bytes(), timestamp)
 		test.That(t, err, test.ShouldBeError)
-		test.That(t, err, test.ShouldResemble, errors.New("test error 4"))
+		test.That(t, err, test.ShouldResemble, expectedErr)
+	})
 
+	t.Run("times out", func(t *testing.T) {
 		carto.AddLidarReadingFunc = func(name string, reading []byte, timestamp time.Time) error {
 			time.Sleep(50 * time.Millisecond)
 			return nil
 		}
 		cartoFacade.carto = &carto
-
-		// times out
 		err = cartoFacade.AddLidarReading(cancelCtx, 1*time.Millisecond, "mysensor", buf.Bytes(), timestamp)
 		test.That(t, err, test.ShouldBeError)
 		expectedErr := multierr.Combine(errors.New(timeoutErrMessage), context.DeadlineExceeded)
@@ -395,40 +396,42 @@ func TestAddIMUReading(t *testing.T) {
 
 	cartoFacade := New(&lib, cfg, algoCfg)
 	carto := CartoMock{}
-	carto.AddIMUReadingFunc = func(name string, reading IMUReading, time time.Time) error {
-		return nil
-	}
 	cartoFacade.carto = &carto
 	cartoFacade.startCGoroutine(cancelCtx, &activeBackgroundWorkers)
 
-	t.Run("testing AddIMUReading", func(t *testing.T) {
-		timestamp := time.Date(2021, 8, 15, 14, 30, 45, 100, time.UTC)
-		testIMUReading := IMUReading{
-			LinearAcceleration: r3.Vector{X: 0.1, Y: 0, Z: 9.8},
-			AngularVelocity:    spatialmath.AngularVelocity{X: 0, Y: -0.2, Z: 0},
-		}
+	timestamp := time.Date(2021, 8, 15, 14, 30, 45, 100, time.UTC)
+	testIMUReading := IMUReading{
+		LinearAcceleration: r3.Vector{X: 0.1, Y: 0, Z: 9.8},
+		AngularVelocity:    spatialmath.AngularVelocity{X: 0, Y: -0.2, Z: 0},
+	}
 
-		// success case
+	t.Run("success", func(t *testing.T) {
+		carto.AddIMUReadingFunc = func(name string, reading IMUReading, time time.Time) error {
+			return nil
+		}
 		err = cartoFacade.AddIMUReading(cancelCtx, 5*time.Second, "myIMU", testIMUReading, timestamp)
 		test.That(t, err, test.ShouldBeNil)
+	})
 
+	t.Run("failure", func(t *testing.T) {
+		expectedErr := errors.New("AddIMUReading failed")
 		carto.AddIMUReadingFunc = func(name string, reading IMUReading, time time.Time) error {
-			return errors.New("test error 5")
+			return expectedErr
 		}
 		cartoFacade.carto = &carto
 
 		// returns error
 		err = cartoFacade.AddIMUReading(cancelCtx, 5*time.Second, "myIMU", testIMUReading, timestamp)
 		test.That(t, err, test.ShouldBeError)
-		test.That(t, err, test.ShouldResemble, errors.New("test error 5"))
+		test.That(t, err, test.ShouldResemble, expectedErr)
+	})
 
+	t.Run("times out", func(t *testing.T) {
 		carto.AddIMUReadingFunc = func(name string, reading IMUReading, timestamp time.Time) error {
 			time.Sleep(50 * time.Millisecond)
 			return nil
 		}
 		cartoFacade.carto = &carto
-
-		// times out
 		err = cartoFacade.AddIMUReading(cancelCtx, 1*time.Millisecond, "myIMU", testIMUReading, timestamp)
 		test.That(t, err, test.ShouldBeError)
 		expectedErr := multierr.Combine(errors.New(timeoutErrMessage), context.DeadlineExceeded)
@@ -452,38 +455,39 @@ func TestPosition(t *testing.T) {
 
 	cartoFacade := New(&lib, cfg, algoCfg)
 	carto := CartoMock{}
-	carto.PositionFunc = func() (Position, error) {
-		pos := Position{X: 1, Y: 2, Z: 3}
-		return pos, nil
-	}
 	cartoFacade.carto = &carto
 	cartoFacade.startCGoroutine(cancelCtx, &activeBackgroundWorkers)
 
-	t.Run("testing Position", func(t *testing.T) {
-		// success case
+	t.Run("success", func(t *testing.T) {
+		carto.PositionFunc = func() (Position, error) {
+			pos := Position{X: 1, Y: 2, Z: 3}
+			return pos, nil
+		}
+		cartoFacade.carto = &carto
 		pos, err := cartoFacade.Position(cancelCtx, 5*time.Second)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, pos.X, test.ShouldEqual, 1)
 		test.That(t, pos.Y, test.ShouldEqual, 2)
 		test.That(t, pos.Z, test.ShouldEqual, 3)
+	})
 
+	t.Run("failure", func(t *testing.T) {
+		expectedErr := errors.New("Position failed")
 		carto.PositionFunc = func() (Position, error) {
-			return Position{}, errors.New("test error 6")
+			return Position{}, expectedErr
 		}
 		cartoFacade.carto = &carto
-
-		// returns error
 		_, err = cartoFacade.Position(cancelCtx, 5*time.Second)
 		test.That(t, err, test.ShouldBeError)
-		test.That(t, err, test.ShouldResemble, errors.New("test error 6"))
+		test.That(t, err, test.ShouldResemble, expectedErr)
+	})
 
+	t.Run("times out", func(t *testing.T) {
 		carto.PositionFunc = func() (Position, error) {
 			time.Sleep(50 * time.Millisecond)
 			return Position{}, nil
 		}
 		cartoFacade.carto = &carto
-
-		// times out
 		_, err = cartoFacade.Position(cancelCtx, 1*time.Millisecond)
 		test.That(t, err, test.ShouldBeError)
 		expectedErr := multierr.Combine(errors.New(timeoutErrMessage), context.DeadlineExceeded)
@@ -507,36 +511,37 @@ func TestInternalState(t *testing.T) {
 
 	cartoFacade := New(&lib, cfg, algoCfg)
 	carto := CartoMock{}
-	carto.InternalStateFunc = func() ([]byte, error) {
-		internalState := []byte("hello!")
-		return internalState, nil
-	}
 	cartoFacade.carto = &carto
 	cartoFacade.startCGoroutine(cancelCtx, &activeBackgroundWorkers)
 
-	t.Run("testing InternalState", func(t *testing.T) {
-		// success case
-		internalState, err := cartoFacade.InternalState(cancelCtx, 5*time.Second)
-		test.That(t, err, test.ShouldBeNil)
-		test.That(t, internalState, test.ShouldResemble, []byte("hello!"))
-
+	t.Run("success", func(t *testing.T) {
+		internalState := []byte("hello!")
 		carto.InternalStateFunc = func() ([]byte, error) {
-			return []byte{}, errors.New("test error 7")
+			return internalState, nil
 		}
 		cartoFacade.carto = &carto
+		internalState, err := cartoFacade.InternalState(cancelCtx, 5*time.Second)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, internalState, test.ShouldResemble, internalState)
+	})
 
-		// returns error
+	t.Run("failure", func(t *testing.T) {
+		expectedErr := errors.New("InternalState failed")
+		carto.InternalStateFunc = func() ([]byte, error) {
+			return []byte{}, expectedErr
+		}
+		cartoFacade.carto = &carto
 		_, err = cartoFacade.InternalState(cancelCtx, 5*time.Second)
 		test.That(t, err, test.ShouldBeError)
-		test.That(t, err, test.ShouldResemble, errors.New("test error 7"))
+		test.That(t, err, test.ShouldResemble, expectedErr)
+	})
 
+	t.Run("times out", func(t *testing.T) {
 		carto.InternalStateFunc = func() ([]byte, error) {
 			time.Sleep(50 * time.Millisecond)
 			return []byte{}, nil
 		}
 		cartoFacade.carto = &carto
-
-		// times out
 		_, err = cartoFacade.InternalState(cancelCtx, 1*time.Millisecond)
 		test.That(t, err, test.ShouldBeError)
 		expectedErr := multierr.Combine(errors.New(timeoutErrMessage), context.DeadlineExceeded)
@@ -560,36 +565,38 @@ func TestPointCloudMap(t *testing.T) {
 
 	cartoFacade := New(&lib, cfg, algoCfg)
 	carto := CartoMock{}
-	carto.PointCloudMapFunc = func() ([]byte, error) {
-		internalState := []byte("hello!")
-		return internalState, nil
-	}
 	cartoFacade.carto = &carto
 	cartoFacade.startCGoroutine(cancelCtx, &activeBackgroundWorkers)
 
-	t.Run("testing PointCloudMap", func(t *testing.T) {
-		// success case
-		internalState, err := cartoFacade.PointCloudMap(cancelCtx, 5*time.Second)
-		test.That(t, err, test.ShouldBeNil)
-		test.That(t, internalState, test.ShouldResemble, []byte("hello!"))
-
+	t.Run("success", func(t *testing.T) {
+		internalState := []byte("hello!")
 		carto.PointCloudMapFunc = func() ([]byte, error) {
-			return []byte{}, errors.New("test error 8")
+			return internalState, nil
 		}
 		cartoFacade.carto = &carto
+		internalState, err := cartoFacade.PointCloudMap(cancelCtx, 5*time.Second)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, internalState, test.ShouldResemble, internalState)
 
-		// returns error
+	})
+
+	t.Run("failure", func(t *testing.T) {
+		expectedErr := errors.New("PointCloudMap failed")
+		carto.PointCloudMapFunc = func() ([]byte, error) {
+			return []byte{}, expectedErr
+		}
+		cartoFacade.carto = &carto
 		_, err = cartoFacade.PointCloudMap(cancelCtx, 5*time.Second)
 		test.That(t, err, test.ShouldBeError)
-		test.That(t, err, test.ShouldResemble, errors.New("test error 8"))
+		test.That(t, err, test.ShouldResemble, expectedErr)
+	})
 
+	t.Run("times out", func(t *testing.T) {
 		carto.PointCloudMapFunc = func() ([]byte, error) {
 			time.Sleep(50 * time.Millisecond)
 			return []byte{}, nil
 		}
 		cartoFacade.carto = &carto
-
-		// times out
 		_, err = cartoFacade.PointCloudMap(cancelCtx, 1*time.Millisecond)
 		test.That(t, err, test.ShouldBeError)
 		expectedErr := multierr.Combine(errors.New(timeoutErrMessage), context.DeadlineExceeded)
@@ -613,34 +620,34 @@ func TestRunFinalOptimization(t *testing.T) {
 
 	cartoFacade := New(&lib, cfg, algoCfg)
 	carto := CartoMock{}
-	carto.RunFinalOptimizationFunc = func() error {
-		return nil
-	}
 	cartoFacade.carto = &carto
 	cartoFacade.startCGoroutine(cancelCtx, &activeBackgroundWorkers)
 
-	t.Run("testing RunFinalOptimization", func(t *testing.T) {
-		// success case
+	t.Run("success", func(t *testing.T) {
+		carto.RunFinalOptimizationFunc = func() error {
+			return nil
+		}
 		err = cartoFacade.RunFinalOptimization(cancelCtx, 5*time.Second)
 		test.That(t, err, test.ShouldBeNil)
+	})
 
+	t.Run("failure", func(t *testing.T) {
+		expectedErr := errors.New("RunFinalOptimization failed")
 		carto.RunFinalOptimizationFunc = func() error {
-			return errors.New("test error 5")
+			return expectedErr
 		}
 		cartoFacade.carto = &carto
-
-		// returns error
 		err = cartoFacade.RunFinalOptimization(cancelCtx, 5*time.Second)
 		test.That(t, err, test.ShouldBeError)
-		test.That(t, err, test.ShouldResemble, errors.New("test error 5"))
+		test.That(t, err, test.ShouldResemble, expectedErr)
+	})
 
+	t.Run("times out", func(t *testing.T) {
 		carto.RunFinalOptimizationFunc = func() error {
 			time.Sleep(50 * time.Millisecond)
 			return nil
 		}
 		cartoFacade.carto = &carto
-
-		// times out
 		err = cartoFacade.RunFinalOptimization(cancelCtx, 1*time.Millisecond)
 		test.That(t, err, test.ShouldBeError)
 		expectedErr := multierr.Combine(errors.New(timeoutErrMessage), context.DeadlineExceeded)

--- a/cartofacade/carto_facade_test.go
+++ b/cartofacade/carto_facade_test.go
@@ -187,7 +187,6 @@ func TestStart(t *testing.T) {
 		carto.StartFunc = func() error {
 			return nil
 		}
-		cartoFacade.carto = &carto
 		err = cartoFacade.Start(cancelCtx, 5*time.Second)
 		test.That(t, err, test.ShouldBeNil)
 	})
@@ -197,18 +196,16 @@ func TestStart(t *testing.T) {
 		carto.StartFunc = func() error {
 			return expectedErr
 		}
-		cartoFacade.carto = &carto
 		err = cartoFacade.Start(cancelCtx, 5*time.Second)
 		test.That(t, err, test.ShouldBeError)
 		test.That(t, err, test.ShouldResemble, expectedErr)
 	})
 
-	t.Run("times out", func(t *testing.T) {
+	t.Run("failure due to time out", func(t *testing.T) {
 		carto.StartFunc = func() error {
 			time.Sleep(50 * time.Millisecond)
 			return nil
 		}
-		cartoFacade.carto = &carto
 		err = cartoFacade.Start(cancelCtx, 1*time.Millisecond)
 		test.That(t, err, test.ShouldBeError)
 		expectedErr := multierr.Combine(errors.New(timeoutErrMessage), context.DeadlineExceeded)
@@ -248,18 +245,16 @@ func TestStop(t *testing.T) {
 		carto.StopFunc = func() error {
 			return expectedErr
 		}
-		cartoFacade.carto = &carto
 		err = cartoFacade.Stop(cancelCtx, 5*time.Second)
 		test.That(t, err, test.ShouldBeError)
 		test.That(t, err, test.ShouldResemble, expectedErr)
 	})
 
-	t.Run("times out", func(t *testing.T) {
+	t.Run("failure due to time out", func(t *testing.T) {
 		carto.StopFunc = func() error {
 			time.Sleep(50 * time.Millisecond)
 			return nil
 		}
-		cartoFacade.carto = &carto
 		err = cartoFacade.Stop(cancelCtx, 1*time.Millisecond)
 		test.That(t, err, test.ShouldBeError)
 		expectedErr := multierr.Combine(errors.New(timeoutErrMessage), context.DeadlineExceeded)
@@ -299,18 +294,16 @@ func TestTerminate(t *testing.T) {
 		carto.TerminateFunc = func() error {
 			return expectedErr
 		}
-		cartoFacade.carto = &carto
 		err = cartoFacade.Terminate(cancelCtx, 5*time.Second)
 		test.That(t, err, test.ShouldBeError)
 		test.That(t, err, test.ShouldResemble, expectedErr)
 	})
 
-	t.Run("times out", func(t *testing.T) {
+	t.Run("failure due to time out", func(t *testing.T) {
 		carto.TerminateFunc = func() error {
 			time.Sleep(50 * time.Millisecond)
 			return nil
 		}
-		cartoFacade.carto = &carto
 		err = cartoFacade.Terminate(cancelCtx, 1*time.Millisecond)
 		test.That(t, err, test.ShouldBeError)
 		expectedErr := multierr.Combine(errors.New(timeoutErrMessage), context.DeadlineExceeded)
@@ -361,18 +354,16 @@ func TestAddLidarReading(t *testing.T) {
 		carto.AddLidarReadingFunc = func(name string, reading []byte, time time.Time) error {
 			return expectedErr
 		}
-		cartoFacade.carto = &carto
 		err = cartoFacade.AddLidarReading(cancelCtx, 5*time.Second, "mysensor", buf.Bytes(), timestamp)
 		test.That(t, err, test.ShouldBeError)
 		test.That(t, err, test.ShouldResemble, expectedErr)
 	})
 
-	t.Run("times out", func(t *testing.T) {
+	t.Run("failure due to time out", func(t *testing.T) {
 		carto.AddLidarReadingFunc = func(name string, reading []byte, timestamp time.Time) error {
 			time.Sleep(50 * time.Millisecond)
 			return nil
 		}
-		cartoFacade.carto = &carto
 		err = cartoFacade.AddLidarReading(cancelCtx, 1*time.Millisecond, "mysensor", buf.Bytes(), timestamp)
 		test.That(t, err, test.ShouldBeError)
 		expectedErr := multierr.Combine(errors.New(timeoutErrMessage), context.DeadlineExceeded)
@@ -418,20 +409,16 @@ func TestAddIMUReading(t *testing.T) {
 		carto.AddIMUReadingFunc = func(name string, reading IMUReading, time time.Time) error {
 			return expectedErr
 		}
-		cartoFacade.carto = &carto
-
-		// returns error
 		err = cartoFacade.AddIMUReading(cancelCtx, 5*time.Second, "myIMU", testIMUReading, timestamp)
 		test.That(t, err, test.ShouldBeError)
 		test.That(t, err, test.ShouldResemble, expectedErr)
 	})
 
-	t.Run("times out", func(t *testing.T) {
+	t.Run("failure due to time out", func(t *testing.T) {
 		carto.AddIMUReadingFunc = func(name string, reading IMUReading, timestamp time.Time) error {
 			time.Sleep(50 * time.Millisecond)
 			return nil
 		}
-		cartoFacade.carto = &carto
 		err = cartoFacade.AddIMUReading(cancelCtx, 1*time.Millisecond, "myIMU", testIMUReading, timestamp)
 		test.That(t, err, test.ShouldBeError)
 		expectedErr := multierr.Combine(errors.New(timeoutErrMessage), context.DeadlineExceeded)
@@ -463,7 +450,6 @@ func TestPosition(t *testing.T) {
 			pos := Position{X: 1, Y: 2, Z: 3}
 			return pos, nil
 		}
-		cartoFacade.carto = &carto
 		pos, err := cartoFacade.Position(cancelCtx, 5*time.Second)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, pos.X, test.ShouldEqual, 1)
@@ -476,18 +462,16 @@ func TestPosition(t *testing.T) {
 		carto.PositionFunc = func() (Position, error) {
 			return Position{}, expectedErr
 		}
-		cartoFacade.carto = &carto
 		_, err = cartoFacade.Position(cancelCtx, 5*time.Second)
 		test.That(t, err, test.ShouldBeError)
 		test.That(t, err, test.ShouldResemble, expectedErr)
 	})
 
-	t.Run("times out", func(t *testing.T) {
+	t.Run("failure due to time out", func(t *testing.T) {
 		carto.PositionFunc = func() (Position, error) {
 			time.Sleep(50 * time.Millisecond)
 			return Position{}, nil
 		}
-		cartoFacade.carto = &carto
 		_, err = cartoFacade.Position(cancelCtx, 1*time.Millisecond)
 		test.That(t, err, test.ShouldBeError)
 		expectedErr := multierr.Combine(errors.New(timeoutErrMessage), context.DeadlineExceeded)
@@ -519,7 +503,6 @@ func TestInternalState(t *testing.T) {
 		carto.InternalStateFunc = func() ([]byte, error) {
 			return internalState, nil
 		}
-		cartoFacade.carto = &carto
 		internalState, err := cartoFacade.InternalState(cancelCtx, 5*time.Second)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, internalState, test.ShouldResemble, internalState)
@@ -530,18 +513,16 @@ func TestInternalState(t *testing.T) {
 		carto.InternalStateFunc = func() ([]byte, error) {
 			return []byte{}, expectedErr
 		}
-		cartoFacade.carto = &carto
 		_, err = cartoFacade.InternalState(cancelCtx, 5*time.Second)
 		test.That(t, err, test.ShouldBeError)
 		test.That(t, err, test.ShouldResemble, expectedErr)
 	})
 
-	t.Run("times out", func(t *testing.T) {
+	t.Run("failure due to time out", func(t *testing.T) {
 		carto.InternalStateFunc = func() ([]byte, error) {
 			time.Sleep(50 * time.Millisecond)
 			return []byte{}, nil
 		}
-		cartoFacade.carto = &carto
 		_, err = cartoFacade.InternalState(cancelCtx, 1*time.Millisecond)
 		test.That(t, err, test.ShouldBeError)
 		expectedErr := multierr.Combine(errors.New(timeoutErrMessage), context.DeadlineExceeded)
@@ -573,7 +554,6 @@ func TestPointCloudMap(t *testing.T) {
 		carto.PointCloudMapFunc = func() ([]byte, error) {
 			return internalState, nil
 		}
-		cartoFacade.carto = &carto
 		internalState, err := cartoFacade.PointCloudMap(cancelCtx, 5*time.Second)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, internalState, test.ShouldResemble, internalState)
@@ -584,18 +564,16 @@ func TestPointCloudMap(t *testing.T) {
 		carto.PointCloudMapFunc = func() ([]byte, error) {
 			return []byte{}, expectedErr
 		}
-		cartoFacade.carto = &carto
 		_, err = cartoFacade.PointCloudMap(cancelCtx, 5*time.Second)
 		test.That(t, err, test.ShouldBeError)
 		test.That(t, err, test.ShouldResemble, expectedErr)
 	})
 
-	t.Run("times out", func(t *testing.T) {
+	t.Run("failure due to time out", func(t *testing.T) {
 		carto.PointCloudMapFunc = func() ([]byte, error) {
 			time.Sleep(50 * time.Millisecond)
 			return []byte{}, nil
 		}
-		cartoFacade.carto = &carto
 		_, err = cartoFacade.PointCloudMap(cancelCtx, 1*time.Millisecond)
 		test.That(t, err, test.ShouldBeError)
 		expectedErr := multierr.Combine(errors.New(timeoutErrMessage), context.DeadlineExceeded)
@@ -635,18 +613,16 @@ func TestRunFinalOptimization(t *testing.T) {
 		carto.RunFinalOptimizationFunc = func() error {
 			return expectedErr
 		}
-		cartoFacade.carto = &carto
 		err = cartoFacade.RunFinalOptimization(cancelCtx, 5*time.Second)
 		test.That(t, err, test.ShouldBeError)
 		test.That(t, err, test.ShouldResemble, expectedErr)
 	})
 
-	t.Run("times out", func(t *testing.T) {
+	t.Run("failure due to time out", func(t *testing.T) {
 		carto.RunFinalOptimizationFunc = func() error {
 			time.Sleep(50 * time.Millisecond)
 			return nil
 		}
-		cartoFacade.carto = &carto
 		err = cartoFacade.RunFinalOptimization(cancelCtx, 1*time.Millisecond)
 		test.That(t, err, test.ShouldBeError)
 		expectedErr := multierr.Combine(errors.New(timeoutErrMessage), context.DeadlineExceeded)

--- a/cartofacade/carto_facade_test.go
+++ b/cartofacade/carto_facade_test.go
@@ -106,7 +106,7 @@ func TestRequest(t *testing.T) {
 		test.That(t, err, test.ShouldResemble, expectedErr)
 	})
 
-	t.Run("failure due to timeout", func(t *testing.T) {
+	t.Run("fails when the work function takes longer than the timeout", func(t *testing.T) {
 		cancelCtx, cancelFunc := context.WithCancel(context.Background())
 		activeBackgroundWorkers := sync.WaitGroup{}
 

--- a/sensorprocess/sensorprocess_test.go
+++ b/sensorprocess/sensorprocess_test.go
@@ -297,7 +297,7 @@ func TestAddLidarReadingOnline(t *testing.T) {
 		test.That(t, timeToSleep, test.ShouldEqual, 0)
 	})
 
-	t.Run("when AddLidarReading blocks for more than the DataRateMsec"+
+	t.Run("when AddLidarReading blocks for more than the DataRateMsec "+
 		"and returns an unexpected error, time to sleep is 0", func(t *testing.T) {
 		cf.AddLidarReadingFunc = func(
 			ctx context.Context,
@@ -330,7 +330,8 @@ func TestAddLidarReadingOnline(t *testing.T) {
 		test.That(t, timeToSleep, test.ShouldBeLessThanOrEqualTo, config.LidarDataRateMsec)
 	})
 
-	t.Run("when AddLidarReading is faster than the DataRateMsec and returns lock error, time to sleep is <= DataRateMsec", func(t *testing.T) {
+	t.Run("when AddLidarReading is faster than the DataRateMsec "+
+		"and returns lock error, time to sleep is <= DataRateMsec", func(t *testing.T) {
 		cf.AddLidarReadingFunc = func(
 			ctx context.Context,
 			timeout time.Duration,
@@ -346,7 +347,8 @@ func TestAddLidarReadingOnline(t *testing.T) {
 		test.That(t, timeToSleep, test.ShouldBeLessThanOrEqualTo, config.LidarDataRateMsec)
 	})
 
-	t.Run("when AddLidarReading is faster than DataRateMsec and returns an unexpected error, time to sleep is <= DataRateMsec", func(t *testing.T) {
+	t.Run("when AddLidarReading is faster than DataRateMsec "+
+		"and returns an unexpected error, time to sleep is <= DataRateMsec", func(t *testing.T) {
 		cf.AddLidarReadingFunc = func(
 			ctx context.Context,
 			timeout time.Duration,
@@ -460,7 +462,8 @@ func TestAddIMUReadingOnline(t *testing.T) {
 		test.That(t, timeToSleep, test.ShouldBeLessThanOrEqualTo, config.IMUDataRateMsec)
 	})
 
-	t.Run("when AddIMUReading is faster than DataRateMsec and returns an unexpected error, time to sleep is <= DataRateMsec", func(t *testing.T) {
+	t.Run("when AddIMUReading is faster than DataRateMsec "+
+		"and returns an unexpected error, time to sleep is <= DataRateMsec", func(t *testing.T) {
 		cf.AddIMUReadingFunc = func(
 			ctx context.Context,
 			timeout time.Duration,

--- a/sensorprocess/sensorprocess_test.go
+++ b/sensorprocess/sensorprocess_test.go
@@ -265,7 +265,7 @@ func TestAddLidarReadingOnline(t *testing.T) {
 		RunFinalOptimizationFunc: cf.RunFinalOptimization,
 	}
 
-	t.Run("AddLidarReading blocks for more than the DataRateMsec and succeeds, time to sleep is 0", func(t *testing.T) {
+	t.Run("when AddLidarReading blocks for more than the DataRateMsec and succeeds, time to sleep is 0", func(t *testing.T) {
 		cf.AddLidarReadingFunc = func(
 			ctx context.Context,
 			timeout time.Duration,
@@ -281,7 +281,7 @@ func TestAddLidarReadingOnline(t *testing.T) {
 		test.That(t, timeToSleep, test.ShouldEqual, 0)
 	})
 
-	t.Run("AddLidarReading slower than DataRateMsec and returns lock error, time to sleep is 0", func(t *testing.T) {
+	t.Run("when AddLidarReading is slower than DataRateMsec and returns a lock error, time to sleep is 0", func(t *testing.T) {
 		cf.AddLidarReadingFunc = func(
 			ctx context.Context,
 			timeout time.Duration,
@@ -297,7 +297,7 @@ func TestAddLidarReadingOnline(t *testing.T) {
 		test.That(t, timeToSleep, test.ShouldEqual, 0)
 	})
 
-	t.Run("AddLidarReading blocks for more than the DataRateMsec"+
+	t.Run("when AddLidarReading blocks for more than the DataRateMsec"+
 		"and returns an unexpected error, time to sleep is 0", func(t *testing.T) {
 		cf.AddLidarReadingFunc = func(
 			ctx context.Context,
@@ -314,7 +314,7 @@ func TestAddLidarReadingOnline(t *testing.T) {
 		test.That(t, timeToSleep, test.ShouldEqual, 0)
 	})
 
-	t.Run("AddLidarReading faster than the DataRateMsec and succeeds, time to sleep is <= DataRateMsec", func(t *testing.T) {
+	t.Run("when AddLidarReading is faster than the DataRateMsec and succeeds, time to sleep is <= DataRateMsec", func(t *testing.T) {
 		cf.AddLidarReadingFunc = func(
 			ctx context.Context,
 			timeout time.Duration,
@@ -330,7 +330,7 @@ func TestAddLidarReadingOnline(t *testing.T) {
 		test.That(t, timeToSleep, test.ShouldBeLessThanOrEqualTo, config.LidarDataRateMsec)
 	})
 
-	t.Run("AddLidarReading faster than the DataRateMsec and returns lock error, time to sleep is <= DataRateMsec", func(t *testing.T) {
+	t.Run("when AddLidarReading is faster than the DataRateMsec and returns lock error, time to sleep is <= DataRateMsec", func(t *testing.T) {
 		cf.AddLidarReadingFunc = func(
 			ctx context.Context,
 			timeout time.Duration,
@@ -346,7 +346,7 @@ func TestAddLidarReadingOnline(t *testing.T) {
 		test.That(t, timeToSleep, test.ShouldBeLessThanOrEqualTo, config.LidarDataRateMsec)
 	})
 
-	t.Run("AddLidarReading faster than DataRateMsec and returns unexpected error, time to sleep is <= DataRateMsec", func(t *testing.T) {
+	t.Run("when AddLidarReading is faster than DataRateMsec and returns an unexpected error, time to sleep is <= DataRateMsec", func(t *testing.T) {
 		cf.AddLidarReadingFunc = func(
 			ctx context.Context,
 			timeout time.Duration,
@@ -380,7 +380,7 @@ func TestAddIMUReadingOnline(t *testing.T) {
 		Timeout:           10 * time.Second,
 	}
 
-	t.Run("AddIMUReading blocks for more than the DataRateMsec and succeeds, time to sleep is 0", func(t *testing.T) {
+	t.Run("when AddIMUReading blocks for more than the DataRateMsec and succeeds, time to sleep is 0", func(t *testing.T) {
 		cf.AddIMUReadingFunc = func(
 			ctx context.Context,
 			timeout time.Duration,
@@ -396,7 +396,7 @@ func TestAddIMUReadingOnline(t *testing.T) {
 		test.That(t, timeToSleep, test.ShouldEqual, 0)
 	})
 
-	t.Run("AddIMUReading slower than DataRateMsec and returns lock error, time to sleep is 0", func(t *testing.T) {
+	t.Run("when AddIMUReading is slower than DataRateMsec and returns a lock error, time to sleep is 0", func(t *testing.T) {
 		cf.AddIMUReadingFunc = func(
 			ctx context.Context,
 			timeout time.Duration,
@@ -412,7 +412,7 @@ func TestAddIMUReadingOnline(t *testing.T) {
 		test.That(t, timeToSleep, test.ShouldEqual, 0)
 	})
 
-	t.Run("AddIMUReading blocks for more than the DataRateMsec and returns an unexpected error, time to sleep is 0", func(t *testing.T) {
+	t.Run("when AddIMUReading blocks for more than the DataRateMsec and returns an unexpected error, time to sleep is 0", func(t *testing.T) {
 		cf.AddIMUReadingFunc = func(
 			ctx context.Context,
 			timeout time.Duration,
@@ -428,7 +428,7 @@ func TestAddIMUReadingOnline(t *testing.T) {
 		test.That(t, timeToSleep, test.ShouldEqual, 0)
 	})
 
-	t.Run("AddIMUReading faster than the DataRateMsec and succeeds, time to sleep is <= DataRateMsec", func(t *testing.T) {
+	t.Run("when AddIMUReading is faster than the DataRateMsec and succeeds, time to sleep is <= DataRateMsec", func(t *testing.T) {
 		cf.AddIMUReadingFunc = func(
 			ctx context.Context,
 			timeout time.Duration,
@@ -444,7 +444,7 @@ func TestAddIMUReadingOnline(t *testing.T) {
 		test.That(t, timeToSleep, test.ShouldBeLessThanOrEqualTo, config.IMUDataRateMsec)
 	})
 
-	t.Run("AddIMUReading faster than the DataRateMsec and returns lock error, time to sleep is <= DataRateMsec", func(t *testing.T) {
+	t.Run("when AddIMUReading is faster than the DataRateMsec and returns a lock error, time to sleep is <= DataRateMsec", func(t *testing.T) {
 		cf.AddIMUReadingFunc = func(
 			ctx context.Context,
 			timeout time.Duration,
@@ -460,7 +460,7 @@ func TestAddIMUReadingOnline(t *testing.T) {
 		test.That(t, timeToSleep, test.ShouldBeLessThanOrEqualTo, config.IMUDataRateMsec)
 	})
 
-	t.Run("AddIMUReading faster than DataRateMsec and returns unexpected error, time to sleep is <= DataRateMsec", func(t *testing.T) {
+	t.Run("when AddIMUReading is faster than DataRateMsec and returns an unexpected error, time to sleep is <= DataRateMsec", func(t *testing.T) {
 		cf.AddIMUReadingFunc = func(
 			ctx context.Context,
 			timeout time.Duration,

--- a/sensorprocess/sensorprocess_test.go
+++ b/sensorprocess/sensorprocess_test.go
@@ -66,7 +66,7 @@ func TestAddLidarReadingOffline(t *testing.T) {
 		RunFinalOptimizationFunc: runFinalOptimizationFunc,
 	}
 
-	t.Run("When addLidarReading returns successfully, no infinite loop", func(t *testing.T) {
+	t.Run("success, no infinite loop", func(t *testing.T) {
 		cf.AddLidarReadingFunc = func(
 			ctx context.Context,
 			timeout time.Duration,
@@ -79,7 +79,7 @@ func TestAddLidarReadingOffline(t *testing.T) {
 		tryAddLidarReadingUntilSuccess(context.Background(), reading, readingTimestamp, config)
 	})
 
-	t.Run("AddLidarReading returns UNABLE_TO_ACQUIRE_LOCK error and the context is cancelled, no infinite loop", func(t *testing.T) {
+	t.Run("failure with UNABLE_TO_ACQUIRE_LOCK error and cancelled context, no infinite loop", func(t *testing.T) {
 		cf.AddLidarReadingFunc = func(
 			ctx context.Context,
 			timeout time.Duration,
@@ -95,7 +95,7 @@ func TestAddLidarReadingOffline(t *testing.T) {
 		tryAddLidarReadingUntilSuccess(cancelCtx, reading, readingTimestamp, config)
 	})
 
-	t.Run("When AddLidarReading returns a different error and the context is cancelled, no infinite loop", func(t *testing.T) {
+	t.Run("failure with a different error and cancelled context, no infinite loop", func(t *testing.T) {
 		cf.AddLidarReadingFunc = func(
 			ctx context.Context,
 			timeout time.Duration,
@@ -111,7 +111,7 @@ func TestAddLidarReadingOffline(t *testing.T) {
 		tryAddLidarReadingUntilSuccess(cancelCtx, reading, readingTimestamp, config)
 	})
 
-	t.Run("When AddLidarReading hits errors a few times, retries, and then succeeds", func(t *testing.T) {
+	t.Run("failure with errors being hit a few times, a retry, and then success", func(t *testing.T) {
 		cancelCtx, cancelFunc := context.WithCancel(context.Background())
 
 		var calls []addLidarReadingArgs
@@ -166,7 +166,7 @@ func TestAddIMUReadingOffline(t *testing.T) {
 		IMUDataRateMsec: 50,
 		Timeout:         10 * time.Second,
 	}
-	t.Run("When addIMUReading returns successfully, no infinite loop", func(t *testing.T) {
+	t.Run("success, no infinite loop", func(t *testing.T) {
 		cf.AddIMUReadingFunc = func(
 			ctx context.Context,
 			timeout time.Duration,
@@ -179,7 +179,7 @@ func TestAddIMUReadingOffline(t *testing.T) {
 		tryAddIMUReadingUntilSuccess(context.Background(), reading, readingTimestamp, config)
 	})
 
-	t.Run("AddIMUReading returns UNABLE_TO_ACQUIRE_LOCK error and the context is cancelled, no infinite loop", func(t *testing.T) {
+	t.Run("failure with UNABLE_TO_ACQUIRE_LOCK error and cancelled context, no infinite loop", func(t *testing.T) {
 		cf.AddIMUReadingFunc = func(
 			ctx context.Context,
 			timeout time.Duration,
@@ -195,7 +195,7 @@ func TestAddIMUReadingOffline(t *testing.T) {
 		tryAddIMUReadingUntilSuccess(cancelCtx, reading, readingTimestamp, config)
 	})
 
-	t.Run("When AddIMUReading returns a different error and the context is cancelled, no infinite loop", func(t *testing.T) {
+	t.Run("failure with a different error and cancelled context, no infinite loop", func(t *testing.T) {
 		cf.AddIMUReadingFunc = func(
 			ctx context.Context,
 			timeout time.Duration,
@@ -211,7 +211,7 @@ func TestAddIMUReadingOffline(t *testing.T) {
 		tryAddIMUReadingUntilSuccess(cancelCtx, reading, readingTimestamp, config)
 	})
 
-	t.Run("When AddIMUReading hits errors a few times, retries, and then succeeds", func(t *testing.T) {
+	t.Run("failure with errors being hit a few times, a retry, and then success", func(t *testing.T) {
 		cancelCtx, cancelFunc := context.WithCancel(context.Background())
 
 		var calls []addIMUReadingArgs
@@ -265,7 +265,7 @@ func TestAddLidarReadingOnline(t *testing.T) {
 		RunFinalOptimizationFunc: cf.RunFinalOptimization,
 	}
 
-	t.Run("When AddLidarReading blocks for more than the DataRateMsec and succeeds, time to sleep is 0", func(t *testing.T) {
+	t.Run("AddLidarReading blocks for more than the DataRateMsec and succeeds, time to sleep is 0", func(t *testing.T) {
 		cf.AddLidarReadingFunc = func(
 			ctx context.Context,
 			timeout time.Duration,
@@ -297,7 +297,7 @@ func TestAddLidarReadingOnline(t *testing.T) {
 		test.That(t, timeToSleep, test.ShouldEqual, 0)
 	})
 
-	t.Run("When AddLidarReading blocks for more than the DataRateMsec"+
+	t.Run("AddLidarReading blocks for more than the DataRateMsec"+
 		"and returns an unexpected error, time to sleep is 0", func(t *testing.T) {
 		cf.AddLidarReadingFunc = func(
 			ctx context.Context,
@@ -380,7 +380,7 @@ func TestAddIMUReadingOnline(t *testing.T) {
 		Timeout:           10 * time.Second,
 	}
 
-	t.Run("When AddIMUReading blocks for more than the DataRateMsec and succeeds, time to sleep is 0", func(t *testing.T) {
+	t.Run("AddIMUReading blocks for more than the DataRateMsec and succeeds, time to sleep is 0", func(t *testing.T) {
 		cf.AddIMUReadingFunc = func(
 			ctx context.Context,
 			timeout time.Duration,
@@ -412,7 +412,7 @@ func TestAddIMUReadingOnline(t *testing.T) {
 		test.That(t, timeToSleep, test.ShouldEqual, 0)
 	})
 
-	t.Run("When AddIMUReading blocks for more than the DataRateMsec and returns an unexpected error, time to sleep is 0", func(t *testing.T) {
+	t.Run("AddIMUReading blocks for more than the DataRateMsec and returns an unexpected error, time to sleep is 0", func(t *testing.T) {
 		cf.AddIMUReadingFunc = func(
 			ctx context.Context,
 			timeout time.Duration,


### PR DESCRIPTION
Improved readability by changing tests from looking like this:

```bash
=== RUN   TestRequest
=== RUN   TestRequest/test_successful_request
=== RUN   TestRequest/test_failed_request
=== RUN   TestRequest/test_requesting_with_a_canceled_context
=== RUN   TestRequest/test_requesting_with_when_the_work_function_takes_longer_than_the_timeout
--- PASS: TestRequest (0.05s)
    --- PASS: TestRequest/test_successful_request (0.00s)
    --- PASS: TestRequest/test_failed_request (0.00s)
    --- PASS: TestRequest/test_requesting_with_a_canceled_context (0.00s)
    --- PASS: TestRequest/test_requesting_with_when_the_work_function_takes_longer_than_the_timeout (0.05s)
=== RUN   TestStart
=== RUN   TestStart/testing_Start
--- PASS: TestStart (0.05s)
    --- PASS: TestStart/testing_Start (0.00s)
=== RUN   TestStop
=== RUN   TestStop/testing_Stop
--- PASS: TestStop (0.05s)
    --- PASS: TestStop/testing_Stop (0.00s)
```

to looking like this:
```bash
=== RUN   TestRequest
=== RUN   TestRequest/success
=== RUN   TestRequest/failure
=== RUN   TestRequest/failure_due_to_cancelled_context
=== RUN   TestRequest/fails_when_the_work_function_takes_longer_than_the_timeout
--- PASS: TestRequest (0.05s)
    --- PASS: TestRequest/success (0.00s)
    --- PASS: TestRequest/failure (0.00s)
    --- PASS: TestRequest/failure_due_to_cancelled_context (0.00s)
    --- PASS: TestRequest/fails_when_the_work_function_takes_longer_than_the_timeout (0.05s)
=== RUN   TestStart
=== RUN   TestStart/success
=== RUN   TestStart/failure
=== RUN   TestStart/times_out
--- PASS: TestStart (0.05s)
    --- PASS: TestStart/success (0.00s)
    --- PASS: TestStart/failure (0.00s)
    --- PASS: TestStart/times_out (0.00s)
=== RUN   TestStop
=== RUN   TestStop/success
=== RUN   TestStop/failure
=== RUN   TestStop/times_out
--- PASS: TestStop (0.05s)
    --- PASS: TestStop/success (0.00s)
    --- PASS: TestStop/failure (0.00s)
    --- PASS: TestStop/times_out (0.00s)