### PR TITLE
[RSDK-5560] tweak replay sensor process

### DIFF
--- a/sensorprocess/lidarsensorprocess.go
+++ b/sensorprocess/lidarsensorprocess.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/viamrobotics/viam-cartographer/cartofacade"
 	s "github.com/viamrobotics/viam-cartographer/sensors"
+	"go.viam.com/rdk/components/camera/replaypcd"
 )
 
 // StartLidar polls the lidar to get the next sensor reading and adds it to the cartofacade.
@@ -32,6 +33,9 @@ func (config *Config) addLidarReadingInOnline(ctx context.Context) error {
 	// get next lidar data response; ignoring status since it is always false
 	lidarReading, err := config.Lidar.TimedLidarReading(ctx)
 	if err != nil {
+		if errors.Is(err, replaypcd.ErrEndOfDataset) {
+			time.Sleep(1 * time.Second)
+		}
 		return err
 	}
 

--- a/sensorprocess/lidarsensorprocess.go
+++ b/sensorprocess/lidarsensorprocess.go
@@ -37,8 +37,10 @@ func (config *Config) addLidarReadingInOnline(ctx context.Context) error {
 
 	// add lidar data to cartographer and sleep remainder of time interval
 	timeToSleep := config.tryAddLidarReadingOnce(ctx, lidarReading)
-	time.Sleep(time.Duration(timeToSleep) * time.Millisecond)
-	config.Logger.Debugf("lidar sleep for %vms", timeToSleep)
+	if !lidarReading.TestIsReplaySensor {
+		time.Sleep(time.Duration(timeToSleep) * time.Millisecond)
+		config.Logger.Debugf("lidar sleep for %vms", timeToSleep)
+	}
 	return nil
 }
 

--- a/sensorprocess/lidarsensorprocess.go
+++ b/sensorprocess/lidarsensorprocess.go
@@ -7,9 +7,10 @@ import (
 	"math"
 	"time"
 
+	"go.viam.com/rdk/components/camera/replaypcd"
+
 	"github.com/viamrobotics/viam-cartographer/cartofacade"
 	s "github.com/viamrobotics/viam-cartographer/sensors"
-	"go.viam.com/rdk/components/camera/replaypcd"
 )
 
 // StartLidar polls the lidar to get the next sensor reading and adds it to the cartofacade.

--- a/sensorprocess/movementsensorprocess.go
+++ b/sensorprocess/movementsensorprocess.go
@@ -38,7 +38,7 @@ func (config *Config) addIMUReadingInOnline(ctx context.Context) error {
 	// add IMU data to cartographer and sleep remainder of time interval
 	timeToSleep := config.tryAddIMUReadingOnce(ctx, *imuReading.TimedIMUResponse)
 
-	if imuReading.TestIsReplaySensor {
+	if !imuReading.TestIsReplaySensor {
 		time.Sleep(time.Duration(timeToSleep) * time.Millisecond)
 		config.Logger.Debugf("imu sleep for %vms", timeToSleep)
 	}

--- a/sensorprocess/movementsensorprocess.go
+++ b/sensorprocess/movementsensorprocess.go
@@ -37,8 +37,12 @@ func (config *Config) addIMUReadingInOnline(ctx context.Context) error {
 
 	// add IMU data to cartographer and sleep remainder of time interval
 	timeToSleep := config.tryAddIMUReadingOnce(ctx, *imuReading.TimedIMUResponse)
-	time.Sleep(time.Duration(timeToSleep) * time.Millisecond)
-	config.Logger.Debugf("imu sleep for %vms", timeToSleep)
+
+	if imuReading.TestIsReplaySensor {
+		time.Sleep(time.Duration(timeToSleep) * time.Millisecond)
+		config.Logger.Debugf("imu sleep for %vms", timeToSleep)
+	}
+
 	return nil
 }
 

--- a/sensorprocess/movementsensorprocess.go
+++ b/sensorprocess/movementsensorprocess.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/viamrobotics/viam-cartographer/cartofacade"
 	s "github.com/viamrobotics/viam-cartographer/sensors"
+	replaymovementsensor "go.viam.com/rdk/components/movementsensor/replay"
 )
 
 // StartIMU polls the IMU to get the next sensor reading and adds it to the cartofacade.
@@ -32,6 +33,9 @@ func (config *Config) addIMUReadingInOnline(ctx context.Context) error {
 	imuReading, err := config.IMU.TimedMovementSensorReading(ctx)
 	if err != nil {
 		config.Logger.Warn(err)
+		if errors.Is(err, replaymovementsensor.ErrEndOfDataset) {
+			time.Sleep(1 * time.Second)
+		}
 		return err
 	}
 

--- a/sensorprocess/movementsensorprocess.go
+++ b/sensorprocess/movementsensorprocess.go
@@ -7,9 +7,10 @@ import (
 	"math"
 	"time"
 
+	replaymovementsensor "go.viam.com/rdk/components/movementsensor/replay"
+
 	"github.com/viamrobotics/viam-cartographer/cartofacade"
 	s "github.com/viamrobotics/viam-cartographer/sensors"
-	replaymovementsensor "go.viam.com/rdk/components/movementsensor/replay"
 )
 
 // StartIMU polls the IMU to get the next sensor reading and adds it to the cartofacade.

--- a/sensorprocess/sensorprocess.go
+++ b/sensorprocess/sensorprocess.go
@@ -3,7 +3,7 @@ package sensorprocess
 
 import (
 	"context"
-	"strings"
+	"errors"
 	"time"
 
 	"go.viam.com/rdk/components/camera/replaypcd"
@@ -34,7 +34,7 @@ func (config *Config) StartOfflineSensorProcess(ctx context.Context) bool {
 	lidarReading, err := config.Lidar.TimedLidarReading(ctx)
 	if err != nil {
 		config.Logger.Warn(err)
-		return strings.Contains(err.Error(), replaypcd.ErrEndOfDataset.Error())
+		return errors.Is(err, replaypcd.ErrEndOfDataset)
 	}
 
 	var imuReading s.TimedIMUReadingResponse
@@ -44,7 +44,7 @@ func (config *Config) StartOfflineSensorProcess(ctx context.Context) bool {
 			movementSensorReading, err := config.IMU.TimedMovementSensorReading(ctx)
 			if err != nil {
 				config.Logger.Warn(err)
-				return strings.Contains(err.Error(), replaymovementsensor.ErrEndOfDataset.Error())
+				return errors.Is(err, replaymovementsensor.ErrEndOfDataset)
 			}
 
 			imuReading = *movementSensorReading.TimedIMUResponse
@@ -70,7 +70,7 @@ func (config *Config) StartOfflineSensorProcess(ctx context.Context) bool {
 				lidarReading, err = config.Lidar.TimedLidarReading(ctx)
 				if err != nil {
 					config.Logger.Warn(err)
-					lidarEndOfDataSetReached := strings.Contains(err.Error(), replaypcd.ErrEndOfDataset.Error())
+					lidarEndOfDataSetReached := errors.Is(err, replaypcd.ErrEndOfDataset)
 					if lidarEndOfDataSetReached {
 						config.runFinalOptimization(ctx)
 					}
@@ -83,7 +83,7 @@ func (config *Config) StartOfflineSensorProcess(ctx context.Context) bool {
 				movementSensorReading, err := config.IMU.TimedMovementSensorReading(ctx)
 				if err != nil {
 					config.Logger.Warn(err)
-					msEndOfDataSetReached := strings.Contains(err.Error(), replaymovementsensor.ErrEndOfDataset.Error())
+					msEndOfDataSetReached := errors.Is(err, replaymovementsensor.ErrEndOfDataset)
 					if msEndOfDataSetReached {
 						config.runFinalOptimization(ctx)
 					}


### PR DESCRIPTION
https://viam.atlassian.net/browse/RSDK-5560

testing for adjusting the online replay sensor process to reduce the lag buildup in cloudslam. User's will see changes in their map within 5-10 seconds, and can be configured to be shorter by adjusting the sync rate in the user's capture config.