### PR TITLE
RSDK-1888 Change log level for cartographer logs

### DIFF
--- a/viam-cartographer/src/carto_facade/carto_facade.cc
+++ b/viam-cartographer/src/carto_facade/carto_facade.cc
@@ -844,7 +844,7 @@ extern int viam_carto_lib_terminate(viam_carto_lib **ppVCL) {
         return VIAM_CARTO_LIB_INVALID;
     }
 
-    FLAGS_logtostderr = 0;
+    FLAGS_logtostdout = 0;
     FLAGS_minloglevel = 0;
     FLAGS_v = 0;
     google::ShutdownGoogleLogging();

--- a/viam-cartographer/src/carto_facade/carto_facade.cc
+++ b/viam-cartographer/src/carto_facade/carto_facade.cc
@@ -824,7 +824,7 @@ extern int viam_carto_lib_init(viam_carto_lib **ppVCL, int minloglevel,
         return VIAM_CARTO_OUT_OF_MEMORY;
     }
     google::InitGoogleLogging("cartographer");
-    FLAGS_logtostderr = 1;
+    FLAGS_logtostdout = 1;
     FLAGS_minloglevel = minloglevel;
     FLAGS_v = verbose;
     vcl->minloglevel = minloglevel;

--- a/viam-cartographer/src/carto_facade/carto_facade_test.cc
+++ b/viam-cartographer/src/carto_facade/carto_facade_test.cc
@@ -139,13 +139,13 @@ BOOST_AUTO_TEST_SUITE(CartoFacadeCPPAPI);
 
 BOOST_AUTO_TEST_CASE(CartoFacade_lib_init_terminate) {
     viam_carto_lib *lib;
-    BOOST_TEST(FLAGS_logtostderr == 0);
+    BOOST_TEST(FLAGS_logtostdout == 0);
     BOOST_TEST(viam_carto_lib_init(nullptr, 0, 0) == VIAM_CARTO_LIB_INVALID);
     BOOST_TEST(viam_carto_lib_terminate(nullptr) == VIAM_CARTO_LIB_INVALID);
     viam_carto_lib *invalidlib = nullptr;
     BOOST_TEST(viam_carto_lib_terminate(&invalidlib) == VIAM_CARTO_LIB_INVALID);
 
-    BOOST_TEST(FLAGS_logtostderr == 0);
+    BOOST_TEST(FLAGS_logtostdout == 0);
     BOOST_TEST(FLAGS_v == 0);
     BOOST_TEST(FLAGS_minloglevel == 0);
     BOOST_TEST(viam_carto_lib_init(&lib, 2, 3) == VIAM_CARTO_SUCCESS);
@@ -153,13 +153,13 @@ BOOST_AUTO_TEST_CASE(CartoFacade_lib_init_terminate) {
     BOOST_TEST(lib->minloglevel == 2);
     BOOST_TEST(lib->verbose == 3);
     // begin global side effects
-    BOOST_TEST(FLAGS_logtostderr == 1);
+    BOOST_TEST(FLAGS_logtostdout == 1);
     BOOST_TEST(FLAGS_minloglevel == 2);
     BOOST_TEST(FLAGS_v == 3);
     // end global side effects
     BOOST_TEST(viam_carto_lib_terminate(&lib) == VIAM_CARTO_SUCCESS);
     BOOST_TEST(lib == nullptr);
-    BOOST_TEST(FLAGS_logtostderr == 0);
+    BOOST_TEST(FLAGS_logtostdout == 0);
     BOOST_TEST(FLAGS_v == 0);
     BOOST_TEST(FLAGS_minloglevel == 0);
 }


### PR DESCRIPTION
This PR converts the cartographer logs to info instead of err.

------------------------------------------------------- BEFORE --------------------------------------------------------
Run with: **go run web/cmd/server/main.go -config /etc/viam.json -debug**
```
2024-01-29T13:21:21.302-0500	ERROR	robot_server	zap/options.go:212	finished unary call with code Unknown	{"grpc.start_time": "2024-01-29T13:21:21-05:00", "system": "grpc", "span.kind": "server", "grpc.service": "viam.service.motion.v1.MotionService", "grpc.method": "GetPlan", "error": "rpc error: code = Unknown desc = resource \"rdk:component:base/viam_base\" not found", "grpc.code": "Unknown", "grpc.time_ms": 0.456}
2024-01-29T13:21:26.416-0500	ERROR	robot_server	zap/options.go:212	finished unary call with code Unknown	{"grpc.start_time": "2024-01-29T13:21:26-05:00", "system": "grpc", "span.kind": "server", "grpc.service": "viam.service.motion.v1.MotionService", "grpc.method": "GetPlan", "error": "rpc error: code = Unknown desc = resource \"rdk:component:base/viam_base\" not found", "grpc.code": "Unknown", "grpc.time_ms": 0.399}
2024-01-29T13:21:31.520-0500	ERROR	robot_server	zap/options.go:212	finished unary call with code Unknown	{"grpc.start_time": "2024-01-29T13:21:31-05:00", "system": "grpc", "span.kind": "server", "grpc.service": "viam.service.motion.v1.MotionService", "grpc.method": "GetPlan", "error": "rpc error: code = Unknown desc = resource \"rdk:component:base/viam_base\" not found", "grpc.code": "Unknown", "grpc.time_ms": 0.355}
2024-01-29T13:21:32.979-0500	ERROR	robot_server.process.cartographer-module_/usr/local/bin/cartographer-module.StdErr	pexec/managed_process.go:242
\_ W20240129 13:21:32.979741  1570 preprocessor.cc:68] Specified options.num_threads: 7 exceeds maximum available from the threading model Ceres was compiled with: 4.  Bounding to maximum number available.
2024-01-29T13:21:36.553-0500	ERROR	robot_server	zap/options.go:212	finished unary call with code Unknown	{"grpc.start_time": "2024-01-29T13:21:36-05:00", "system": "grpc", "span.kind": "server", "grpc.service": "viam.service.motion.v1.MotionService", "grpc.method": "GetPlan", "error": "rpc error: code = Unknown desc = resource \"rdk:component:base/viam_base\" not found", "grpc.code": "Unknown", "grpc.time_ms": 0.337}
2024-01-29T13:21:41.792-0500	ERROR	robot_server	zap/options.go:212	finished unary call with code Unknown	{"grpc.start_time": "2024-01-29T13:21:41-05:00", "system": "grpc", "span.kind": "server", "grpc.service": "viam.service.motion.v1.MotionService", "grpc.method": "GetPlan", "error": "rpc error: code = Unknown desc = resource \"rdk:component:base/viam_base\" not found", "grpc.code": "Unknown", "grpc.time_ms": 0.708}
2024-01-29T13:21:46.838-0500	ERROR	robot_server	zap/options.go:212	finished unary call with code Unknown	{"grpc.start_time": "2024-01-29T13:21:46-05:00", "system": "grpc", "span.kind": "server", "grpc.service": "viam.service.motion.v1.MotionService", "grpc.method": "GetPlan", "error": "rpc error: code = Unknown desc = resource \"rdk:component:base/viam_base\" not found", "grpc.code": "Unknown", "grpc.time_ms": 0.474}
2024-01-29T13:21:51.978-0500	ERROR	robot_server	zap/options.go:212	finished unary call with code Unknown	{"grpc.start_time": "2024-01-29T13:21:51-05:00", "system": "grpc", "span.kind": "server", "grpc.service": "viam.service.motion.v1.MotionService", "grpc.method": "GetPlan", "error": "rpc error: code = Unknown desc = resource \"rdk:component:base/viam_base\" not found", "grpc.code": "Unknown", "grpc.time_ms": 0.366}
2024-01-29T13:21:53.699-0500	ERROR	robot_server.process.cartographer-module_/usr/local/bin/cartographer-module.StdErr	pexec/managed_process.go:242
\_ W20240129 13:21:53.699640  1571 preprocessor.cc:68] Specified options.num_threads: 7 exceeds maximum available from the threading model Ceres was compiled with: 4.  Bounding to maximum number available.
```

-------------------------------------------------------- AFTER --------------------------------------------------------
Run with: **go run web/cmd/server/main.go -config /etc/viam.json**
```
2024-01-29T13:38:49.489-0500	INFO	robot_server	rpc/server.go:556	will run external signaling answerer	{"signaling_address": "app.viam.com:443", "for_hosts": ["jhlaptop-main.h63500gc3x.viam.cloud"]}
2024-01-29T18:38:49.510Z	INFO	robot_server	web/web.go:598	serving	{"url":"https://jhlaptop-main.h63500gc3x.local.viam.cloud:8080","alt_url":"https://0.0.0.0:8080"}
^C2024-01-29T13:38:58.811-0500	INFO	robot_server	rpc/server.go:785	stopping
2024-01-29T18:38:58.811Z	ERROR	robot_server	config/watcher.go:71	error reading cloud config	{"error":"error getting cloud config: rpc error: code = Canceled desc = context canceled","errorVerbose":"rpc error: code = Canceled desc = context canceled\nerror getting cloud config\ngo.viam.com/rdk/config.readFromCloud\n\t/Users/jeremyhyde/Development/rdk/config/reader.go:208\ngo.viam.com/rdk/config.newCloudWatcher.func1\n\t/Users/jeremyhyde/Development/rdk/config/watcher.go:69\ngo.viam.com/utils.ManagedGo.func1\n\t/Users/jeremyhyde/go/pkg/mod/go.viam.com/utils@v0.1.59/runtime.go:180\ngo.viam.com/utils.PanicCapturingGoWithCallback.func1\n\t/Users/jeremyhyde/go/pkg/mod/go.viam.com/utils@v0.1.59/runtime.go:164\nruntime.goexit\n\t/opt/homebrew/Cellar/go/1.21.6/libexec/src/runtime/asm_arm64.s:1197"}
2024-01-29T13:38:58.812-0500	INFO	robot_server	rpc/wrtc_server.go:88	waiting for handlers to complete
2024-01-29T13:38:58.813-0500	INFO	robot_server	rpc/wrtc_server.go:90	handlers complete
2024-01-29T13:38:58.813-0500	INFO	robot_server	rpc/wrtc_server.go:92	closing lingering peer connections
2024-01-29T13:38:58.813-0500	INFO	robot_server	rpc/wrtc_server.go:98	lingering peer connections closed
2024-01-29T13:38:58.816-0500	INFO	robot_server	rpc/server.go:816	stopped cleanly
2024-01-29T13:38:58.818-0500	INFO	robot_server.process.cartographer-module_/usr/local/bin/cartographer-module.StdOut	pexec/managed_process.go:244
\_ 2024-01-29T13:38:58.818-0500	INFO	cartographerModule.rdk:service:slam/carto	viam-cartographer/viam_cartographer.go:733	Closing cartographer module
2024-01-29T13:38:58.918-0500	INFO	robot_server.process.cartographer-module_/usr/local/bin/cartographer-module.StdOut	pexec/managed_process.go:244
Optimizing: Done.
2024-01-29T13:38:58.918-0500	INFO	robot_server.process.cartographer-module_/usr/local/bin/cartographer-module.StdOut	pexec/managed_process.go:244
\_ 2024-01-29T13:38:58.918-0500	INFO	cartographerModule.rdk:service:slam/carto	viam-cartographer/viam_cartographer.go:754	Closing complete
2024-01-29T13:38:59.523-0500	INFO	robot_server.process.rplidar-module_/usr/local/bin/rplidar-module.StdOut	pexec/managed_process.go:244
\_ closing out lock file for current process:  /tmp/rplidar_pid30036_dvtty.usbserial-0001.lock
2024-01-29T13:38:59.524-0500	INFO	robot_server.process.rplidar-module_/usr/local/bin/rplidar-module	pexec/managed_process_unix.go:91	stopping process 30036 with signal terminated
2024-01-29T13:38:59.524-0500	INFO	robot_server.process.rplidar-module_/usr/local/bin/rplidar-module.StdOut	pexec/managed_process.go:244
\_ 2024-01-29T18:38:59.524Z	INFO	rplidarModule	module/module.go:241	Shutting down gracefully.
2024-01-29T13:38:59.536-0500	INFO	robot_server.process.cartographer-module_/usr/local/bin/cartographer-module	pexec/managed_process_unix.go:91	stopping process 30037 with signal terminated
2024-01-29T13:38:59.537-0500	INFO	robot_server.process.cartographer-module_/usr/local/bin/cartographer-module.StdOut	pexec/managed_process.go:244
\_ 2024-01-29T18:38:59.537Z	INFO	cartographerModule	module/module.go:243	Shutting down gracefully.
```

Run with: **go run web/cmd/server/main.go -config /etc/viam.json -debug**
```
2024-01-29T13:39:21.796-0500	INFO	robot_server.process.cartographer-module_/usr/local/bin/cartographer-module.StdOut	pexec/managed_process.go:244
\_ I20240129 13:39:21.783699 8130784 util.cc:154] [viam::carto_facade::io::read_pcd] Loaded as a denseblob in 0.279ms with 637points. Available dimensions: x y z
2024-01-29T13:39:21.796-0500	INFO	robot_server.process.cartographer-module_/usr/local/bin/cartographer-module.StdOut	pexec/managed_process.go:244
\_ I20240129 13:39:21.783764 8130784 util.cc:178] read_pcd succeeded
2024-01-29T13:39:21.796-0500	INFO	robot_server.process.cartographer-module_/usr/local/bin/cartographer-module.StdOut	pexec/managed_process.go:244
\_ I20240129 13:39:21.784258 8130784 util.cc:183] Loaded 637 data points
2024-01-29T13:39:21.796-0500	INFO	robot_server.process.cartographer-module_/usr/local/bin/cartographer-module.StdOut	pexec/managed_process.go:244
\_ I20240129 13:39:21.785260 8130784 carto_facade.cc:652] AddSensorData timestamp: 17065535617830000 Sensor type: Lidar  measurement.ranges.size(): 637
2024-01-29T13:39:21.806-0500	INFO	robot_server.process.cartographer-module_/usr/local/bin/cartographer-module.StdOut	pexec/managed_process.go:244
\_ I20240129 13:39:21.789924 8130784 callbacks.cc:125] iter      cost      cost_change  |gradient|   |step|    tr_ratio  tr_radius  ls_iter  iter_time  total_time
2024-01-29T13:39:21.806-0500	INFO	robot_server.process.cartographer-module_/usr/local/bin/cartographer-module.StdOut	pexec/managed_process.go:244
\_    0  1.150244e-01    0.00e+00    1.05e-01   0.00e+00   0.00e+00  1.00e+04        0    1.38e-04    1.86e-04
2024-01-29T13:39:21.806-0500	INFO	robot_server.process.cartographer-module_/usr/local/bin/cartographer-module.StdOut	pexec/managed_process.go:244
\_ I20240129 13:39:21.790184 8130784 callbacks.cc:125]    1  1.150055e-01    1.89e-05    6.69e-02   9.40e-04   3.60e-01  9.78e+03        1    2.30e-04    4.58e-04
2024-01-29T13:39:21.806-0500	INFO	robot_server.process.cartographer-module_/usr/local/bin/cartographer-module.StdOut	pexec/managed_process.go:244
\_ I20240129 13:39:21.790390 8130784 callbacks.cc:125]    2  1.149981e-01    7.42e-06    4.29e-02   6.16e-04   3.36e-01  9.45e+03        1    1.78e-04    6.62e-04
2024-01-29T13:39:21.808-0500	INFO	robot_server.process.cartographer-module_/usr/local/bin/cartographer-module.StdOut	pexec/managed_process.go:244
\_ I20240129 13:39:21.790604 8130784 callbacks.cc:125]    3  1.149949e-01    3.21e-06    2.78e-02   4.11e-04   3.27e-01  9.07e+03        1    1.92e-04    8.79e-04
2024-01-29T13:39:21.808-0500	INFO	robot_server.process.cartographer-module_/usr/local/bin/cartographer-module.StdOut	pexec/managed_process.go:244
\_ I20240129 13:39:21.790853 8130784 callbacks.cc:125]    4  1.12024-01-29T13:39:21.791-0500	DEBUG	cartographerModule.rdk:service:slam/carto	sensorprocess/lidarsensorprocess.go:93	2024-01-29 18:39:21.783093 +0000 UTC 	 | LIDAR | Success 	 	 | 1706553561
2024-01-29T13:39:21.808-0500	INFO	robot_server.process.cartographer-module_/usr/local/bin/cartographer-module.StdOut	pexec/managed_process.go:244
\_
2024-01-29T13:39:21.984-0500	INFO	robot_server.process.cartographer-module_/usr/local/bin/cartographer-module.StdOut	pexec/managed_process.go:244
\_ 2024-01-29T13:39:21.983-0500	DEBUG	cartographerModule.rdk:service:slam/carto	sensorprocess/lidarsensorprocess.go:47	lidar sleep for 192ms
2024-01-29T13:39:21.999-0500	INFO	robot_server	zap/options.go:212	finished unary call with code OK	{"grpc.start_time": "2024-01-29T13:39:21-05:00", "system": "grpc", "span.kind": "server", "grpc.service": "viam.robot.v1.RobotService", "grpc.method": "SendSessionHeartbeat", "grpc.code": "OK", "grpc.time_ms": 0.135}
2024-01-29T13:39:22.085-0500	INFO	robot_server.process.cartographer-module_/usr/local/bin/cartographer-module.StdOut	pexec/managed_process.go:244
\_ 2024-01-29T13:39:21.989-0500	DEBUG	cartographerModule.rdk:service:slam/carto	sensorprocess/lidarsensorprocess.go:93	2024-01-29 18:39:21.98583 +0000 UTC 	 | LIDAR | Success 	 	 | 1706553561
2024-01-29T13:39:22.085-0500	INFO	robot_server.process.cartographer-module_/usr/local/bin/cartographer-module.StdOut	pexec/managed_process.go:244
\_
2024-01-29T13:39:22.097-0500	INFO	robot_server	zap/options.go:212	finished unary call with code OK	{"grpc.start_time": "2024-01-29T13:39:22-05:00", "system": "grpc", "span.kind": "server", "grpc.service": "viam.robot.v1.RobotService", "grpc.method": "ResourceNames", "grpc.code": "OK", "grpc.time_ms": 0.101}
2024-01-29T13:39:22.098-0500	INFO	robot_server	zap/options.go:212	finished unary call with code OK	{"grpc.start_time": "2024-01-29T13:39:22-05:00", "system": "grpc", "span.kind": "server", "grpc.service": "viam.robot.v1.RobotService", "grpc.method": "GetOperations", "grpc.code": "OK", "grpc.time_ms": 0.124}
2024-01-29T13:39:22.099-0500	INFO	robot_server	zap/options.go:212	finished unary call with code OK	{"grpc.start_time": "2024-01-29T13:39:22-05:00", "system": "grpc", "span.kind": "server", "grpc.service": "viam.robot.v1.RobotService", "grpc.method": "GetSessions", "grpc.code": "OK", "grpc.time_ms": 0.157}
2024-01-29T13:39:22.186-0500	INFO	robot_server.process.cartographer-module_/usr/local/bin/cartographer-module.StdOut	pexec/managed_process.go:244
\_ 2024-01-29T13:39:22.186-0500	DEBUG	cartographerModule.rdk:service:slam/carto	sensorprocess/lidarsensorprocess.go:47	lidar sleep for 196ms
2024-01-29T13:39:22.256-0500	INFO	robot_server.process.cartographer-module_/usr/local/bin/cartographer-module.StdOut	pexec/managed_process.go:244
\_ 2024-01-29T13:39:22.196-0500	DEBUG	cartographerModule.rdk:service:slam/carto	sensorprocess/lidarsensorprocess.go:93	2024-01-29 18:39:22.189865 +0000 UTC 	 | LIDAR | Success 	 	 | 1706553562
```

**JIRA Ticket:** https://viam.atlassian.net/browse/RSDK-1888