### PR TITLE
[RSDK-3906] validation passes when a replay camera does not have data present

### DIFF
--- a/sensors/sensors.go
+++ b/sensors/sensors.go
@@ -159,7 +159,8 @@ func ValidateGetLidarData(
 
 		logger.Debugw("ValidateGetLidarData hit error: ", "error", err)
 		// if the sensor is a replay camera with no data ready, allow validation to pass
-		// offline mode will stop the mapping session if the sensor still has no data
+		// offline mode will stop the mapping session if the sensor still has no data,
+		// while online mode will continue mapping once data is found by the replay sensor
 		if strings.Contains(err.Error(), replaypcd.ErrEndOfDataset.Error()) {
 			break
 		}
@@ -198,7 +199,8 @@ func ValidateGetIMUData(
 
 		logger.Debugw("ValidateGetIMUData hit error: ", "error", err)
 		// if the sensor is a replay imu with no data ready, allow validation to pass
-		// offline mode will stop the mapping session if the sensor still has no data
+		// offline mode will stop the mapping session if the sensor still has no data,
+		// while online mode will continue mapping once data is found by the replay sensor
 		if strings.Contains(err.Error(), replay.ErrEndOfDataset.Error()) {
 			break
 		}


### PR DESCRIPTION
Updates cartographer to pass validation if a replay camera is waiting for data