### PR TITLE
RSDK-3400 update Appimage Ymls

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -31,7 +31,7 @@ jobs:
     container:
       image: ${{ matrix.image }}
       options: --platform ${{ matrix.platform }}
-    timeout-minutes: 30
+    timeout-minutes: 45
 
     steps:
     - name: Check out code

--- a/.github/workflows/pullrequest-trusted.yml
+++ b/.github/workflows/pullrequest-trusted.yml
@@ -7,7 +7,7 @@ concurrency:
 
 on:
   pull_request_target:
-    branches: [ 'RSDK-3591_UpdateWorkflows' ]
+    branches: [ 'main' ]
     types: [ 'labeled' ]
 
 # To test workflow updates you need to work in a branch directly on viamrobotics/viam-cartographer
@@ -28,13 +28,9 @@ jobs:
       always() && !cancelled() && contains(github.event.pull_request.labels.*.name, 'safe to test') &&
       !contains(github.event.pull_request.labels.*.name, 'appimage-ignore-tests') &&
       contains(github.event.pull_request.labels.*.name, 'appimage') && needs.test.result == 'success'
-<<<<<<< HEAD
     uses: viamrobotics/viam-cartographer/.github/workflows/appimage.yml@main
     with:
       release_type: 'pr'
-=======
-    uses: viamrobotics/viam-cartographer/.github/workflows/appimage.yml@RSDK-3591_UpdateWorkflows
->>>>>>> 17a8142 (workflow add)
     secrets:
       GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
 
@@ -42,12 +38,8 @@ jobs:
     if: |
        always() && !cancelled() && contains(github.event.pull_request.labels.*.name, 'safe to test') &&
        contains(github.event.pull_request.labels.*.name, 'appimage-ignore-tests')
-<<<<<<< HEAD
     uses: viamrobotics/viam-cartographer/.github/workflows/appimage.yml@main
     with:
       release_type: 'pr'
-=======
-    uses: viamrobotics/viam-cartographer/.github/workflows/appimage.yml@RSDK-3591_UpdateWorkflows
->>>>>>> 17a8142 (workflow add)
     secrets:
       GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}

--- a/.github/workflows/releasecandidate.yml
+++ b/.github/workflows/releasecandidate.yml
@@ -17,7 +17,7 @@ jobs:
     uses: viamrobotics/viam-cartographer/.github/workflows/test.yml@main
 
   appimage:
-    uses: viamrobotics/viam-cartographer/.github/workflows/appimage.yml@RSDK-3591_UpdateWorkflows
+    uses: viamrobotics/viam-cartographer/.github/workflows/appimage.yml@main
     needs: test
     with:
       release_type: 'rc'

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -17,16 +17,8 @@ jobs:
     uses: viamrobotics/viam-cartographer/.github/workflows/test.yml@main
 
   appimage:
-<<<<<<< HEAD
-<<<<<<< HEAD
   # remove
-=======
->>>>>>> 5ed4420 (RSDK-3591 Update Workflows (#169))
     uses: viamrobotics/viam-cartographer/.github/workflows/appimage.yml@main
-=======
-  # remove
-    uses: viamrobotics/viam-cartographer/.github/workflows/appimage.yml@RSDK-3591_UpdateWorkflows
->>>>>>> 17a8142 (workflow add)
     needs: test
     with:
       release_type: 'stable'


### PR DESCRIPTION
This PR updates the yml files associated with appiamge creation to use new build directories. It also updates the timeouts for appimage and testing workflows from 30 min to 45 mins due to use of self-hosted github cli runners.