### PR TITLE
RSDK-5366 - treat empty string for movement sensor name as not providing a moveme…

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -61,7 +61,7 @@ func (config *Config) Validate(path string) ([]string, error) {
 	deps = append(deps, cameraName)
 
 	imuName, imuExists := config.MovementSensor["name"]
-	if imuExists {
+	if imuExists && imuName != "" {
 		deps = append(deps, imuName)
 	}
 
@@ -95,7 +95,7 @@ func GetOptionalParameters(config *Config, defaultLidarDataFrequencyHz, defaultI
 
 	// Validate movement sensor info and set defaults
 	imuName, exists := config.MovementSensor["name"]
-	if exists {
+	if exists && imuName != "" {
 		optionalConfigParams.ImuName = imuName
 		strMovementSensorDataFreqHz, ok := config.MovementSensor["data_frequency_hz"]
 		if !ok {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -135,7 +135,8 @@ func TestGetOptionalParameters(t *testing.T) {
 		cfgService := makeCfgService()
 
 		cfgService.Attributes["movement_sensor"] = map[string]string{
-			"name": "",
+			"name":              "",
+			"data_frequency_hz": "5",
 		}
 
 		cfg, err := newConfig(cfgService)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -115,7 +115,6 @@ func TestGetOptionalParameters(t *testing.T) {
 
 	t.Run("Pass default parameters", func(t *testing.T) {
 		cfgService := makeCfgService()
-		cfgService.Attributes["sensors"] = []string{"a"}
 		cfg, err := newConfig(cfgService)
 		test.That(t, err, test.ShouldBeNil)
 		optionalConfigParams, err := GetOptionalParameters(

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -134,7 +134,11 @@ func TestGetOptionalParameters(t *testing.T) {
 
 	t.Run("Pass default parameters with no IMU name specified", func(t *testing.T) {
 		cfgService := makeCfgService()
-		cfgService.Attributes["sensors"] = []string{"a"}
+
+		cfgService.Attributes["movement_sensor"] = map[string]string{
+			"name": "",
+		}
+
 		cfg, err := newConfig(cfgService)
 		test.That(t, err, test.ShouldBeNil)
 		optionalConfigParams, err := GetOptionalParameters(
@@ -149,34 +153,6 @@ func TestGetOptionalParameters(t *testing.T) {
 		test.That(t, optionalConfigParams.EnableMapping, test.ShouldBeFalse)
 		test.That(t, optionalConfigParams.MapRateSec, test.ShouldEqual, 0)
 		test.That(t, optionalConfigParams.ExistingMap, test.ShouldEqual, "")
-	})
-
-	t.Run("Return overrides", func(t *testing.T) {
-		cfgService := makeCfgService()
-
-		cfgService.Attributes["camera"] = map[string]string{
-			"name":              "testNameCamera",
-			"data_frequency_hz": "2",
-		}
-		cfgService.Attributes["movement_sensor"] = map[string]string{
-			"name":              "testNameSensor",
-			"data_frequency_hz": "2",
-		}
-
-		cfgService.Attributes["enable_mapping"] = true
-
-		cfg, err := newConfig(cfgService)
-		test.That(t, err, test.ShouldBeNil)
-		optionalConfigParams, err := GetOptionalParameters(
-			cfg,
-			1000,
-			1000,
-			logger)
-		test.That(t, err, test.ShouldBeNil)
-		test.That(t, optionalConfigParams.ImuName, test.ShouldEqual, "testNameSensor")
-		test.That(t, optionalConfigParams.ImuDataFrequencyHz, test.ShouldEqual, 2)
-		test.That(t, optionalConfigParams.LidarDataFrequencyHz, test.ShouldEqual, 2)
-		test.That(t, optionalConfigParams.EnableMapping, test.ShouldBeTrue)
 	})
 
 	t.Run("Return overrides", func(t *testing.T) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -125,9 +125,58 @@ func TestGetOptionalParameters(t *testing.T) {
 			logger)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, optionalConfigParams.LidarDataFrequencyHz, test.ShouldEqual, 1000)
+		test.That(t, optionalConfigParams.ImuName, test.ShouldEqual, "")
+		test.That(t, optionalConfigParams.ImuDataFrequencyHz, test.ShouldEqual, 0)
 		test.That(t, optionalConfigParams.EnableMapping, test.ShouldBeFalse)
 		test.That(t, optionalConfigParams.MapRateSec, test.ShouldEqual, 0)
 		test.That(t, optionalConfigParams.ExistingMap, test.ShouldEqual, "")
+	})
+
+	t.Run("Pass default parameters with no IMU name specified", func(t *testing.T) {
+		cfgService := makeCfgService()
+		cfgService.Attributes["sensors"] = []string{"a"}
+		cfg, err := newConfig(cfgService)
+		test.That(t, err, test.ShouldBeNil)
+		optionalConfigParams, err := GetOptionalParameters(
+			cfg,
+			1000,
+			1000,
+			logger)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, optionalConfigParams.LidarDataFrequencyHz, test.ShouldEqual, 1000)
+		test.That(t, optionalConfigParams.ImuName, test.ShouldEqual, "")
+		test.That(t, optionalConfigParams.ImuDataFrequencyHz, test.ShouldEqual, 0)
+		test.That(t, optionalConfigParams.EnableMapping, test.ShouldBeFalse)
+		test.That(t, optionalConfigParams.MapRateSec, test.ShouldEqual, 0)
+		test.That(t, optionalConfigParams.ExistingMap, test.ShouldEqual, "")
+	})
+
+	t.Run("Return overrides", func(t *testing.T) {
+		cfgService := makeCfgService()
+
+		cfgService.Attributes["camera"] = map[string]string{
+			"name":              "testNameCamera",
+			"data_frequency_hz": "2",
+		}
+		cfgService.Attributes["movement_sensor"] = map[string]string{
+			"name":              "testNameSensor",
+			"data_frequency_hz": "2",
+		}
+
+		cfgService.Attributes["enable_mapping"] = true
+
+		cfg, err := newConfig(cfgService)
+		test.That(t, err, test.ShouldBeNil)
+		optionalConfigParams, err := GetOptionalParameters(
+			cfg,
+			1000,
+			1000,
+			logger)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, optionalConfigParams.ImuName, test.ShouldEqual, "testNameSensor")
+		test.That(t, optionalConfigParams.ImuDataFrequencyHz, test.ShouldEqual, 2)
+		test.That(t, optionalConfigParams.LidarDataFrequencyHz, test.ShouldEqual, 2)
+		test.That(t, optionalConfigParams.EnableMapping, test.ShouldBeTrue)
 	})
 
 	t.Run("Return overrides", func(t *testing.T) {

--- a/viam_cartographer_test.go
+++ b/viam_cartographer_test.go
@@ -95,6 +95,23 @@ func TestNew(t *testing.T) {
 		test.That(t, svc.Close(context.Background()), test.ShouldBeNil)
 	})
 
+	t.Run("Successful creation of cartographer slam service with good lidar without IMU name specified", func(t *testing.T) {
+		termFunc := testhelper.InitTestCL(t, logger)
+		defer termFunc()
+
+		attrCfg := &vcConfig.Config{
+			Camera:         map[string]string{"name": "good_lidar", "data_frequency_hz": testLidarDataFreqHz},
+			MovementSensor: map[string]string{"name": ""},
+			ConfigParams:   map[string]string{"mode": "2d"},
+			EnableMapping:  &_true,
+		}
+
+		svc, err := testhelper.CreateSLAMService(t, attrCfg, logger)
+		test.That(t, err, test.ShouldBeNil)
+
+		test.That(t, svc.Close(context.Background()), test.ShouldBeNil)
+	})
+
 	t.Run("Successful creation of cartographer slam service with good lidar with IMU", func(t *testing.T) {
 		termFunc := testhelper.InitTestCL(t, logger)
 		defer termFunc()


### PR DESCRIPTION
This PR checks if the imuName was provided in the places where we initially only checked if the movement sensor was provided.