### PR TITLE
RSDK-6397 - create do Command to get positions from carto

### DIFF
--- a/viam_cartographer.go
+++ b/viam_cartographer.go
@@ -64,7 +64,7 @@ const (
 	PositionHistoryGetCommand = "position_history_get"
 	// PositionHistoryEnableCommand will change whether or not the UI will get the PositionHistory
 	PositionHistoryEnableCommand = "position_history_enable"
-	// PositionHistoryValue will change whether or not the UI will get the PositionHistory
+	// PositionHistoryValueCommand will change whether or not the UI will get the PositionHistory
 	PositionHistoryValueCommand = "position_history_value"
 	// SuccessMessage is sent back after a successful DoCommand request.
 	SuccessMessage = "success"
@@ -599,7 +599,10 @@ func (cartoSvc *CartographerService) slamPathPointCloud(ctx context.Context) ([]
 	var pc = pointcloud.NewWithPrealloc(len(cartoSvc.positionHistory))
 
 	for _, point := range cartoSvc.positionHistory {
-		pc.Set(point, pointcloud.NewColoredData(color.NRGBA{G: math.MaxUint8}))
+		err := pc.Set(point, pointcloud.NewColoredData(color.NRGBA{G: math.MaxUint8}))
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	var buf bytes.Buffer

--- a/viam_cartographer.go
+++ b/viam_cartographer.go
@@ -60,11 +60,11 @@ const (
 
 	// JobDoneCommand is the string that needs to be sent to DoCommand to find out if the job has finished.
 	JobDoneCommand = "job_done"
-	// PositionHistoryGetCommand will return the point cloud merged with the position history
+	// PositionHistoryGetCommand will return the point cloud merged with the position history.
 	PositionHistoryGetCommand = "position_history_get"
-	// PositionHistoryEnableCommand will change whether or not the UI will get the PositionHistory
+	// PositionHistoryEnableCommand will set the boolean that enables position rendering on the UI to true.
 	PositionHistoryEnableCommand = "position_history_enable"
-	// PositionHistoryValueCommand will change whether or not the UI will get the PositionHistory
+	// PositionHistoryValueCommand will change whether or not the UI will render the Position History.
 	PositionHistoryValueCommand = "position_history_value"
 	// SuccessMessage is sent back after a successful DoCommand request.
 	SuccessMessage = "success"

--- a/viam_cartographer.go
+++ b/viam_cartographer.go
@@ -596,7 +596,7 @@ func (cartoSvc *CartographerService) PointCloudMap(ctx context.Context) (func() 
 }
 
 func (cartoSvc *CartographerService) slamPathPointCloud() ([]byte, error) {
-	var pc = pointcloud.NewWithPrealloc(len(cartoSvc.positionHistory))
+	pc := pointcloud.NewWithPrealloc(len(cartoSvc.positionHistory))
 
 	for _, point := range cartoSvc.positionHistory {
 		err := pc.Set(point, pointcloud.NewColoredData(color.NRGBA{G: math.MaxUint8}))

--- a/viam_cartographer.go
+++ b/viam_cartographer.go
@@ -595,7 +595,7 @@ func (cartoSvc *CartographerService) PointCloudMap(ctx context.Context) (func() 
 	return toChunkedFunc(pc), nil
 }
 
-func (cartoSvc *CartographerService) slamPathPointCloud(ctx context.Context) ([]byte, error) {
+func (cartoSvc *CartographerService) slamPathPointCloud() ([]byte, error) {
 	var pc = pointcloud.NewWithPrealloc(len(cartoSvc.positionHistory))
 
 	for _, point := range cartoSvc.positionHistory {
@@ -725,7 +725,7 @@ func (cartoSvc *CartographerService) DoCommand(ctx context.Context, req map[stri
 	}
 
 	if _, ok := req[PositionHistoryGetCommand]; ok {
-		pc, err := cartoSvc.slamPathPointCloud(ctx)
+		pc, err := cartoSvc.slamPathPointCloud()
 		if err != nil {
 			return nil, errors.Wrap(ErrBadSlamPathPointCloud, err.Error())
 		}

--- a/viam_cartographer_test.go
+++ b/viam_cartographer_test.go
@@ -34,9 +34,27 @@ const (
 )
 
 var (
-	_zeroTime = time.Time{}
-	_true     = true
-	_false    = false
+	_zeroTime       = time.Time{}
+	_true           = true
+	_false          = false
+	emptyPointCloud = []byte{
+		86, 69, 82, 83, 73, 79, 78, 32,
+		46, 55, 10, 70, 73, 69, 76, 68,
+		83, 32, 120, 32, 121, 32, 122,
+		10, 83, 73, 90, 69, 32, 52, 32,
+		52, 32, 52, 10, 84, 89, 80, 69,
+		32, 70, 32, 70, 32, 70, 10, 67,
+		79, 85, 78, 84, 32, 49, 32, 49,
+		32, 49, 10, 87, 73, 68, 84, 72,
+		32, 48, 10, 72, 69, 73, 71, 72,
+		84, 32, 49, 10, 86, 73, 69, 87,
+		80, 79, 73, 78, 84, 32, 48, 32,
+		48, 32, 48, 32, 49, 32, 48, 32,
+		48, 32, 48, 10, 80, 79, 73, 78,
+		84, 83, 32, 48, 10, 68, 65, 84,
+		65, 32, 98, 105, 110, 97, 114,
+		121, 10,
+	}
 )
 
 func TestNew(t *testing.T) {
@@ -517,5 +535,41 @@ func TestDoCommand(t *testing.T) {
 			test.That(t, err.Error(), test.ShouldContainSubstring, viamcartographer.ErrBadPostprocessingPath.Error())
 			test.That(t, resp, test.ShouldBeNil)
 		})
+	t.Run("position history value and enable return expectedly", func(t *testing.T) {
+		cmd := map[string]interface{}{viamcartographer.PositionHistoryValueCommand: ""}
+		resp, err := svc.DoCommand(context.Background(), cmd)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(
+			t,
+			resp, test.ShouldResemble,
+			map[string]interface{}{viamcartographer.PositionHistoryValueCommand: false},
+		)
+
+		cmd = map[string]interface{}{viamcartographer.PositionHistoryEnableCommand: ""}
+		resp, err = svc.DoCommand(context.Background(), cmd)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(
+			t,
+			resp, test.ShouldResemble,
+			map[string]interface{}{viamcartographer.PositionHistoryEnableCommand: viamcartographer.SuccessMessage},
+		)
+
+		cmd = map[string]interface{}{viamcartographer.PositionHistoryValueCommand: ""}
+		resp, err = svc.DoCommand(context.Background(), cmd)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(
+			t,
+			resp, test.ShouldResemble,
+			map[string]interface{}{viamcartographer.PositionHistoryValueCommand: true},
+		)
+	})
+	t.Run("position history get returns a byte slice of the pointcloud", func(t *testing.T) {
+		cmd := map[string]interface{}{viamcartographer.PositionHistoryGetCommand: ""}
+		resp, err := svc.DoCommand(context.Background(), cmd)
+		test.That(t, err, test.ShouldBeNil)
+		val, ok := resp[viamcartographer.PositionHistoryGetCommand]
+		test.That(t, ok, test.ShouldBeTrue)
+		test.That(t, val, test.ShouldResemble, emptyPointCloud)
+	})
 	test.That(t, svc.Close(context.Background()), test.ShouldBeNil)
 }


### PR DESCRIPTION
### Adds 3 Commands to the `DoCommand`:
1. `PositionHistoryGetCommand = "position_history_get"`
      * Gets pointcloud representation of every position the robot has been in during a call to `Position`
2. `PositionHistoryEnableCommand = "position_history_enable"`
      * sets a boolean value that the FE checks and uses to determine whether or not to render the points, if this became a documented real feature we could just store this boolean in the FE and use a toggle button there to set it 
3. `PositionHistoryValueCommand = "position_history_value"`
      * Gets the boolean that determines whether or not the FE should display the position history
      
      
### Related PRS:
* RDK RC changes that call this DoCommand (calls command (3) & if it is true calls (1) to get the actual position and inputs to the prime component): https://github.com/viamrobotics/rdk/pull/3460
* Prime changes (combines path and map point cloud, path points have max value on the G and that are set to turquoise using that fact.: https://github.com/viamrobotics/prime/pull/469



https://github.com/viamrobotics/viam-cartographer/assets/121991867/1fa8dd4b-14d0-4abe-b680-095385089072

