### PR TITLE
RSDK-4936 Remove DefaultExecutableName

### DIFF
--- a/viam_cartographer.go
+++ b/viam_cartographer.go
@@ -37,8 +37,6 @@ var (
 )
 
 const (
-	// DefaultExecutableName is what this program expects to call to start the cartographer grpc server.
-	DefaultExecutableName                = "carto_grpc_server"
 	defaultLidarDataRateMsec             = 200
 	defaultIMUDataRateMsec               = 50
 	defaultMapRateSec                    = 60


### PR DESCRIPTION
Hey yall, this PR is to remove the unused DefaultExecutableName as it is no longer used.

**Testing:**
None outside of CI tests