### PR TITLE
migrate to rdk v1.0.0 and add GOTOOLCHAIN to lint

### DIFF
--- a/.github/workflows/appimage-comment.yml
+++ b/.github/workflows/appimage-comment.yml
@@ -13,7 +13,7 @@ jobs:
     if: ${{ github.event.workflow_run.event == 'pull_request_target' && github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Download PR Variables
-        uses: dawidd6/action-download-artifact@v2
+        uses: dawidd6/action-download-artifact@v6
         with:
           run_id: ${{ github.event.workflow_run.id }}
           name: pr-variables

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -42,13 +42,13 @@ jobs:
     steps:
     - name: Check out code
       if: inputs.release_type != 'pr'
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: recursive
       
     - name: Check out PR branch code
       if: inputs.release_type == 'pr'
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         submodules: recursive
@@ -68,7 +68,7 @@ jobs:
 
     - id: 'auth'
       name: 'Authenticate to Google Cloud'
-      uses: 'google-github-actions/auth@v1'
+      uses: 'google-github-actions/auth@v2'
       with:
         create_credentials_file: true
         workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}

--- a/.github/workflows/deploy_module.yml
+++ b/.github/workflows/deploy_module.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: recursive
 
@@ -70,7 +70,7 @@ jobs:
       matrix:
         platform: [amd64, arm64]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: actions/download-artifact@v4
       with:
         name: appimage-${{ matrix.platform }}

--- a/.github/workflows/pullrequestclose.yml
+++ b/.github/workflows/pullrequestclose.yml
@@ -21,14 +21,14 @@ jobs:
     steps:
     - id: 'auth'
       name: 'Authenticate to Google Cloud'
-      uses: 'google-github-actions/auth@v1'
+      uses: 'google-github-actions/auth@v2'
       with:
         create_credentials_file: true
         workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
         service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
     - name: Set up Cloud SDK
-      uses: google-github-actions/setup-gcloud@v1
+      uses: google-github-actions/setup-gcloud@v2
 
     - name: Delete Files
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,13 +44,13 @@ jobs:
 
     - name: Check out main branch code
       if: github.event_name != 'pull_request_target'
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: recursive
 
     - name: Check out PR branch code
       if: github.event_name == 'pull_request_target'
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         submodules: recursive

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 BUILD_CHANNEL?=local
 BUILD_DIR = build/$(shell uname -s)-$(shell uname -m)
+GOVERSION = $(shell grep '^go .\..' go.mod | head -n1 | cut -d' ' -f2)
 BIN_OUTPUT_PATH = bin/$(shell uname -s)-$(shell uname -m)
 TOOL_BIN := $(shell pwd)/bin/tools/$(shell uname -s)-$(shell uname -m)
 GIT_REVISION := $(shell git rev-parse HEAD | tr -d '\n')
@@ -69,7 +70,7 @@ lint-cpp:
 
 lint-go: $(TOOL_BIN)/combined $(TOOL_BIN)/actionlint
 	go vet -vettool=$(TOOL_BIN)/combined ./...
-	GOGC=50 go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.62.2 run -v --fix --config=./etc/golangci.yaml --timeout=5m
+	GOTOOLCHAIN=go$(GOVERSION) GOGC=50 go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.62.2 run -v --fix --config=./etc/golangci.yaml --timeout=5m
 	actionlint
 
 $(TOOL_BIN)/combined $(TOOL_BIN)/actionlint:

--- a/cartofacade/capi_test.go
+++ b/cartofacade/capi_test.go
@@ -28,6 +28,10 @@ func positionIsZero(t *testing.T, position Position) {
 	test.That(t, position.Real, test.ShouldEqual, 1)
 }
 
+// NOTE: As of go.viam.com/rdk v1.0.0, the pointcloud package DOES support binary
+// compressed pointclouds (see pointcloud.writePCDCompressed / readPCDCompressed).
+// Need to implement binary compressed pointclouds still: https://viam.atlassian.net/browse/RSDK-3753.
+
 func testAddLidarReading(t *testing.T, vc Carto, pcdPath string, timestamp time.Time, pcdType pointcloud.PCDType) {
 	file, err := os.Open(artifact.MustPath(pcdPath))
 	test.That(t, err, test.ShouldBeNil)

--- a/cartofacade/capi_test.go
+++ b/cartofacade/capi_test.go
@@ -28,21 +28,6 @@ func positionIsZero(t *testing.T, position Position) {
 	test.That(t, position.Real, test.ShouldEqual, 1)
 }
 
-// confirm the pointcloud package still doesn't support binary compressed
-// pointclouds. If it does, we need to implement:
-// https://viam.atlassian.net/browse/RSDK-3753
-func confirmBinaryCompressedUnsupported(t *testing.T) {
-	file, err := os.Open(artifact.MustPath("viam-cartographer/mock_lidar/0.pcd"))
-	test.That(t, err, test.ShouldBeNil)
-	pc, err := pointcloud.ReadPCD(file, pointcloud.BasicType)
-	test.That(t, err, test.ShouldBeNil)
-
-	buf := new(bytes.Buffer)
-	err = pointcloud.ToPCD(pc, buf, pointcloud.PCDCompressed)
-	test.That(t, err, test.ShouldBeError)
-	test.That(t, err.Error(), test.ShouldResemble, "compressed PCD not yet implemented")
-}
-
 func testAddLidarReading(t *testing.T, vc Carto, pcdPath string, timestamp time.Time, pcdType pointcloud.PCDType) {
 	file, err := os.Open(artifact.MustPath(pcdPath))
 	test.That(t, err, test.ShouldBeNil)
@@ -297,8 +282,6 @@ func TestCGoAPIWithoutMovementSensor(t *testing.T) {
 		test.That(t, len(internalState), test.ShouldEqual, len(lastInternalState))
 		lastInternalState = internalState
 
-		confirmBinaryCompressedUnsupported(t)
-
 		// NOTE: This test is very carefully created in order to not hit
 		// cases where cartographer won't update the map for whatever reason.
 		// For example, if you change the time increments from 2 seconds to 1
@@ -511,8 +494,6 @@ func TestCGoAPIWithMovementSensor(t *testing.T) {
 		test.That(t, internalState, test.ShouldNotBeNil)
 		test.That(t, len(internalState), test.ShouldEqual, len(lastInternalState))
 		lastInternalState = internalState
-
-		confirmBinaryCompressedUnsupported(t)
 
 		// NOTE: This test is very carefully created in order to not hit
 		// cases where cartographer won't update the map for whatever reason.

--- a/cartofacade/capi_test.go
+++ b/cartofacade/capi_test.go
@@ -34,7 +34,7 @@ func positionIsZero(t *testing.T, position Position) {
 func confirmBinaryCompressedUnsupported(t *testing.T) {
 	file, err := os.Open(artifact.MustPath("viam-cartographer/mock_lidar/0.pcd"))
 	test.That(t, err, test.ShouldBeNil)
-	pc, err := pointcloud.ReadPCD(file)
+	pc, err := pointcloud.ReadPCD(file, pointcloud.BasicType)
 	test.That(t, err, test.ShouldBeNil)
 
 	buf := new(bytes.Buffer)
@@ -47,7 +47,7 @@ func testAddLidarReading(t *testing.T, vc Carto, pcdPath string, timestamp time.
 	file, err := os.Open(artifact.MustPath(pcdPath))
 	test.That(t, err, test.ShouldBeNil)
 
-	pc, err := pointcloud.ReadPCD(file)
+	pc, err := pointcloud.ReadPCD(file, pointcloud.BasicType)
 	test.That(t, err, test.ShouldBeNil)
 
 	buf := new(bytes.Buffer)
@@ -347,7 +347,7 @@ func TestCGoAPIWithoutMovementSensor(t *testing.T) {
 		pcd, err = vc.pointCloudMap()
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, pcd, test.ShouldNotBeNil)
-		pc, err := pointcloud.ReadPCD(bytes.NewReader(pcd))
+		pc, err := pointcloud.ReadPCD(bytes.NewReader(pcd), pointcloud.BasicType)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, pc.Size(), test.ShouldNotEqual, 0)
 
@@ -384,7 +384,7 @@ func TestCGoAPIWithoutMovementSensor(t *testing.T) {
 		pcd, err = vc.pointCloudMap()
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, pcd, test.ShouldNotBeNil)
-		pc, err = pointcloud.ReadPCD(bytes.NewReader(pcd))
+		pc, err = pointcloud.ReadPCD(bytes.NewReader(pcd), pointcloud.BasicType)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, pc.Size(), test.ShouldNotEqual, 0)
 
@@ -607,7 +607,7 @@ func TestCGoAPIWithMovementSensor(t *testing.T) {
 		pcd, err = vc.pointCloudMap()
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, pcd, test.ShouldNotBeNil)
-		pc, err := pointcloud.ReadPCD(bytes.NewReader(pcd))
+		pc, err := pointcloud.ReadPCD(bytes.NewReader(pcd), pointcloud.BasicType)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, pc.Size(), test.ShouldNotEqual, 0)
 

--- a/cartofacade/carto_facade_test.go
+++ b/cartofacade/carto_facade_test.go
@@ -316,7 +316,7 @@ func TestAddLidarReading(t *testing.T) {
 	file, err := os.Open(artifact.MustPath("viam-cartographer/mock_lidar/0.pcd"))
 	test.That(t, err, test.ShouldBeNil)
 	buf := new(bytes.Buffer)
-	pc, err := pointcloud.ReadPCD(file)
+	pc, err := pointcloud.ReadPCD(file, pointcloud.BasicType)
 	test.That(t, err, test.ShouldBeNil)
 	err = pointcloud.ToPCD(pc, buf, 0)
 	test.That(t, err, test.ShouldBeNil)

--- a/config/config.go
+++ b/config/config.go
@@ -42,20 +42,20 @@ var (
 )
 
 // Validate creates the list of implicit dependencies.
-func (config *Config) Validate(path string) ([]string, error) {
+func (config *Config) Validate(path string) ([]string, []string, error) {
 	var deps []string
 	cameraName, ok := config.Camera["name"]
 	if !ok {
-		return nil, utils.NewConfigValidationError(path, errCameraMustHaveName)
+		return nil, nil, utils.NewConfigValidationError(path, errCameraMustHaveName)
 	}
 	dataFreqHz, ok := config.Camera["data_frequency_hz"]
 	if ok {
 		dataFreqHz, err := strconv.Atoi(dataFreqHz)
 		if err != nil {
-			return nil, errors.New("camera[data_frequency_hz] must only contain digits")
+			return nil, nil, errors.New("camera[data_frequency_hz] must only contain digits")
 		}
 		if dataFreqHz < 0 {
-			return nil, errors.New("cannot specify camera[data_frequency_hz] less than zero")
+			return nil, nil, errors.New("cannot specify camera[data_frequency_hz] less than zero")
 		}
 	}
 	deps = append(deps, cameraName)
@@ -65,7 +65,7 @@ func (config *Config) Validate(path string) ([]string, error) {
 		deps = append(deps, movementSensorName)
 	}
 
-	return deps, nil
+	return deps, nil, nil
 }
 
 // GetOptionalParameters sets any unset optional config parameters to the values passed to this function,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -60,8 +60,8 @@ func TestValidate(t *testing.T) {
 		cfgService.Attributes[key] = true
 
 		_, err := newConfig(cfgService)
-		msg := fmt.Sprintf("decoding failed due to the following error(s):\n\n'%s' expected type 'string'"+
-			", got unconvertible type 'bool', value: 'true'", key)
+		msg := fmt.Sprintf("decoding failed due to the following error(s): '%s' expected type 'string'"+
+			", got unconvertible type 'bool'", key)
 		expE := newError(msg)
 		test.That(t, err, test.ShouldBeError, expE)
 
@@ -265,7 +265,7 @@ func newConfig(conf resource.Config) (*Config, error) {
 		return &Config{}, newError(err.Error())
 	}
 
-	if _, err := slamConf.Validate("services.slam.attributes.fake"); err != nil {
+	if _, _, err := slamConf.Validate("services.slam.attributes.fake"); err != nil {
 		return &Config{}, newError(err.Error())
 	}
 

--- a/postprocess/postprocess.go
+++ b/postprocess/postprocess.go
@@ -137,7 +137,7 @@ func updatePointCloudWithAddedPoints(updatedData *[]byte, points []r3.Vector) er
 	}
 
 	reader := bytes.NewReader(*updatedData)
-	pc, err := pointcloud.ReadPCD(reader)
+	pc, err := pointcloud.ReadPCD(reader, pointcloud.BasicType)
 	if err != nil {
 		return err
 	}
@@ -180,12 +180,12 @@ func updatePointCloudWithRemovedPoints(updatedData *[]byte, points []r3.Vector) 
 	}
 
 	reader := bytes.NewReader(*updatedData)
-	pc, err := pointcloud.ReadPCD(reader)
+	pc, err := pointcloud.ReadPCD(reader, pointcloud.BasicType)
 	if err != nil {
 		return err
 	}
 
-	updatedPC := pointcloud.NewWithPrealloc(pc.Size() - len(points))
+	updatedPC := pointcloud.NewBasicPointCloud(pc.Size() - len(points))
 	pointsVisited := 0
 
 	filterRemovedPoints := func(p r3.Vector, d pointcloud.Data) bool {

--- a/postprocess/postprocess_test.go
+++ b/postprocess/postprocess_test.go
@@ -155,7 +155,7 @@ func TestUpdatePointCloud(t *testing.T) {
 }
 
 func vecSliceToBytes(points []r3.Vector, outputData *[]byte) error {
-	pc := pointcloud.NewWithPrealloc(len(points))
+	pc := pointcloud.NewBasicPointCloud(len(points))
 	for _, p := range points {
 		pc.Set(p, pointcloud.NewColoredData(color.NRGBA{B: fullConfidence, R: math.MaxUint8}))
 	}

--- a/sensors/lidar.go
+++ b/sensors/lidar.go
@@ -53,7 +53,7 @@ func (lidar Lidar) TimedLidarReading(ctx context.Context) (TimedLidarReadingResp
 	testIsReplaySensor := false
 
 	ctxWithMetadata, md := contextutils.ContextWithMetadata(ctx)
-	readingPc, err := lidar.Lidar.NextPointCloud(ctxWithMetadata)
+	readingPc, err := lidar.Lidar.NextPointCloud(ctxWithMetadata, nil)
 	if err != nil {
 		return TimedLidarReadingResponse{}, errors.Wrap(err, "NextPointCloud error")
 	}
@@ -83,7 +83,7 @@ func NewLidar(
 ) (TimedLidar, error) {
 	_, span := trace.StartSpan(ctx, "viamcartographer::sensors::NewLidar")
 	defer span.End()
-	lidar, err := camera.FromDependencies(deps, cameraName)
+	lidar, err := camera.FromProvider(deps, cameraName)
 	if err != nil {
 		return Lidar{}, errors.Wrapf(err, "error getting lidar camera %v for slam service", cameraName)
 	}

--- a/sensors/movementsensor.go
+++ b/sensors/movementsensor.go
@@ -296,7 +296,7 @@ func NewMovementSensor(
 	if movementSensorName == "" {
 		return &MovementSensor{}, nil
 	}
-	movementSensor, err := movementsensor.FromDependencies(deps, movementSensorName)
+	movementSensor, err := movementsensor.FromProvider(deps, movementSensorName)
 	if err != nil {
 		return &MovementSensor{}, errors.Wrapf(err, "error getting movement sensor \"%v\" for slam service", movementSensorName)
 	}

--- a/sensors/test_deps.go
+++ b/sensors/test_deps.go
@@ -170,8 +170,8 @@ func SetupDeps(lidarName, movementSensorName TestSensor) resource.Dependencies {
 
 func getGoodLidar() *inject.Camera {
 	cam := &inject.Camera{}
-	cam.NextPointCloudFunc = func(ctx context.Context) (pointcloud.PointCloud, error) {
-		return pointcloud.New(), nil
+	cam.NextPointCloudFunc = func(ctx context.Context, extra map[string]interface{}) (pointcloud.PointCloud, error) {
+		return pointcloud.NewBasicEmpty(), nil
 	}
 	cam.ProjectorFunc = func(ctx context.Context) (transform.Projector, error) {
 		return nil, transform.NewNoIntrinsicsError("")
@@ -185,12 +185,12 @@ func getGoodLidar() *inject.Camera {
 func getWarmingUpLidar() *inject.Camera {
 	cam := &inject.Camera{}
 	counter := 0
-	cam.NextPointCloudFunc = func(ctx context.Context) (pointcloud.PointCloud, error) {
+	cam.NextPointCloudFunc = func(ctx context.Context, extra map[string]interface{}) (pointcloud.PointCloud, error) {
 		counter++
 		if counter == 1 {
 			return nil, errors.Errorf("warming up %d", counter)
 		}
-		return pointcloud.New(), nil
+		return pointcloud.NewBasicEmpty(), nil
 	}
 	cam.ProjectorFunc = func(ctx context.Context) (transform.Projector, error) {
 		return nil, transform.NewNoIntrinsicsError("")
@@ -203,7 +203,7 @@ func getWarmingUpLidar() *inject.Camera {
 
 func getLidarWithErroringFunctions() *inject.Camera {
 	cam := &inject.Camera{}
-	cam.NextPointCloudFunc = func(ctx context.Context) (pointcloud.PointCloud, error) {
+	cam.NextPointCloudFunc = func(ctx context.Context, extra map[string]interface{}) (pointcloud.PointCloud, error) {
 		return nil, errors.New(InvalidSensorTestErrMsg)
 	}
 	cam.ProjectorFunc = func(ctx context.Context) (transform.Projector, error) {
@@ -217,8 +217,8 @@ func getLidarWithErroringFunctions() *inject.Camera {
 
 func getLidarWithInvalidProperties() *inject.Camera {
 	cam := &inject.Camera{}
-	cam.NextPointCloudFunc = func(ctx context.Context) (pointcloud.PointCloud, error) {
-		return pointcloud.New(), nil
+	cam.NextPointCloudFunc = func(ctx context.Context, extra map[string]interface{}) (pointcloud.PointCloud, error) {
+		return pointcloud.NewBasicEmpty(), nil
 	}
 	cam.ProjectorFunc = func(ctx context.Context) (transform.Projector, error) {
 		return nil, transform.NewNoIntrinsicsError("")
@@ -231,12 +231,12 @@ func getLidarWithInvalidProperties() *inject.Camera {
 
 func getReplayLidar(testTime string) *inject.Camera {
 	cam := &inject.Camera{}
-	cam.NextPointCloudFunc = func(ctx context.Context) (pointcloud.PointCloud, error) {
+	cam.NextPointCloudFunc = func(ctx context.Context, extra map[string]interface{}) (pointcloud.PointCloud, error) {
 		md := ctx.Value(contextutils.MetadataContextKey)
 		if mdMap, ok := md.(map[string][]string); ok {
 			mdMap[contextutils.TimeRequestedMetadataKey] = []string{testTime}
 		}
-		return pointcloud.New(), nil
+		return pointcloud.NewBasicEmpty(), nil
 	}
 	cam.ProjectorFunc = func(ctx context.Context) (transform.Projector, error) {
 		return nil, transform.NewNoIntrinsicsError("")
@@ -249,7 +249,7 @@ func getReplayLidar(testTime string) *inject.Camera {
 
 func getFinishedReplayLidar() *inject.Camera {
 	cam := &inject.Camera{}
-	cam.NextPointCloudFunc = func(ctx context.Context) (pointcloud.PointCloud, error) {
+	cam.NextPointCloudFunc = func(ctx context.Context, extra map[string]interface{}) (pointcloud.PointCloud, error) {
 		return nil, replaypcd.ErrEndOfDataset
 	}
 	cam.ProjectorFunc = func(ctx context.Context) (transform.Projector, error) {

--- a/testhelper/integrationtesthelper.go
+++ b/testhelper/integrationtesthelper.go
@@ -221,7 +221,7 @@ func testCartographerMap(t *testing.T, svc slam.Service, localizationMode bool) 
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, pcd, test.ShouldNotBeNil)
 
-	pointcloud, err := pointcloud.ReadPCD(bytes.NewReader(pcd))
+	pointcloud, err := pointcloud.ReadPCD(bytes.NewReader(pcd), pointcloud.BasicType)
 	test.That(t, err, test.ShouldBeNil)
 	t.Logf("Pointcloud points: %v", pointcloud.Size())
 	test.That(t, pointcloud.Size(), test.ShouldBeGreaterThanOrEqualTo, 100)
@@ -541,7 +541,7 @@ func createTimedLidarReadingResponse(t *testing.T, i uint64, timeTracker *timeTr
 		t.Error("TEST FAILED TimedLidarReading Mock failed to open pcd file")
 		return s.TimedLidarReadingResponse{}, err
 	}
-	readingPc, err := pointcloud.ReadPCD(file)
+	readingPc, err := pointcloud.ReadPCD(file, pointcloud.BasicType)
 	if err != nil {
 		t.Error("TEST FAILED TimedLidarReading Mock failed to read pcd")
 		return s.TimedLidarReadingResponse{}, err

--- a/testhelper/testhelper.go
+++ b/testhelper/testhelper.go
@@ -77,7 +77,7 @@ func SetupStubDeps(lidarName, movementSensorName s.TestSensor, t *testing.T) res
 
 func getLidarWithErroringFunctions(t *testing.T) *inject.Camera {
 	cam := &inject.Camera{}
-	cam.NextPointCloudFunc = func(ctx context.Context) (pointcloud.PointCloud, error) {
+	cam.NextPointCloudFunc = func(ctx context.Context, extra map[string]interface{}) (pointcloud.PointCloud, error) {
 		t.Error("TEST FAILED stub lidar NextPointCloud called")
 		return nil, errors.New("invalid sensor")
 	}
@@ -133,7 +133,7 @@ func CreateIntegrationSLAMService(
 	cfgService := resource.Config{Name: "test", API: slam.API, Model: viamcartographer.Model}
 	cfgService.ConvertedAttributes = cfg
 
-	sensorDeps, err := cfg.Validate("path")
+	sensorDeps, _, err := cfg.Validate("path")
 	if err != nil {
 		return nil, err
 	}
@@ -176,7 +176,7 @@ func CreateSLAMService(
 	ctx := context.Background()
 	cfgService := resource.Config{Name: "test", API: slam.API, Model: viamcartographer.Model}
 	cfgService.ConvertedAttributes = cfg
-	sensorDeps, err := cfg.Validate("path")
+	sensorDeps, _, err := cfg.Validate("path")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Had Claude make the necessary rdk v1.0 updates

add gotoolchain variable to ensure lint is up to date with the go version