### PR TITLE
[RSDK-5601] Add sensor validation when using cloudslam

### DIFF
--- a/viam_cartographer.go
+++ b/viam_cartographer.go
@@ -289,7 +289,7 @@ func New(
 		}
 	}
 
-	// do not initialize CartoFacade or Sensor Processes if using cloudslam
+	// do not initialize CartoFacade or Sensor Processes when using cloudslam
 	if svcConfig.UseCloudSlam != nil && *svcConfig.UseCloudSlam {
 		return &CartographerService{
 			Named:        c.ResourceName().AsNamed(),

--- a/viam_cartographer.go
+++ b/viam_cartographer.go
@@ -170,14 +170,6 @@ func New(
 		return nil, err
 	}
 
-	if svcConfig.UseCloudSlam != nil && *svcConfig.UseCloudSlam {
-		return &CartographerService{
-			Named:        c.ResourceName().AsNamed(),
-			useCloudSlam: true,
-			logger:       logger,
-		}, nil
-	}
-
 	subAlgo := SubAlgo(svcConfig.ConfigParams["mode"])
 	if subAlgo != Dim2d {
 		return nil, errors.Errorf("%v does not have a 'mode: %v'",
@@ -295,6 +287,15 @@ func New(
 			err = errors.Wrap(err, "failed to get data from IMU")
 			return nil, err
 		}
+	}
+
+	// do not initialize CartoFacade or Sensor Processes if using cloudslam
+	if svcConfig.UseCloudSlam != nil && *svcConfig.UseCloudSlam {
+		return &CartographerService{
+			Named:        c.ResourceName().AsNamed(),
+			useCloudSlam: true,
+			logger:       logger,
+		}, nil
 	}
 
 	err = initCartoFacade(cancelCartoFacadeCtx, cartoSvc)


### PR DESCRIPTION
adjusts the code to run sensor validation on the source robot when using cloudslam. If validation fails, the slam card will not appear & the user will see logs pertaining to the failure

https://viam.atlassian.net/browse/RSDK-5601