### PR TITLE
RSDK-4933 Remove logging for IMU if not configured

### DIFF
--- a/sensors/sensors.go
+++ b/sensors/sensors.go
@@ -111,7 +111,6 @@ func NewIMU(
 	_, span := trace.StartSpan(ctx, "viamcartographer::sensors::NewIMU")
 	defer span.End()
 	if imuName == "" {
-		logger.Info("no movement sensor configured, proceeding without IMU")
 		return IMU{}, nil
 	}
 	newIMU, err := movementsensor.FromDependencies(deps, imuName)

--- a/sensors/sensors.go
+++ b/sensors/sensors.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"math"
+	"strings"
 	"time"
 
 	"github.com/edaniels/golog"
@@ -12,7 +13,9 @@ import (
 	"github.com/pkg/errors"
 	"go.opencensus.io/trace"
 	"go.viam.com/rdk/components/camera"
+	"go.viam.com/rdk/components/camera/replaypcd"
 	"go.viam.com/rdk/components/movementsensor"
+	"go.viam.com/rdk/components/movementsensor/replay"
 	"go.viam.com/rdk/pointcloud"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/spatialmath"
@@ -155,6 +158,12 @@ func ValidateGetLidarData(
 		}
 
 		logger.Debugw("ValidateGetLidarData hit error: ", "error", err)
+		// if the sensor is a replay camera with no data ready, allow validation to pass
+		// offline mode will stop the mapping session if the sensor still has no data,
+		// while online mode will continue mapping once data is found by the replay sensor
+		if strings.Contains(err.Error(), replaypcd.ErrEndOfDataset.Error()) {
+			break
+		}
 		if time.Since(startTime) >= sensorValidationMaxTimeout {
 			return errors.Wrap(err, "ValidateGetLidarData timeout")
 		}
@@ -189,6 +198,12 @@ func ValidateGetIMUData(
 		}
 
 		logger.Debugw("ValidateGetIMUData hit error: ", "error", err)
+		// if the sensor is a replay imu with no data ready, allow validation to pass
+		// offline mode will stop the mapping session if the sensor still has no data,
+		// while online mode will continue mapping once data is found by the replay sensor
+		if strings.Contains(err.Error(), replay.ErrEndOfDataset.Error()) {
+			break
+		}
 		if time.Since(startTime) >= sensorValidationMaxTimeout {
 			return errors.Wrap(err, "ValidateGetIMUData timeout")
 		}

--- a/viam_cartographer.go
+++ b/viam_cartographer.go
@@ -460,7 +460,7 @@ func initCartoFacade(ctx context.Context, cartoSvc *CartographerService) error {
 		cartoSvc.logger.Warn("IMU configured, setting use_imu_data to true")
 		cartoAlgoConfig.UseIMUData = true
 	} else {
-		cartoSvc.logger.Warn("No IMU configured, setting use_imu_data to false")
+		cartoSvc.logger.Debug("No IMU configured, setting use_imu_data to false")
 	}
 
 	cf := cartofacade.New(&cartoLib, cartoCfg, cartoAlgoConfig)


### PR DESCRIPTION
Hey yall, this PR is to remove logging about a missing movement sensor if it is not configured as it is not actually an error to surface to the user. 
I also changed one log from a warning to debug for the same reasons. 
**Testing:**
Ran `viam-cartographer` locally after changes to make sure no warning logs showed up.